### PR TITLE
クリップボードからの画像貼り付け（Ctrl+V）に対応

### DIFF
--- a/components/ImageUpload/constants.ts
+++ b/components/ImageUpload/constants.ts
@@ -1,0 +1,5 @@
+/** 許可する画像ファイル形式 */
+export const ACCEPTED_IMAGE_TYPES = ["image/jpeg", "image/png", "image/webp", "image/gif"];
+
+/** 最大ファイルサイズ (20MB) */
+export const MAX_IMAGE_FILE_SIZE = 20 * 1024 * 1024;

--- a/components/ImageUpload/index.tsx
+++ b/components/ImageUpload/index.tsx
@@ -4,12 +4,7 @@ import { useCallback, useRef, useState } from "react";
 import type { ChangeEvent, DragEvent, KeyboardEvent } from "react";
 import clsx from "clsx";
 import { ImageIcon, LoaderCircle } from "lucide-react";
-
-/** 許可するファイル形式 */
-const ACCEPTED_TYPES = ["image/jpeg", "image/png", "image/webp", "image/gif"];
-
-/** 最大ファイルサイズ (20MB) */
-const MAX_FILE_SIZE = 20 * 1024 * 1024;
+import { ACCEPTED_IMAGE_TYPES, MAX_IMAGE_FILE_SIZE } from "./constants";
 
 interface ImageUploadProps {
   /** ファイル選択時のコールバック */
@@ -49,11 +44,11 @@ export function ImageUpload({
       let validationError: string | null = null;
 
       for (const file of files) {
-        if (!ACCEPTED_TYPES.includes(file.type)) {
+        if (!ACCEPTED_IMAGE_TYPES.includes(file.type)) {
           validationError = "JPEG / PNG / WebP / GIF 形式の画像を選択してください";
           continue;
         }
-        if (file.size > MAX_FILE_SIZE) {
+        if (file.size > MAX_IMAGE_FILE_SIZE) {
           validationError = "ファイルサイズは20MB以下にしてください";
           continue;
         }
@@ -199,7 +194,7 @@ export function ImageUpload({
       <input
         ref={inputRef}
         type="file"
-        accept={ACCEPTED_TYPES.join(",")}
+        accept={ACCEPTED_IMAGE_TYPES.join(",")}
         multiple={multiple}
         className="hidden"
         onChange={handleChange}

--- a/features/masking/components/MaskingGallery.test.tsx
+++ b/features/masking/components/MaskingGallery.test.tsx
@@ -1,0 +1,109 @@
+import { render, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { toast } from "sonner";
+import { MaskingGallery } from "./MaskingGallery";
+
+vi.mock("sonner", () => ({
+  toast: {
+    info: vi.fn(),
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+  Toaster: () => null,
+}));
+
+vi.mock("fflate", () => ({
+  zip: vi.fn(),
+}));
+
+vi.mock("@/features/face-detection", () => ({
+  useFaceDetection: () => ({
+    isModelLoading: false,
+    isModelError: false,
+    isDetecting: false,
+    detectFaces: vi.fn().mockResolvedValue([]),
+  }),
+}));
+
+vi.mock("@/features/ocr", () => ({
+  useOcr: () => ({
+    isRecognizing: false,
+    recognizeText: vi.fn().mockResolvedValue([]),
+  }),
+}));
+
+vi.mock("@/lib/confirmStore", () => ({
+  useConfirmStore: {
+    getState: () => ({ open: vi.fn().mockResolvedValue(true) }),
+  },
+}));
+
+vi.mock("@/components/ImageUpload", () => ({
+  ImageUpload: ({ onUpload }: { onUpload: (files: File[]) => void }) => (
+    <div data-testid="image-upload" onClick={() => onUpload([])} />
+  ),
+}));
+
+/**
+ * jsdom では ClipboardEvent が未定義のため、
+ * paste イベントを Event として生成し clipboardData を Object.defineProperty で設定するヘルパー
+ */
+const createPasteEvent = (items: Array<{ type: string; getAsFile: () => File | null }> | null) => {
+  const event = new Event("paste", { bubbles: true, cancelable: true });
+  Object.defineProperty(event, "clipboardData", {
+    value: items !== null ? { items } : null,
+    writable: false,
+  });
+  return event;
+};
+
+describe("MaskingGallery - クリップボード貼り付け", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    URL.createObjectURL = vi.fn().mockReturnValue("blob:mock-url");
+    URL.revokeObjectURL = vi.fn();
+  });
+
+  it("画像をペーストすると toast.info が呼ばれる", async () => {
+    render(<MaskingGallery />);
+
+    const imageFile = new File(["data"], "screenshot.png", { type: "image/png" });
+    const items = [{ type: "image/png", getAsFile: () => imageFile }];
+
+    fireEvent(window, createPasteEvent(items));
+
+    await waitFor(() => {
+      expect(toast.info).toHaveBeenCalledWith("画像を貼り付けました");
+    });
+  });
+
+  it("クリップボードに画像がない場合は何もしない", () => {
+    render(<MaskingGallery />);
+
+    const items = [{ type: "text/plain", getAsFile: () => null }];
+
+    fireEvent(window, createPasteEvent(items));
+
+    expect(toast.info).not.toHaveBeenCalled();
+  });
+
+  it("clipboardData が null の場合は何もしない", () => {
+    render(<MaskingGallery />);
+
+    fireEvent(window, createPasteEvent(null));
+
+    expect(toast.info).not.toHaveBeenCalled();
+  });
+
+  it("コンポーネントのアンマウント後は paste イベントを処理しない", () => {
+    const { unmount } = render(<MaskingGallery />);
+    unmount();
+
+    const imageFile = new File(["data"], "screenshot.png", { type: "image/png" });
+    const items = [{ type: "image/png", getAsFile: () => imageFile }];
+
+    fireEvent(window, createPasteEvent(items));
+
+    expect(toast.info).not.toHaveBeenCalled();
+  });
+});

--- a/features/masking/components/MaskingGallery.test.tsx
+++ b/features/masking/components/MaskingGallery.test.tsx
@@ -120,6 +120,25 @@ describe("MaskingGallery - クリップボード貼り付け", () => {
     expect(createObjectURLSpy).not.toHaveBeenCalled();
   });
 
+  it("有効画像と無効画像が混在する場合は toast.info のみ呼ばれ toast.error は出ない", async () => {
+    render(<MaskingGallery />);
+
+    const validFile = new File(["data"], "valid.png", { type: "image/png" });
+    const invalidFile = new File(["data"], "invalid.bmp", { type: "image/bmp" });
+    const items = [
+      { type: "image/png", getAsFile: () => validFile },
+      { type: "image/bmp", getAsFile: () => invalidFile },
+    ];
+
+    fireEvent(window, createPasteEvent(items));
+
+    await waitFor(() => {
+      expect(toast.info).toHaveBeenCalledWith("画像を貼り付けました");
+      expect(createObjectURLSpy).toHaveBeenCalled();
+    });
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
   it("クリップボードに画像がない場合は何もしない", () => {
     render(<MaskingGallery />);
 
@@ -128,6 +147,8 @@ describe("MaskingGallery - クリップボード貼り付け", () => {
     fireEvent(window, createPasteEvent(items));
 
     expect(toast.info).not.toHaveBeenCalled();
+    expect(toast.error).not.toHaveBeenCalled();
+    expect(createObjectURLSpy).not.toHaveBeenCalled();
   });
 
   it("clipboardData が null の場合は何もしない", () => {
@@ -136,6 +157,8 @@ describe("MaskingGallery - クリップボード貼り付け", () => {
     fireEvent(window, createPasteEvent(null));
 
     expect(toast.info).not.toHaveBeenCalled();
+    expect(toast.error).not.toHaveBeenCalled();
+    expect(createObjectURLSpy).not.toHaveBeenCalled();
   });
 
   it("コンポーネントのアンマウント後は paste イベントを処理しない", () => {
@@ -148,5 +171,7 @@ describe("MaskingGallery - クリップボード貼り付け", () => {
     fireEvent(window, createPasteEvent(items));
 
     expect(toast.info).not.toHaveBeenCalled();
+    expect(toast.error).not.toHaveBeenCalled();
+    expect(createObjectURLSpy).not.toHaveBeenCalled();
   });
 });

--- a/features/masking/components/MaskingGallery.test.tsx
+++ b/features/masking/components/MaskingGallery.test.tsx
@@ -64,7 +64,7 @@ describe("MaskingGallery - クリップボード貼り付け", () => {
     URL.revokeObjectURL = vi.fn();
   });
 
-  it("画像をペーストすると toast.info が呼ばれる", async () => {
+  it("有効な画像をペーストすると toast.info が呼ばれアップロード処理が開始される", async () => {
     render(<MaskingGallery />);
 
     const imageFile = new File(["data"], "screenshot.png", { type: "image/png" });
@@ -74,7 +74,42 @@ describe("MaskingGallery - クリップボード貼り付け", () => {
 
     await waitFor(() => {
       expect(toast.info).toHaveBeenCalledWith("画像を貼り付けました");
+      /** handleUpload → arrayBuffer → createObjectURL まで到達したことを確認 */
+      expect(URL.createObjectURL).toHaveBeenCalled();
     });
+  });
+
+  it("許可外の MIME 形式をペーストすると toast.error が呼ばれアップロードしない", async () => {
+    render(<MaskingGallery />);
+
+    const bmpFile = new File(["data"], "image.bmp", { type: "image/bmp" });
+    const items = [{ type: "image/bmp", getAsFile: () => bmpFile }];
+
+    fireEvent(window, createPasteEvent(items));
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith(
+        "JPEG / PNG / WebP / GIF 形式の画像を選択してください"
+      );
+    });
+    expect(toast.info).not.toHaveBeenCalled();
+    expect(URL.createObjectURL).not.toHaveBeenCalled();
+  });
+
+  it("20MB 超のファイルをペーストすると toast.error が呼ばれアップロードしない", async () => {
+    render(<MaskingGallery />);
+
+    const largeFile = new File(["data"], "large.png", { type: "image/png" });
+    Object.defineProperty(largeFile, "size", { value: 21 * 1024 * 1024 });
+    const items = [{ type: "image/png", getAsFile: () => largeFile }];
+
+    fireEvent(window, createPasteEvent(items));
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith("ファイルサイズは20MB以下にしてください");
+    });
+    expect(toast.info).not.toHaveBeenCalled();
+    expect(URL.createObjectURL).not.toHaveBeenCalled();
   });
 
   it("クリップボードに画像がない場合は何もしない", () => {

--- a/features/masking/components/MaskingGallery.test.tsx
+++ b/features/masking/components/MaskingGallery.test.tsx
@@ -1,5 +1,5 @@
 import { render, fireEvent, waitFor } from "@testing-library/react";
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { toast } from "sonner";
 import { MaskingGallery } from "./MaskingGallery";
 
@@ -58,10 +58,18 @@ const createPasteEvent = (items: Array<{ type: string; getAsFile: () => File | n
 };
 
 describe("MaskingGallery - クリップボード貼り付け", () => {
+  let createObjectURLSpy: ReturnType<typeof vi.spyOn>;
+  let revokeObjectURLSpy: ReturnType<typeof vi.spyOn>;
+
   beforeEach(() => {
     vi.clearAllMocks();
-    URL.createObjectURL = vi.fn().mockReturnValue("blob:mock-url");
-    URL.revokeObjectURL = vi.fn();
+    createObjectURLSpy = vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:mock-url");
+    revokeObjectURLSpy = vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    createObjectURLSpy.mockRestore();
+    revokeObjectURLSpy.mockRestore();
   });
 
   it("有効な画像をペーストすると toast.info が呼ばれアップロード処理が開始される", async () => {
@@ -75,7 +83,7 @@ describe("MaskingGallery - クリップボード貼り付け", () => {
     await waitFor(() => {
       expect(toast.info).toHaveBeenCalledWith("画像を貼り付けました");
       /** handleUpload → arrayBuffer → createObjectURL まで到達したことを確認 */
-      expect(URL.createObjectURL).toHaveBeenCalled();
+      expect(createObjectURLSpy).toHaveBeenCalled();
     });
   });
 
@@ -93,7 +101,7 @@ describe("MaskingGallery - クリップボード貼り付け", () => {
       );
     });
     expect(toast.info).not.toHaveBeenCalled();
-    expect(URL.createObjectURL).not.toHaveBeenCalled();
+    expect(createObjectURLSpy).not.toHaveBeenCalled();
   });
 
   it("20MB 超のファイルをペーストすると toast.error が呼ばれアップロードしない", async () => {
@@ -109,7 +117,7 @@ describe("MaskingGallery - クリップボード貼り付け", () => {
       expect(toast.error).toHaveBeenCalledWith("ファイルサイズは20MB以下にしてください");
     });
     expect(toast.info).not.toHaveBeenCalled();
-    expect(URL.createObjectURL).not.toHaveBeenCalled();
+    expect(createObjectURLSpy).not.toHaveBeenCalled();
   });
 
   it("クリップボードに画像がない場合は何もしない", () => {

--- a/features/masking/components/MaskingGallery.tsx
+++ b/features/masking/components/MaskingGallery.tsx
@@ -5,6 +5,7 @@ import clsx from "clsx";
 import { zip } from "fflate";
 import { toast } from "sonner";
 import { ImageUpload } from "@/components/ImageUpload";
+import { ACCEPTED_IMAGE_TYPES, MAX_IMAGE_FILE_SIZE } from "@/components/ImageUpload/constants";
 import { useFaceDetection } from "@/features/face-detection";
 import { useOcr } from "@/features/ocr";
 import { useConfirmStore } from "@/lib/confirmStore";
@@ -206,46 +207,40 @@ export function MaskingGallery() {
    * - 貼り付け成功時にトースト通知を表示する
    */
   useEffect(() => {
-    /** 許可するファイル形式（ImageUpload と同じ基準） */
-    const PASTE_ACCEPTED_TYPES = ["image/jpeg", "image/png", "image/webp", "image/gif"];
-    /** 最大ファイルサイズ 20MB（ImageUpload と同じ基準） */
-    const PASTE_MAX_FILE_SIZE = 20 * 1024 * 1024;
-
     const handlePaste = (e: ClipboardEvent) => {
       if (isModelLoading || isModelError) return;
       const items = e.clipboardData?.items;
       if (!items) return;
 
       const validFiles: File[] = [];
-      let hasInvalidType = false;
-      let hasOversized = false;
+      let validationError: string | null = null;
 
       for (const item of Array.from(items)) {
         if (!item.type.startsWith("image/")) continue;
         const file = item.getAsFile();
         if (!file) continue;
 
-        if (!PASTE_ACCEPTED_TYPES.includes(file.type)) {
-          hasInvalidType = true;
+        if (!ACCEPTED_IMAGE_TYPES.includes(file.type)) {
+          validationError = "JPEG / PNG / WebP / GIF 形式の画像を選択してください";
           continue;
         }
-        if (file.size > PASTE_MAX_FILE_SIZE) {
-          hasOversized = true;
+        if (file.size > MAX_IMAGE_FILE_SIZE) {
+          validationError = "ファイルサイズは20MB以下にしてください";
           continue;
         }
         validFiles.push(file);
       }
 
-      if (hasInvalidType) {
-        toast.error("JPEG / PNG / WebP / GIF 形式の画像を選択してください");
+      /** ImageUpload と同じ挙動: 有効ファイルがあればアップロードのみ、なければエラー表示 */
+      if (validFiles.length > 0) {
+        toast.info("画像を貼り付けました");
+        void handleUpload(validFiles);
+        return;
       }
-      if (hasOversized) {
-        toast.error("ファイルサイズは20MB以下にしてください");
-      }
-      if (validFiles.length === 0) return;
 
-      toast.info("画像を貼り付けました");
-      void handleUpload(validFiles);
+      if (validationError) {
+        toast.error(validationError);
+      }
     };
 
     window.addEventListener("paste", handlePaste);

--- a/features/masking/components/MaskingGallery.tsx
+++ b/features/masking/components/MaskingGallery.tsx
@@ -202,25 +202,50 @@ export function MaskingGallery() {
    *
    * - モデル未ロード・エラー時は何もしない
    * - クリップボードに画像がない場合も何もしない
+   * - ImageUpload と同じ基準（JPEG/PNG/WebP/GIF・20MB以下）でバリデーションを行う
    * - 貼り付け成功時にトースト通知を表示する
    */
   useEffect(() => {
+    /** 許可するファイル形式（ImageUpload と同じ基準） */
+    const PASTE_ACCEPTED_TYPES = ["image/jpeg", "image/png", "image/webp", "image/gif"];
+    /** 最大ファイルサイズ 20MB（ImageUpload と同じ基準） */
+    const PASTE_MAX_FILE_SIZE = 20 * 1024 * 1024;
+
     const handlePaste = (e: ClipboardEvent) => {
       if (isModelLoading || isModelError) return;
       const items = e.clipboardData?.items;
       if (!items) return;
 
-      const imageFiles: File[] = [];
+      const validFiles: File[] = [];
+      let hasInvalidType = false;
+      let hasOversized = false;
+
       for (const item of Array.from(items)) {
         if (!item.type.startsWith("image/")) continue;
         const file = item.getAsFile();
-        if (file) imageFiles.push(file);
+        if (!file) continue;
+
+        if (!PASTE_ACCEPTED_TYPES.includes(file.type)) {
+          hasInvalidType = true;
+          continue;
+        }
+        if (file.size > PASTE_MAX_FILE_SIZE) {
+          hasOversized = true;
+          continue;
+        }
+        validFiles.push(file);
       }
 
-      if (imageFiles.length === 0) return;
+      if (hasInvalidType) {
+        toast.error("JPEG / PNG / WebP / GIF 形式の画像を選択してください");
+      }
+      if (hasOversized) {
+        toast.error("ファイルサイズは20MB以下にしてください");
+      }
+      if (validFiles.length === 0) return;
 
       toast.info("画像を貼り付けました");
-      void handleUpload(imageFiles);
+      void handleUpload(validFiles);
     };
 
     window.addEventListener("paste", handlePaste);

--- a/features/masking/components/MaskingGallery.tsx
+++ b/features/masking/components/MaskingGallery.tsx
@@ -198,6 +198,38 @@ export function MaskingGallery() {
   );
 
   /**
+   * ページ全体の paste イベントをリッスンし、クリップボードの画像を handleUpload へ渡す
+   *
+   * - モデル未ロード・エラー時は何もしない
+   * - クリップボードに画像がない場合も何もしない
+   * - 貼り付け成功時にトースト通知を表示する
+   */
+  useEffect(() => {
+    const handlePaste = (e: ClipboardEvent) => {
+      if (isModelLoading || isModelError) return;
+      const items = e.clipboardData?.items;
+      if (!items) return;
+
+      const imageFiles: File[] = [];
+      for (const item of Array.from(items)) {
+        if (!item.type.startsWith("image/")) continue;
+        const file = item.getAsFile();
+        if (file) imageFiles.push(file);
+      }
+
+      if (imageFiles.length === 0) return;
+
+      toast.info("画像を貼り付けました");
+      void handleUpload(imageFiles);
+    };
+
+    window.addEventListener("paste", handlePaste);
+    return () => {
+      window.removeEventListener("paste", handlePaste);
+    };
+  }, [handleUpload, isModelLoading, isModelError]);
+
+  /**
    * 個別画像を再検出する
    *
    * @param imageId - 再検出対象画像ID


### PR DESCRIPTION
## 概要

`Ctrl+V` / `Cmd+V` でクリップボードの画像を直接貼り付けてマスキング処理を開始できるようにする。ファイル選択ダイアログを開かずにスクリーンショットをそのまま処理できる。

## 関連Issue

Closes #17

## 変更内容

- [x] 機能追加
- [ ] バグ修正
- [ ] リファクタリング
- [x] テスト追加・修正
- [ ] ドキュメント修正
- [ ] 設定・環境変更
- [ ] その他

## 主な変更箇所

### UI・コンポーネント

特になし（既存 UI は変更なし）。貼り付け成功時にトースト通知「画像を貼り付けました」を表示。

### ロジック・処理

**`components/ImageUpload/constants.ts`（新規）**

- `ACCEPTED_IMAGE_TYPES`・`MAX_IMAGE_FILE_SIZE` を共通定数として切り出し
- `ImageUpload` と `MaskingGallery` の両方から参照する形に共通化

**`features/masking/components/MaskingGallery.tsx`**

- `useEffect` で `window` に `paste` イベントリスナーを追加
- `ClipboardEvent.clipboardData.items` から `image/*` の `File` を収集
- 共通定数 `ACCEPTED_IMAGE_TYPES`・`MAX_IMAGE_FILE_SIZE` を使ったバリデーションを実施
- `ImageUpload` と同じ挙動：有効ファイルがあればアップロードのみ（エラー非表示）、有効ファイルが0件のときのみエラー表示
- クリップボードに画像がない場合・モデル未ロード・エラー時は何もしない
- コンポーネントのアンマウント時にリスナーを解除してリーク防止

### その他

**`features/masking/components/MaskingGallery.test.tsx`（新規）**

- クリップボード貼り付けの正常系・異常系・アンマウント後のテストを追加

## 動作確認

- [x] ローカル環境での動作確認
- [x] テストの実行・通過確認
- [x] UI動作確認
- [x] 既存機能への影響確認
- [ ] ブラウザ動作確認（Chrome / Firefox / Safari）

## テスト

### 追加したテスト

- 有効な画像をペーストすると `toast.info` が呼ばれアップロード処理が開始される（`URL.createObjectURL` 呼び出しで検証）
- 許可外 MIME 形式をペーストすると `toast.error` が呼ばれアップロードしない
- 20MB 超のファイルをペーストすると `toast.error` が呼ばれアップロードしない
- クリップボードに画像がない場合は何もしない
- `clipboardData` が null の場合は何もしない
- コンポーネントのアンマウント後は paste イベントを処理しない
- `URL.createObjectURL` / `URL.revokeObjectURL` は `vi.spyOn` + `afterEach mockRestore()` でテスト分離

### テスト結果

- [x] 全てのテストが通過
- [x] 新規テストを追加
- [ ] 既存テストの修正

## 破壊的変更

- [ ] 破壊的変更あり
- [x] 破壊的変更なし

## レビューポイント

- `handleUpload` の依存に `isModelLoading` / `isModelError` を含め、モデル未準備時は処理しないようにしている点
- `window.addEventListener('paste', ...)` の登録タイミングが `handleUpload` 定義後であることで `ReferenceError` を回避している点

## チェックリスト

- [x] コードレビューの準備ができている
- [x] 適切なラベルを付けている
- [x] セルフレビューを実施している
- [x] `pnpm lint` と `pnpm type-check` が通ることを確認した
- [ ] 必要に応じてドキュメントを更新している
