### PR TITLE
EditorToolbar のUIを改善：2行レイアウト化・モードボタンのアイコン化

### DIFF
--- a/features/editor/components/EditorToolbar.tsx
+++ b/features/editor/components/EditorToolbar.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import clsx from "clsx";
+import { MousePointer2, Pen, Plus } from "lucide-react";
+import type React from "react";
 import type { StampCatalogEntry } from "../constants";
 import type { EditorMode, RectAddTarget, StampType } from "../types";
 import { StampTypeSelector } from "./StampTypeSelector";
@@ -26,10 +28,10 @@ interface EditorToolbarProps {
 }
 
 /** モードボタンの定義 */
-const MODE_BUTTONS: { mode: EditorMode; label: string }[] = [
-  { mode: "select", label: "選択" },
-  { mode: "rect", label: "矩形" },
-  { mode: "paint", label: "ペイント" },
+const MODE_BUTTONS: { mode: EditorMode; label: string; icon: React.ReactNode }[] = [
+  { mode: "select", label: "選択", icon: <MousePointer2 size={14} /> },
+  { mode: "rect", label: "追加", icon: <Plus size={14} /> },
+  { mode: "paint", label: "ペイント", icon: <Pen size={14} /> },
 ];
 
 /** 矩形追加ターゲットボタンの定義 */
@@ -46,8 +48,8 @@ function Divider() {
 /**
  * エディタ操作ツールバーコンポーネント
  *
- * モード切替・矩形追加ターゲット選択・スタンプ種別選択・ブラシサイズ調整・
- * 選択アイテム削除ボタンを提供する。
+ * 1行目: モード切替・矩形ターゲット・ペイントブラシ・削除ボタン（常に固定）
+ * 2行目: スタンプコントロール（スタンプ追加時 / スタンプ選択時のみ表示）
  */
 export function EditorToolbar({
   mode,
@@ -68,56 +70,94 @@ export function EditorToolbar({
   const showStampControls = (mode === "rect" && rectTarget === "stamp") || isStampSelected;
 
   return (
-    <div className="flex flex-wrap items-center gap-x-2 gap-y-1.5 rounded-lg border border-zinc-200 bg-zinc-50 px-2 py-1.5">
-      {/* モード切替: ピルグループ */}
-      <div className="flex overflow-hidden rounded-md border border-zinc-300 shadow-sm">
-        {MODE_BUTTONS.map(({ mode: m, label }, i) => (
+    <div className="flex flex-col gap-1.5 rounded-lg border border-zinc-200 bg-zinc-50 px-2 py-1.5">
+      {/* 1行目: 主要コントロール */}
+      <div className="flex items-center gap-x-2">
+        {/* モード切替: ピルグループ（アイコンのみ・title でツールチップ） */}
+        <div className="flex overflow-hidden rounded-md border border-zinc-300 shadow-sm">
+          {MODE_BUTTONS.map(({ mode: m, label, icon }, i) => (
+            <button
+              key={m}
+              type="button"
+              title={label}
+              onClick={() => onChangeMode(m)}
+              className={clsx([
+                "flex items-center px-2.5 py-1.5 transition-colors",
+                i > 0 && "border-l border-zinc-300",
+                mode === m ? "bg-blue-600 text-white" : "bg-white text-zinc-700 hover:bg-zinc-50",
+              ])}
+            >
+              {icon}
+            </button>
+          ))}
+        </div>
+
+        {/* 矩形ターゲット: ピルグループ */}
+        {mode === "rect" && (
+          <>
+            <Divider />
+            <div className="flex overflow-hidden rounded-md border border-zinc-300 shadow-sm">
+              {RECT_TARGET_BUTTONS.map(({ target, label }, i) => (
+                <button
+                  key={target}
+                  type="button"
+                  onClick={() => onRectTargetChange(target)}
+                  className={clsx([
+                    "shrink-0 whitespace-nowrap px-3 py-1 text-sm font-medium transition-colors",
+                    i > 0 && "border-l border-zinc-300",
+                    rectTarget === target
+                      ? "bg-emerald-600 text-white"
+                      : "bg-white text-zinc-700 hover:bg-zinc-50",
+                  ])}
+                >
+                  {label}
+                </button>
+              ))}
+            </div>
+          </>
+        )}
+
+        {/* ペイントブラシサイズスライダー */}
+        {mode === "paint" && (
+          <>
+            <Divider />
+            <div className="flex items-center gap-2">
+              <label className="text-sm text-zinc-600" htmlFor="brush-size-slider">
+                ブラシ: {brushSize}
+              </label>
+              <input
+                id="brush-size-slider"
+                type="range"
+                min={5}
+                max={50}
+                value={brushSize}
+                onChange={(e) => onBrushSizeChange(Number(e.target.value))}
+                className="w-24"
+              />
+            </div>
+          </>
+        )}
+
+        {/* 削除ボタン */}
+        {mode === "select" && (
           <button
-            key={m}
             type="button"
-            onClick={() => onChangeMode(m)}
+            onClick={onDeleteSelected}
+            disabled={selectedId === null}
             className={clsx([
-              "px-3 py-1 text-sm font-medium transition-colors",
-              i > 0 && "border-l border-zinc-300",
-              mode === m ? "bg-blue-600 text-white" : "bg-white text-zinc-700 hover:bg-zinc-50",
+              "ml-auto rounded-md px-3 py-1 text-sm font-medium transition-colors",
+              "bg-red-600 text-white hover:bg-red-700",
+              selectedId === null && "cursor-not-allowed opacity-50",
             ])}
           >
-            {label}
+            削除
           </button>
-        ))}
+        )}
       </div>
 
-      {/* 矩形モード時の追加オプション */}
-      {mode === "rect" && (
-        <>
-          <Divider />
-
-          {/* 矩形ターゲット: ピルグループ */}
-          <div className="flex overflow-hidden rounded-md border border-zinc-300 shadow-sm">
-            {RECT_TARGET_BUTTONS.map(({ target, label }, i) => (
-              <button
-                key={target}
-                type="button"
-                onClick={() => onRectTargetChange(target)}
-                className={clsx([
-                  "px-3 py-1 text-sm font-medium transition-colors",
-                  i > 0 && "border-l border-zinc-300",
-                  rectTarget === target
-                    ? "bg-emerald-600 text-white"
-                    : "bg-white text-zinc-700 hover:bg-zinc-50",
-                ])}
-              >
-                {label}
-              </button>
-            ))}
-          </div>
-        </>
-      )}
-
-      {/* スタンプ種別・画像選択（スタンプ追加時 / スタンプ選択時） */}
+      {/* 2行目: スタンプコントロール（スタンプ追加時 / スタンプ選択時） */}
       {showStampControls && (
-        <>
-          <Divider />
+        <div className="flex items-center gap-x-2 border-t border-zinc-200 pt-1.5">
           <StampTypeSelector value={selectedStampType} onChange={onStampTypeChange} />
           {selectedStampType === "stamp-face" && stampCatalog.length > 0 && (
             <select
@@ -132,44 +172,7 @@ export function EditorToolbar({
               ))}
             </select>
           )}
-        </>
-      )}
-
-      {/* ペイントモード時のブラシサイズスライダー */}
-      {mode === "paint" && (
-        <>
-          <Divider />
-          <div className="flex items-center gap-2">
-            <label className="text-sm text-zinc-600" htmlFor="brush-size-slider">
-              ブラシ: {brushSize}
-            </label>
-            <input
-              id="brush-size-slider"
-              type="range"
-              min={5}
-              max={50}
-              value={brushSize}
-              onChange={(e) => onBrushSizeChange(Number(e.target.value))}
-              className="w-24"
-            />
-          </div>
-        </>
-      )}
-
-      {/* 削除ボタン */}
-      {mode === "select" && (
-        <button
-          type="button"
-          onClick={onDeleteSelected}
-          disabled={selectedId === null}
-          className={clsx([
-            "ml-auto rounded-md px-3 py-1 text-sm font-medium transition-colors",
-            "bg-red-600 text-white hover:bg-red-700",
-            selectedId === null && "cursor-not-allowed opacity-50",
-          ])}
-        >
-          削除
-        </button>
+        </div>
       )}
     </div>
   );

--- a/features/editor/components/EditorToolbar.tsx
+++ b/features/editor/components/EditorToolbar.tsx
@@ -3,6 +3,7 @@
 import clsx from "clsx";
 import { MousePointer2, Pen, Plus } from "lucide-react";
 import type React from "react";
+import type { LucideProps } from "lucide-react";
 import type { StampCatalogEntry } from "../constants";
 import type { EditorMode, RectAddTarget, StampType } from "../types";
 import { StampTypeSelector } from "./StampTypeSelector";
@@ -28,10 +29,14 @@ interface EditorToolbarProps {
 }
 
 /** モードボタンの定義 */
-const MODE_BUTTONS: { mode: EditorMode; label: string; icon: React.ReactNode }[] = [
-  { mode: "select", label: "選択", icon: <MousePointer2 size={14} /> },
-  { mode: "rect", label: "追加", icon: <Plus size={14} /> },
-  { mode: "paint", label: "ペイント", icon: <Pen size={14} /> },
+const MODE_BUTTONS: {
+  mode: EditorMode;
+  label: string;
+  Icon: React.ComponentType<LucideProps>;
+}[] = [
+  { mode: "select", label: "選択", Icon: MousePointer2 },
+  { mode: "rect", label: "追加", Icon: Plus },
+  { mode: "paint", label: "ペイント", Icon: Pen },
 ];
 
 /** 矩形追加ターゲットボタンの定義 */
@@ -75,11 +80,13 @@ export function EditorToolbar({
       <div className="flex items-center gap-x-2">
         {/* モード切替: ピルグループ（アイコンのみ・title でツールチップ） */}
         <div className="flex overflow-hidden rounded-md border border-zinc-300 shadow-sm">
-          {MODE_BUTTONS.map(({ mode: m, label, icon }, i) => (
+          {MODE_BUTTONS.map(({ mode: m, label, Icon }, i) => (
             <button
               key={m}
               type="button"
               title={label}
+              aria-label={label}
+              aria-pressed={mode === m}
               onClick={() => onChangeMode(m)}
               className={clsx([
                 "flex items-center px-2.5 py-1.5 transition-colors",
@@ -87,7 +94,7 @@ export function EditorToolbar({
                 mode === m ? "bg-blue-600 text-white" : "bg-white text-zinc-700 hover:bg-zinc-50",
               ])}
             >
-              {icon}
+              <Icon size={14} aria-hidden="true" />
             </button>
           ))}
         </div>


### PR DESCRIPTION
## 概要

EditorToolbar のレイアウトがモード切替のたびに崩れる問題を解消するため、2行構造への再設計とモードボタンのアイコン化を行った。

## 関連Issue

Closes #27

## 変更内容

- [x] 機能追加
- [ ] バグ修正
- [x] リファクタリング
- [ ] テスト追加・修正
- [ ] ドキュメント修正
- [ ] 設定・環境変更
- [ ] その他

## 主な変更箇所

### UI・コンポーネント

- `features/editor/components/EditorToolbar.tsx` を再設計
  - 外側コンテナを `flex flex-wrap`（1行）→ `flex flex-col`（2行）に変更
  - **1行目（固定）**: モード切替・矩形ターゲット・ペイントブラシ・削除ボタン
  - **2行目（条件表示）**: スタンプコントロール（スタンプ追加時・スタンプ選択時のみ `border-t` 付きで表示）
  - モードボタンをアイコンのみに変更し、`title` 属性でホバー時にラベルを表示
    - 選択: `MousePointer2` / 追加（旧: 矩形）: `Plus` / ペイント: `Pen`（lucide-react）
  - 「矩形」モードのラベルを「追加」に改名

### ロジック・処理

変更なし

### その他

変更なし

## 動作確認

- [x] ローカル環境での動作確認
- [x] テストの実行・通過確認
- [x] UI動作確認
- [x] 既存機能への影響確認
- [ ] ブラウザ動作確認（Chrome / Firefox / Safari）

## スクリーンショット・動画

（省略）

## テスト

### 追加したテスト

- なし（UIレイアウト変更のみ）

### テスト結果

- [x] 全てのテストが通過
- [ ] 新規テストを追加
- [ ] 既存テストの修正

## 破壊的変更

- [ ] 破壊的変更あり
- [x] 破壊的変更なし

### 破壊的変更の詳細

props インターフェースの変更なし。外部から見た API は変わらない。

## レビューポイント

- スタンプコントロールの2行目表示が `showStampControls` の条件で意図通り出入りするか
- アイコンのみのモードボタンでユーザーが直感的に操作できるか（`title` ツールチップの効果）

## 補足

スタンプコントロールが2行目に出現する際にキャンバスエリアが下にずれる動作は仕様上の許容範囲として残している。

## チェックリスト

- [x] コードレビューの準備ができている
- [x] 適切なラベルを付けている
- [x] セルフレビューを実施している
- [x] `pnpm lint` と `pnpm type-check` が通ることを確認した
- [ ] 必要に応じてドキュメントを更新している
