### PR TITLE
別タブ・外部アプリからのD&Dで画像をマスキングできるように対応

### DIFF
--- a/components/ImageUpload/ImageUpload.test.tsx
+++ b/components/ImageUpload/ImageUpload.test.tsx
@@ -147,6 +147,52 @@ describe("ImageUpload - 別タブ・外部アプリからのD&D", () => {
     vi.stubGlobal("Image", MockImageError);
   };
 
+  it("text/uri-list に data:image/png URI を渡すと onUpload が呼ばれる", async () => {
+    setupSuccessMock();
+    const onUpload = vi.fn();
+    render(<ImageUpload onUpload={onUpload} />);
+
+    const dropZone = screen.getByRole("button", {
+      name: "画像をアップロード。クリックまたはドラッグ＆ドロップ",
+    });
+
+    /** 最小限の 1x1 PNG data: URI */
+    const pngDataUri =
+      "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==";
+
+    fireEvent.drop(dropZone, {
+      dataTransfer: {
+        files: [],
+        getData: (type: string) => (type === "text/uri-list" ? pngDataUri : ""),
+      },
+    });
+
+    await waitFor(() => {
+      expect(onUpload).toHaveBeenCalled();
+    });
+  });
+
+  it("text/uri-list に許可外 MIME の data: URI を渡すとエラーを表示して onUpload は呼ばれない", () => {
+    const onUpload = vi.fn();
+    render(<ImageUpload onUpload={onUpload} />);
+
+    const dropZone = screen.getByRole("button", {
+      name: "画像をアップロード。クリックまたはドラッグ＆ドロップ",
+    });
+
+    fireEvent.drop(dropZone, {
+      dataTransfer: {
+        files: [],
+        getData: (type: string) => (type === "text/uri-list" ? "data:image/bmp;base64,AAAA" : ""),
+      },
+    });
+
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "JPEG / PNG / WebP / GIF 形式の画像を選択してください"
+    );
+    expect(onUpload).not.toHaveBeenCalled();
+  });
+
   it("text/uri-list の URL から画像ファイルが生成され onUpload が呼ばれる", async () => {
     setupSuccessMock();
     const onUpload = vi.fn();

--- a/components/ImageUpload/ImageUpload.test.tsx
+++ b/components/ImageUpload/ImageUpload.test.tsx
@@ -372,6 +372,42 @@ describe("ImageUpload - 別タブ・外部アプリからのD&D", () => {
     expect(onUpload).not.toHaveBeenCalled();
   });
 
+  it("解像度が MAX_CANVAS_DIMENSION を超える画像はエラーを表示して onUpload は呼ばれない", async () => {
+    class MockImageOversized {
+      crossOrigin = "";
+      referrerPolicy = "";
+      naturalWidth = 9000;
+      naturalHeight = 9000;
+      onload: (() => void) | null = null;
+      onerror: (() => void) | null = null;
+
+      set src(_url: string) {
+        window.setTimeout(() => this.onload?.(), 0);
+      }
+    }
+
+    vi.stubGlobal("Image", MockImageOversized);
+
+    const onUpload = vi.fn();
+    render(<ImageUpload onUpload={onUpload} />);
+
+    const dropZone = screen.getByRole("button", {
+      name: "画像をアップロード。クリックまたはドラッグ＆ドロップ",
+    });
+
+    fireEvent.drop(dropZone, {
+      dataTransfer: {
+        files: [],
+        getData: (type: string) => (type === "text/uri-list" ? "https://example.com/huge.jpg" : ""),
+      },
+    });
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith(expect.stringContaining("解像度が大きすぎます"));
+    });
+    expect(onUpload).not.toHaveBeenCalled();
+  });
+
   it("files が空で URL もない場合は何もしない", () => {
     const onUpload = vi.fn();
     render(<ImageUpload onUpload={onUpload} />);

--- a/components/ImageUpload/ImageUpload.test.tsx
+++ b/components/ImageUpload/ImageUpload.test.tsx
@@ -212,6 +212,72 @@ describe("ImageUpload - 別タブ・外部アプリからのD&D", () => {
     });
   });
 
+  it("text/uri-list がコメント行・空行を含む複数行でも先頭 URL から onUpload が呼ばれる", async () => {
+    setupSuccessMock();
+    const onUpload = vi.fn();
+    render(<ImageUpload onUpload={onUpload} />);
+
+    const dropZone = screen.getByRole("button", {
+      name: "画像をアップロード。クリックまたはドラッグ＆ドロップ",
+    });
+
+    const multiLineUriList = [
+      "# comment line",
+      "",
+      "https://example.com/photo.jpg",
+      "https://example.com/other.jpg",
+    ].join("\n");
+
+    fireEvent.drop(dropZone, {
+      dataTransfer: {
+        files: [],
+        getData: (type: string) => (type === "text/uri-list" ? multiLineUriList : ""),
+      },
+    });
+
+    await waitFor(() => {
+      expect(onUpload).toHaveBeenCalled();
+    });
+  });
+
+  it("javascript: スキームの URL はエラーを表示して onUpload は呼ばれない", () => {
+    const onUpload = vi.fn();
+    render(<ImageUpload onUpload={onUpload} />);
+
+    const dropZone = screen.getByRole("button", {
+      name: "画像をアップロード。クリックまたはドラッグ＆ドロップ",
+    });
+
+    fireEvent.drop(dropZone, {
+      dataTransfer: {
+        files: [],
+        getData: (type: string) => (type === "text/uri-list" ? "javascript:alert(1)" : ""),
+      },
+    });
+
+    expect(screen.getByRole("alert")).toHaveTextContent("この画像は読み込めませんでした");
+    expect(onUpload).not.toHaveBeenCalled();
+  });
+
+  it("file: スキームの URL はエラーを表示して onUpload は呼ばれない", () => {
+    const onUpload = vi.fn();
+    render(<ImageUpload onUpload={onUpload} />);
+
+    const dropZone = screen.getByRole("button", {
+      name: "画像をアップロード。クリックまたはドラッグ＆ドロップ",
+    });
+
+    fireEvent.drop(dropZone, {
+      dataTransfer: {
+        files: [],
+        getData: (type: string) => (type === "text/uri-list" ? "file:///etc/passwd" : ""),
+      },
+    });
+
+    expect(screen.getByRole("alert")).toHaveTextContent("この画像は読み込めませんでした");
+    expect(onUpload).not.toHaveBeenCalled();
+  });
+
   it("files が空で URL もない場合は何もしない", () => {
     const onUpload = vi.fn();
     render(<ImageUpload onUpload={onUpload} />);

--- a/components/ImageUpload/ImageUpload.test.tsx
+++ b/components/ImageUpload/ImageUpload.test.tsx
@@ -92,6 +92,11 @@ describe("ImageUpload - 別タブ・外部アプリからのD&D", () => {
     vi.unstubAllGlobals();
   });
 
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
   /**
    * Canvas プロトタイプと Image グローバルをモックして urlToFile が File を返すよう設定する
    *

--- a/components/ImageUpload/ImageUpload.test.tsx
+++ b/components/ImageUpload/ImageUpload.test.tsx
@@ -278,6 +278,49 @@ describe("ImageUpload - 別タブ・外部アプリからのD&D", () => {
     expect(onUpload).not.toHaveBeenCalled();
   });
 
+  it(".bmp など許可外形式の URL はエラーを表示して onUpload は呼ばれない", () => {
+    const onUpload = vi.fn();
+    render(<ImageUpload onUpload={onUpload} />);
+
+    const dropZone = screen.getByRole("button", {
+      name: "画像をアップロード。クリックまたはドラッグ＆ドロップ",
+    });
+
+    fireEvent.drop(dropZone, {
+      dataTransfer: {
+        files: [],
+        getData: (type: string) =>
+          type === "text/uri-list" ? "https://example.com/photo.bmp" : "",
+      },
+    });
+
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "JPEG / PNG / WebP / GIF 形式の画像を選択してください"
+    );
+    expect(onUpload).not.toHaveBeenCalled();
+  });
+
+  it(".svg など許可外形式の URL はエラーを表示して onUpload は呼ばれない", () => {
+    const onUpload = vi.fn();
+    render(<ImageUpload onUpload={onUpload} />);
+
+    const dropZone = screen.getByRole("button", {
+      name: "画像をアップロード。クリックまたはドラッグ＆ドロップ",
+    });
+
+    fireEvent.drop(dropZone, {
+      dataTransfer: {
+        files: [],
+        getData: (type: string) => (type === "text/uri-list" ? "https://example.com/icon.svg" : ""),
+      },
+    });
+
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "JPEG / PNG / WebP / GIF 形式の画像を選択してください"
+    );
+    expect(onUpload).not.toHaveBeenCalled();
+  });
+
   it("files が空で URL もない場合は何もしない", () => {
     const onUpload = vi.fn();
     render(<ImageUpload onUpload={onUpload} />);

--- a/components/ImageUpload/ImageUpload.test.tsx
+++ b/components/ImageUpload/ImageUpload.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
-import { describe, expect, it, vi, beforeEach } from "vitest";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import { ImageUpload } from "./index";
 
 describe("ImageUpload", () => {

--- a/components/ImageUpload/ImageUpload.test.tsx
+++ b/components/ImageUpload/ImageUpload.test.tsx
@@ -258,7 +258,7 @@ describe("ImageUpload - 別タブ・外部アプリからのD&D", () => {
 
     await waitFor(() => {
       expect(toast.error).toHaveBeenCalledWith(
-        "この画像は読み込めませんでした（CORSエラーの可能性があります）"
+        "この画像は読み込めませんでした（CORS・ネットワーク・URLの問題の可能性があります）"
       );
     });
   });

--- a/components/ImageUpload/ImageUpload.test.tsx
+++ b/components/ImageUpload/ImageUpload.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { ImageUpload } from "./index";
 
@@ -83,5 +83,145 @@ describe("ImageUpload", () => {
     Object.defineProperty(input, "files", { value: [file1, file2] });
     fireEvent.change(input);
     expect(onUpload).toHaveBeenCalledWith([file1, file2]);
+  });
+});
+
+describe("ImageUpload - 別タブ・外部アプリからのD&D", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  /**
+   * Canvas プロトタイプと Image グローバルをモックして urlToFile が File を返すよう設定する
+   *
+   * document.createElement を差し替えると React 内部のレンダリングが壊れるため、
+   * HTMLCanvasElement.prototype の getContext/toBlob をスパイする。
+   * vi.fn().mockImplementation はアロー関数で class として使えないため class 構文を使う。
+   */
+  const setupSuccessMock = () => {
+    const mockBlob = new Blob(["fake-image"], { type: "image/png" });
+    const mockContext = { drawImage: vi.fn() };
+
+    (
+      vi.spyOn(HTMLCanvasElement.prototype, "getContext") as ReturnType<typeof vi.spyOn>
+    ).mockReturnValue(mockContext);
+    vi.spyOn(HTMLCanvasElement.prototype, "toBlob").mockImplementation((cb: BlobCallback) =>
+      cb(mockBlob)
+    );
+
+    class MockImageSuccess {
+      crossOrigin = "";
+      naturalWidth = 100;
+      naturalHeight = 100;
+      onload: (() => void) | null = null;
+      onerror: (() => void) | null = null;
+
+      set src(_url: string) {
+        window.setTimeout(() => this.onload?.(), 0);
+      }
+    }
+
+    vi.stubGlobal("Image", MockImageSuccess);
+  };
+
+  /**
+   * Image の src セット時に onerror を呼ぶようにモックする
+   */
+  const setupErrorMock = () => {
+    class MockImageError {
+      crossOrigin = "";
+      onload: (() => void) | null = null;
+      onerror: (() => void) | null = null;
+
+      set src(_url: string) {
+        window.setTimeout(() => this.onerror?.(), 0);
+      }
+    }
+
+    vi.stubGlobal("Image", MockImageError);
+  };
+
+  it("text/uri-list の URL から画像ファイルが生成され onUpload が呼ばれる", async () => {
+    setupSuccessMock();
+    const onUpload = vi.fn();
+    render(<ImageUpload onUpload={onUpload} />);
+
+    const dropZone = screen.getByRole("button", {
+      name: "画像をアップロード。クリックまたはドラッグ＆ドロップ",
+    });
+
+    fireEvent.drop(dropZone, {
+      dataTransfer: {
+        files: [],
+        getData: (type: string) =>
+          type === "text/uri-list" ? "https://example.com/photo.jpg" : "",
+      },
+    });
+
+    await waitFor(() => {
+      expect(onUpload).toHaveBeenCalled();
+    });
+  });
+
+  it("text/html の <img src> から画像ファイルが生成され onUpload が呼ばれる", async () => {
+    setupSuccessMock();
+    const onUpload = vi.fn();
+    render(<ImageUpload onUpload={onUpload} />);
+
+    const dropZone = screen.getByRole("button", {
+      name: "画像をアップロード。クリックまたはドラッグ＆ドロップ",
+    });
+
+    fireEvent.drop(dropZone, {
+      dataTransfer: {
+        files: [],
+        getData: (type: string) =>
+          type === "text/html" ? '<img src="https://example.com/photo.png" />' : "",
+      },
+    });
+
+    await waitFor(() => {
+      expect(onUpload).toHaveBeenCalled();
+    });
+  });
+
+  it("画像 URL の読み込みに失敗した場合はエラーメッセージを表示する", async () => {
+    setupErrorMock();
+    render(<ImageUpload onUpload={vi.fn()} />);
+
+    const dropZone = screen.getByRole("button", {
+      name: "画像をアップロード。クリックまたはドラッグ＆ドロップ",
+    });
+
+    fireEvent.drop(dropZone, {
+      dataTransfer: {
+        files: [],
+        getData: (type: string) =>
+          type === "text/uri-list" ? "https://example.com/cors-blocked.jpg" : "",
+      },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent("この画像は読み込めませんでした");
+    });
+  });
+
+  it("files が空で URL もない場合は何もしない", () => {
+    const onUpload = vi.fn();
+    render(<ImageUpload onUpload={onUpload} />);
+
+    const dropZone = screen.getByRole("button", {
+      name: "画像をアップロード。クリックまたはドラッグ＆ドロップ",
+    });
+
+    fireEvent.drop(dropZone, {
+      dataTransfer: {
+        files: [],
+        getData: () => "",
+      },
+    });
+
+    expect(onUpload).not.toHaveBeenCalled();
   });
 });

--- a/components/ImageUpload/ImageUpload.test.tsx
+++ b/components/ImageUpload/ImageUpload.test.tsx
@@ -1,6 +1,9 @@
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { toast } from "sonner";
 import { ImageUpload } from "./index";
+
+vi.mock("sonner", () => ({ toast: { error: vi.fn(), info: vi.fn() } }));
 
 describe("ImageUpload", () => {
   beforeEach(() => {
@@ -187,7 +190,7 @@ describe("ImageUpload - 別タブ・外部アプリからのD&D", () => {
       },
     });
 
-    expect(screen.getByRole("alert")).toHaveTextContent(
+    expect(toast.error).toHaveBeenCalledWith(
       "JPEG / PNG / WebP / GIF 形式の画像を選択してください"
     );
     expect(onUpload).not.toHaveBeenCalled();
@@ -254,7 +257,9 @@ describe("ImageUpload - 別タブ・外部アプリからのD&D", () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByRole("alert")).toHaveTextContent("この画像は読み込めませんでした");
+      expect(toast.error).toHaveBeenCalledWith(
+        "この画像は読み込めませんでした（CORSエラーの可能性があります）"
+      );
     });
   });
 
@@ -301,7 +306,7 @@ describe("ImageUpload - 別タブ・外部アプリからのD&D", () => {
       },
     });
 
-    expect(screen.getByRole("alert")).toHaveTextContent("この画像は読み込めませんでした");
+    expect(toast.error).toHaveBeenCalledWith("この画像は読み込めませんでした");
     expect(onUpload).not.toHaveBeenCalled();
   });
 
@@ -320,7 +325,7 @@ describe("ImageUpload - 別タブ・外部アプリからのD&D", () => {
       },
     });
 
-    expect(screen.getByRole("alert")).toHaveTextContent("この画像は読み込めませんでした");
+    expect(toast.error).toHaveBeenCalledWith("この画像は読み込めませんでした");
     expect(onUpload).not.toHaveBeenCalled();
   });
 
@@ -340,7 +345,7 @@ describe("ImageUpload - 別タブ・外部アプリからのD&D", () => {
       },
     });
 
-    expect(screen.getByRole("alert")).toHaveTextContent(
+    expect(toast.error).toHaveBeenCalledWith(
       "JPEG / PNG / WebP / GIF 形式の画像を選択してください"
     );
     expect(onUpload).not.toHaveBeenCalled();
@@ -361,7 +366,7 @@ describe("ImageUpload - 別タブ・外部アプリからのD&D", () => {
       },
     });
 
-    expect(screen.getByRole("alert")).toHaveTextContent(
+    expect(toast.error).toHaveBeenCalledWith(
       "JPEG / PNG / WebP / GIF 形式の画像を選択してください"
     );
     expect(onUpload).not.toHaveBeenCalled();

--- a/components/ImageUpload/constants.ts
+++ b/components/ImageUpload/constants.ts
@@ -6,3 +6,6 @@ export const MAX_IMAGE_FILE_SIZE = 20 * 1024 * 1024;
 
 /** 許可形式外ファイルのエラーメッセージ */
 export const ACCEPTED_IMAGE_TYPES_ERROR = "JPEG / PNG / WebP / GIF 形式の画像を選択してください";
+
+/** Canvas 変換で許可する最大辺の長さ (px)。超過するとタブのメモリ不足を引き起こし得る */
+export const MAX_CANVAS_DIMENSION = 8000;

--- a/components/ImageUpload/constants.ts
+++ b/components/ImageUpload/constants.ts
@@ -3,3 +3,6 @@ export const ACCEPTED_IMAGE_TYPES = ["image/jpeg", "image/png", "image/webp", "i
 
 /** 最大ファイルサイズ (20MB) */
 export const MAX_IMAGE_FILE_SIZE = 20 * 1024 * 1024;
+
+/** 許可形式外ファイルのエラーメッセージ */
+export const ACCEPTED_IMAGE_TYPES_ERROR = "JPEG / PNG / WebP / GIF 形式の画像を選択してください";

--- a/components/ImageUpload/index.tsx
+++ b/components/ImageUpload/index.tsx
@@ -70,6 +70,8 @@ const urlToFile = (url: string): Promise<File> => {
   return new Promise((resolve, reject) => {
     const img = new Image();
     img.crossOrigin = "anonymous";
+    /** Referer ヘッダーの送信を抑えてドロップ元への閲覧元URL漏洩を防ぐ */
+    img.referrerPolicy = "no-referrer";
 
     img.onload = () => {
       const canvas = document.createElement("canvas");
@@ -81,17 +83,29 @@ const urlToFile = (url: string): Promise<File> => {
         return;
       }
       ctx.drawImage(img, 0, 0);
-      canvas.toBlob((blob) => {
-        if (!blob) {
-          reject(new Error("画像の変換に失敗しました"));
-          return;
-        }
-        /** data: URI はパス分割でファイル名を取得できないため固定名にする */
-        const fileName = url.startsWith("data:")
-          ? `image.${blob.type.split("/")[1] ?? "png"}`
-          : (url.split("/").pop()?.split("?")[0] ?? "image.png");
-        resolve(new File([blob], fileName, { type: blob.type }));
-      }, "image/png");
+      /**
+       * CORS ヘッダー不足等で Canvas が taint されている場合、
+       * toBlob() は SecurityError をスローするため try/catch で捕捉して reject する
+       */
+      try {
+        canvas.toBlob((blob) => {
+          if (!blob) {
+            reject(new Error("画像の変換に失敗しました"));
+            return;
+          }
+          /** data: URI はパス分割でファイル名を取得できないため固定名にする */
+          const fileName = url.startsWith("data:")
+            ? `image.${blob.type.split("/")[1] ?? "png"}`
+            : (url.split("/").pop()?.split("?")[0] ?? "image.png");
+          resolve(new File([blob], fileName, { type: blob.type }));
+        }, "image/png");
+      } catch (err) {
+        reject(
+          err instanceof Error
+            ? err
+            : new Error("この画像は読み込めませんでした（セキュリティエラーの可能性があります）")
+        );
+      }
     };
 
     img.onerror = () => {

--- a/components/ImageUpload/index.tsx
+++ b/components/ImageUpload/index.tsx
@@ -93,10 +93,14 @@ const urlToFile = (url: string): Promise<File> => {
             reject(new Error("画像の変換に失敗しました"));
             return;
           }
-          /** data: URI はパス分割でファイル名を取得できないため固定名にする */
+          /**
+           * data: URI はパス分割でファイル名を取得できないため固定名にする。
+           * http/https は new URL() で pathname の basename を取得し、
+           * search/hash を除外する。空文字の場合はフォールバック。
+           */
           const fileName = url.startsWith("data:")
             ? `image.${blob.type.split("/")[1] ?? "png"}`
-            : url.split("/").pop()?.split("?")[0] || "image.png";
+            : new URL(url).pathname.split("/").pop() || "image.png";
           resolve(new File([blob], fileName, { type: blob.type }));
         }, "image/png");
       } catch (err) {

--- a/components/ImageUpload/index.tsx
+++ b/components/ImageUpload/index.tsx
@@ -312,6 +312,9 @@ export function ImageUpload({
       const rawUrl = extractUrlFromUriList(uriList) ?? extractImageUrlFromHtml(html);
       if (!rawUrl) return;
 
+      /** URL D&D 経路に入ったら以前のインラインエラーをクリアする */
+      setError(null);
+
       /** 許可外スキーム（javascript: / file: 等）はエラーとして弾く */
       const imageUrl = validateUrlScheme(rawUrl);
       if (!imageUrl) {

--- a/components/ImageUpload/index.tsx
+++ b/components/ImageUpload/index.tsx
@@ -56,6 +56,40 @@ const validateUrlScheme = (url: string): string | null => {
   }
 };
 
+/** canvas.toBlob でサポートされる出力 MIME タイプ */
+const CANVAS_SUPPORTED_TYPES = ["image/jpeg", "image/png", "image/webp"] as const;
+type CanvasMimeType = (typeof CANVAS_SUPPORTED_TYPES)[number];
+
+/**
+ * URL または data: URI から canvas.toBlob に渡す出力 MIME タイプを決定する
+ *
+ * GIF など canvas でエンコードできない形式は image/png にフォールバックする。
+ *
+ * @param url - 画像 URL または data: URI
+ * @returns canvas.toBlob に渡す MIME タイプ
+ */
+const detectOutputMimeType = (url: string): CanvasMimeType => {
+  if (url.startsWith("data:")) {
+    const mimeMatch = url.match(/^data:([^;,]+)/);
+    const mime = mimeMatch?.[1] ?? "";
+    return (CANVAS_SUPPORTED_TYPES as readonly string[]).includes(mime)
+      ? (mime as CanvasMimeType)
+      : "image/png";
+  }
+  try {
+    const ext = new URL(url).pathname.split(".").pop()?.toLowerCase() ?? "";
+    const extToMime: Record<string, CanvasMimeType> = {
+      jpg: "image/jpeg",
+      jpeg: "image/jpeg",
+      png: "image/png",
+      webp: "image/webp",
+    };
+    return extToMime[ext] ?? "image/png";
+  } catch {
+    return "image/png";
+  }
+};
+
 /**
  * 画像 URL を `<img crossOrigin="anonymous">` + Canvas `toBlob` で File に変換する
  *
@@ -102,7 +136,7 @@ const urlToFile = (url: string): Promise<File> => {
             ? `image.${blob.type.split("/")[1] ?? "png"}`
             : new URL(url).pathname.split("/").pop() || "image.png";
           resolve(new File([blob], fileName, { type: blob.type }));
-        }, "image/png");
+        }, detectOutputMimeType(url));
       } catch (err) {
         /**
          * Canvas が taint されている場合など、DOMException の SecurityError が来る可能性がある。

--- a/components/ImageUpload/index.tsx
+++ b/components/ImageUpload/index.tsx
@@ -169,6 +169,8 @@ const urlToFile = (url: string): Promise<File> => {
        * MAX_IMAGE_FILE_SIZE チェックより先に解像度をガードする。
        */
       if (img.naturalWidth > MAX_CANVAS_DIMENSION || img.naturalHeight > MAX_CANVAS_DIMENSION) {
+        img.onload = null;
+        img.onerror = null;
         reject(
           new Error(
             `画像の解像度が大きすぎます（最大 ${MAX_CANVAS_DIMENSION}×${MAX_CANVAS_DIMENSION}px）`
@@ -182,6 +184,8 @@ const urlToFile = (url: string): Promise<File> => {
       canvas.height = img.naturalHeight;
       const ctx = canvas.getContext("2d");
       if (!ctx) {
+        img.onload = null;
+        img.onerror = null;
         reject(new Error("Canvas コンテキストの取得に失敗しました"));
         return;
       }
@@ -192,6 +196,12 @@ const urlToFile = (url: string): Promise<File> => {
        */
       try {
         canvas.toBlob((blob) => {
+          /** GC を早めるため toBlob 完了後に canvas のピクセルバッファを解放する */
+          canvas.width = 0;
+          canvas.height = 0;
+          img.onload = null;
+          img.onerror = null;
+
           if (!blob) {
             reject(new Error("画像の変換に失敗しました"));
             return;
@@ -213,6 +223,10 @@ const urlToFile = (url: string): Promise<File> => {
           resolve(new File([blob], fileName, { type: blob.type }));
         }, detectOutputMimeType(url));
       } catch (err) {
+        canvas.width = 0;
+        canvas.height = 0;
+        img.onload = null;
+        img.onerror = null;
         /**
          * Canvas が taint されている場合など、DOMException の SecurityError が来る可能性がある。
          * 生の英語メッセージをユーザーに露出しないよう既知ケースをフレンドリー文言にマッピングする。
@@ -226,6 +240,8 @@ const urlToFile = (url: string): Promise<File> => {
     };
 
     img.onerror = () => {
+      img.onload = null;
+      img.onerror = null;
       reject(new Error("この画像は読み込めませんでした（CORSエラーの可能性があります）"));
     };
 

--- a/components/ImageUpload/index.tsx
+++ b/components/ImageUpload/index.tsx
@@ -304,7 +304,7 @@ export function ImageUpload({
       void (async () => {
         try {
           const file = await urlToFile(imageUrl);
-          handleFiles(multiple ? [file] : [file]);
+          handleFiles([file]);
         } catch (err) {
           /**
            * urlToFile がスローするエラーは既にフレンドリー文言に変換済み。

--- a/components/ImageUpload/index.tsx
+++ b/components/ImageUpload/index.tsx
@@ -4,6 +4,7 @@ import { useCallback, useRef, useState } from "react";
 import type { ChangeEvent, DragEvent, KeyboardEvent } from "react";
 import clsx from "clsx";
 import { ImageIcon, LoaderCircle } from "lucide-react";
+import { toast } from "sonner";
 import {
   ACCEPTED_IMAGE_TYPES,
   ACCEPTED_IMAGE_TYPES_ERROR,
@@ -314,14 +315,14 @@ export function ImageUpload({
       /** 許可外スキーム（javascript: / file: 等）はエラーとして弾く */
       const imageUrl = validateUrlScheme(rawUrl);
       if (!imageUrl) {
-        setError("この画像は読み込めませんでした");
+        toast.error("この画像は読み込めませんでした");
         return;
       }
 
       /** 許可外 MIME タイプ（BMP / SVG 等）は変換前にエラーとして弾く */
       const typeError = validateImageTypeFromUrl(imageUrl);
       if (typeError) {
-        setError(typeError);
+        toast.error(typeError);
         return;
       }
 
@@ -335,7 +336,7 @@ export function ImageUpload({
            * 想定外の型のエラーは共通文言に丸めてユーザーへ露出しない。
            */
           const message = err instanceof Error ? err.message : "この画像は読み込めませんでした";
-          setError(message);
+          toast.error(message);
         }
       })();
     },

--- a/components/ImageUpload/index.tsx
+++ b/components/ImageUpload/index.tsx
@@ -4,7 +4,7 @@ import { useCallback, useRef, useState } from "react";
 import type { ChangeEvent, DragEvent, KeyboardEvent } from "react";
 import clsx from "clsx";
 import { ImageIcon, LoaderCircle } from "lucide-react";
-import { ACCEPTED_IMAGE_TYPES, MAX_IMAGE_FILE_SIZE } from "./constants";
+import { ACCEPTED_IMAGE_TYPES, ACCEPTED_IMAGE_TYPES_ERROR, MAX_IMAGE_FILE_SIZE } from "./constants";
 
 /** D&D で許可する URL スキーム */
 const ALLOWED_URL_SCHEMES = ["http:", "https:", "data:"];
@@ -89,12 +89,10 @@ const IMAGE_EXT_TO_MIME: Record<string, string> = {
  * @returns エラーメッセージ、または null（問題なし）
  */
 const validateImageTypeFromUrl = (url: string): string | null => {
-  const ACCEPTED_ERROR = "JPEG / PNG / WebP / GIF 形式の画像を選択してください";
-
   if (url.startsWith("data:")) {
     const mimeMatch = url.match(/^data:([^;,]+)/);
     const mime = mimeMatch?.[1] ?? "";
-    return ACCEPTED_IMAGE_TYPES.includes(mime) ? null : ACCEPTED_ERROR;
+    return ACCEPTED_IMAGE_TYPES.includes(mime) ? null : ACCEPTED_IMAGE_TYPES_ERROR;
   }
 
   try {
@@ -102,7 +100,7 @@ const validateImageTypeFromUrl = (url: string): string | null => {
     const mime = IMAGE_EXT_TO_MIME[ext];
     /** 拡張子不明の場合は変換を試みる（拡張子なし URL 等） */
     if (!mime) return null;
-    return ACCEPTED_IMAGE_TYPES.includes(mime) ? null : ACCEPTED_ERROR;
+    return ACCEPTED_IMAGE_TYPES.includes(mime) ? null : ACCEPTED_IMAGE_TYPES_ERROR;
   } catch {
     return null;
   }
@@ -249,7 +247,7 @@ export function ImageUpload({
 
       for (const file of files) {
         if (!ACCEPTED_IMAGE_TYPES.includes(file.type)) {
-          validationError = "JPEG / PNG / WebP / GIF 形式の画像を選択してください";
+          validationError = ACCEPTED_IMAGE_TYPES_ERROR;
           continue;
         }
         if (file.size > MAX_IMAGE_FILE_SIZE) {

--- a/components/ImageUpload/index.tsx
+++ b/components/ImageUpload/index.tsx
@@ -184,6 +184,8 @@ const urlToFile = (url: string): Promise<File> => {
       canvas.height = img.naturalHeight;
       const ctx = canvas.getContext("2d");
       if (!ctx) {
+        canvas.width = 0;
+        canvas.height = 0;
         img.onload = null;
         img.onerror = null;
         reject(new Error("Canvas コンテキストの取得に失敗しました"));
@@ -203,6 +205,7 @@ const urlToFile = (url: string): Promise<File> => {
           img.onerror = null;
 
           if (!blob) {
+            console.error("[urlToFile] toBlob returned null:", url);
             reject(new Error("画像の変換に失敗しました"));
             return;
           }
@@ -231,6 +234,7 @@ const urlToFile = (url: string): Promise<File> => {
          * Canvas が taint されている場合など、DOMException の SecurityError が来る可能性がある。
          * 生の英語メッセージをユーザーに露出しないよう既知ケースをフレンドリー文言にマッピングする。
          */
+        console.error("[urlToFile] toBlob threw:", err, "url:", url);
         const friendlyMessage =
           err instanceof DOMException && err.name === "SecurityError"
             ? "この画像は読み込めませんでした（セキュリティエラーの可能性があります）"
@@ -242,7 +246,12 @@ const urlToFile = (url: string): Promise<File> => {
     img.onerror = () => {
       img.onload = null;
       img.onerror = null;
-      reject(new Error("この画像は読み込めませんでした（CORSエラーの可能性があります）"));
+      console.error("[urlToFile] img load failed:", url);
+      reject(
+        new Error(
+          "この画像は読み込めませんでした（CORS・ネットワーク・URLの問題の可能性があります）"
+        )
+      );
     };
 
     img.src = url;

--- a/components/ImageUpload/index.tsx
+++ b/components/ImageUpload/index.tsx
@@ -178,13 +178,19 @@ const urlToFile = (url: string): Promise<File> => {
             return;
           }
           /**
-           * data: URI はパス分割でファイル名を取得できないため固定名にする。
-           * http/https は new URL() で pathname の basename を取得し、
-           * search/hash を除外する。空文字の場合はフォールバック。
+           * 拡張子は blob.type から決定する。
+           * Canvas による再エンコード（例: GIF → PNG）で URL の拡張子と
+           * File.type が不一致になるのを防ぐため、URL 由来のパスは stem のみ採用する。
            */
+          const ext = blob.type.split("/")[1] ?? "png";
           const fileName = url.startsWith("data:")
-            ? `image.${blob.type.split("/")[1] ?? "png"}`
-            : new URL(url).pathname.split("/").pop() || "image.png";
+            ? `image.${ext}`
+            : `${
+                new URL(url).pathname
+                  .split("/")
+                  .pop()
+                  ?.replace(/\.[^.]*$/, "") || "image"
+              }.${ext}`;
           resolve(new File([blob], fileName, { type: blob.type }));
         }, detectOutputMimeType(url));
       } catch (err) {

--- a/components/ImageUpload/index.tsx
+++ b/components/ImageUpload/index.tsx
@@ -11,6 +11,60 @@ const ACCEPTED_TYPES = ["image/jpeg", "image/png", "image/webp", "image/gif"];
 /** 最大ファイルサイズ (20MB) */
 const MAX_FILE_SIZE = 20 * 1024 * 1024;
 
+/**
+ * `text/html` 文字列から最初の `<img>` タグの `src` 属性を抽出する
+ *
+ * @param html - ドロップされた HTML 文字列
+ * @returns 画像 URL、または null
+ */
+const extractImageUrlFromHtml = (html: string): string | null => {
+  const doc = new DOMParser().parseFromString(html, "text/html");
+  const img = doc.querySelector("img");
+  return img?.src ?? null;
+};
+
+/**
+ * 画像 URL を `<img crossOrigin="anonymous">` + Canvas `toBlob` で File に変換する
+ *
+ * サーバーへの画像データ送信を避けるため fetch は使用しない。
+ * CORS エラーや形式不正の場合は reject される。
+ *
+ * @param url - 画像 URL（http/https/data: URI）
+ * @returns 変換した File オブジェクト
+ */
+const urlToFile = (url: string): Promise<File> => {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.crossOrigin = "anonymous";
+
+    img.onload = () => {
+      const canvas = document.createElement("canvas");
+      canvas.width = img.naturalWidth;
+      canvas.height = img.naturalHeight;
+      const ctx = canvas.getContext("2d");
+      if (!ctx) {
+        reject(new Error("Canvas コンテキストの取得に失敗しました"));
+        return;
+      }
+      ctx.drawImage(img, 0, 0);
+      canvas.toBlob((blob) => {
+        if (!blob) {
+          reject(new Error("画像の変換に失敗しました"));
+          return;
+        }
+        const fileName = url.split("/").pop()?.split("?")[0] ?? "image.png";
+        resolve(new File([blob], fileName, { type: blob.type }));
+      }, "image/png");
+    };
+
+    img.onerror = () => {
+      reject(new Error("この画像は読み込めませんでした（CORSエラーの可能性があります）"));
+    };
+
+    img.src = url;
+  });
+};
+
 interface ImageUploadProps {
   /** ファイル選択時のコールバック */
   onUpload: (files: File[]) => void;
@@ -76,9 +130,29 @@ export function ImageUpload({
       e.preventDefault();
       setIsDragOver(false);
       if (disabled) return;
+
       const files = Array.from(e.dataTransfer.files);
-      if (files.length === 0) return;
-      handleFiles(multiple ? files : [files[0]]);
+      if (files.length > 0) {
+        handleFiles(multiple ? files : [files[0]]);
+        return;
+      }
+
+      /** files が空の場合は別タブ・外部アプリからの D&D として URL を取得する */
+      const uriList = e.dataTransfer.getData("text/uri-list");
+      const html = e.dataTransfer.getData("text/html");
+
+      const imageUrl = uriList.trim() || extractImageUrlFromHtml(html);
+      if (!imageUrl) return;
+
+      void (async () => {
+        try {
+          const file = await urlToFile(imageUrl);
+          handleFiles(multiple ? [file] : [file]);
+        } catch (err) {
+          const message = err instanceof Error ? err.message : "この画像は読み込めませんでした";
+          setError(message);
+        }
+      })();
     },
     [disabled, handleFiles, multiple]
   );

--- a/components/ImageUpload/index.tsx
+++ b/components/ImageUpload/index.tsx
@@ -96,15 +96,19 @@ const urlToFile = (url: string): Promise<File> => {
           /** data: URI はパス分割でファイル名を取得できないため固定名にする */
           const fileName = url.startsWith("data:")
             ? `image.${blob.type.split("/")[1] ?? "png"}`
-            : (url.split("/").pop()?.split("?")[0] ?? "image.png");
+            : url.split("/").pop()?.split("?")[0] || "image.png";
           resolve(new File([blob], fileName, { type: blob.type }));
         }, "image/png");
       } catch (err) {
-        reject(
-          err instanceof Error
-            ? err
-            : new Error("この画像は読み込めませんでした（セキュリティエラーの可能性があります）")
-        );
+        /**
+         * Canvas が taint されている場合など、DOMException の SecurityError が来る可能性がある。
+         * 生の英語メッセージをユーザーに露出しないよう既知ケースをフレンドリー文言にマッピングする。
+         */
+        const friendlyMessage =
+          err instanceof DOMException && err.name === "SecurityError"
+            ? "この画像は読み込めませんでした（セキュリティエラーの可能性があります）"
+            : "この画像は読み込めませんでした";
+        reject(new Error(friendlyMessage));
       }
     };
 
@@ -207,6 +211,10 @@ export function ImageUpload({
           const file = await urlToFile(imageUrl);
           handleFiles(multiple ? [file] : [file]);
         } catch (err) {
+          /**
+           * urlToFile がスローするエラーは既にフレンドリー文言に変換済み。
+           * 想定外の型のエラーは共通文言に丸めてユーザーへ露出しない。
+           */
           const message = err instanceof Error ? err.message : "この画像は読み込めませんでした";
           setError(message);
         }

--- a/components/ImageUpload/index.tsx
+++ b/components/ImageUpload/index.tsx
@@ -56,6 +56,58 @@ const validateUrlScheme = (url: string): string | null => {
   }
 };
 
+/**
+ * 既知の画像拡張子から MIME タイプへのマッピング
+ *
+ * ACCEPTED_IMAGE_TYPES に含まれない形式（BMP / SVG 等）も列挙して明示的に弾けるようにする。
+ * このマップに存在しない拡張子（拡張子なし URL 等）は未知として変換を試みる。
+ */
+const IMAGE_EXT_TO_MIME: Record<string, string> = {
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  png: "image/png",
+  webp: "image/webp",
+  gif: "image/gif",
+  bmp: "image/bmp",
+  svg: "image/svg+xml",
+  tiff: "image/tiff",
+  tif: "image/tiff",
+  ico: "image/x-icon",
+  avif: "image/avif",
+  heic: "image/heic",
+  heif: "image/heif",
+};
+
+/**
+ * URL または data: URI の画像形式が許可済み MIME タイプかどうかを変換前に検証する
+ *
+ * - `data:` URI: MIME を `ACCEPTED_IMAGE_TYPES` と照合する
+ * - http/https URL: 拡張子から MIME を推測し `ACCEPTED_IMAGE_TYPES` と照合する
+ * - 拡張子不明（マッピング外・拡張子なし）の URL は許可して変換を試みる
+ *
+ * @param url - 検証対象の URL または data: URI
+ * @returns エラーメッセージ、または null（問題なし）
+ */
+const validateImageTypeFromUrl = (url: string): string | null => {
+  const ACCEPTED_ERROR = "JPEG / PNG / WebP / GIF 形式の画像を選択してください";
+
+  if (url.startsWith("data:")) {
+    const mimeMatch = url.match(/^data:([^;,]+)/);
+    const mime = mimeMatch?.[1] ?? "";
+    return ACCEPTED_IMAGE_TYPES.includes(mime) ? null : ACCEPTED_ERROR;
+  }
+
+  try {
+    const ext = new URL(url).pathname.split(".").pop()?.toLowerCase() ?? "";
+    const mime = IMAGE_EXT_TO_MIME[ext];
+    /** 拡張子不明の場合は変換を試みる（拡張子なし URL 等） */
+    if (!mime) return null;
+    return ACCEPTED_IMAGE_TYPES.includes(mime) ? null : ACCEPTED_ERROR;
+  } catch {
+    return null;
+  }
+};
+
 /** canvas.toBlob でサポートされる出力 MIME タイプ */
 const CANVAS_SUPPORTED_TYPES = ["image/jpeg", "image/png", "image/webp"] as const;
 type CanvasMimeType = (typeof CANVAS_SUPPORTED_TYPES)[number];
@@ -241,6 +293,13 @@ export function ImageUpload({
       const imageUrl = validateUrlScheme(rawUrl);
       if (!imageUrl) {
         setError("この画像は読み込めませんでした");
+        return;
+      }
+
+      /** 許可外 MIME タイプ（BMP / SVG 等）は変換前にエラーとして弾く */
+      const typeError = validateImageTypeFromUrl(imageUrl);
+      if (typeError) {
+        setError(typeError);
         return;
       }
 

--- a/components/ImageUpload/index.tsx
+++ b/components/ImageUpload/index.tsx
@@ -4,7 +4,12 @@ import { useCallback, useRef, useState } from "react";
 import type { ChangeEvent, DragEvent, KeyboardEvent } from "react";
 import clsx from "clsx";
 import { ImageIcon, LoaderCircle } from "lucide-react";
-import { ACCEPTED_IMAGE_TYPES, ACCEPTED_IMAGE_TYPES_ERROR, MAX_IMAGE_FILE_SIZE } from "./constants";
+import {
+  ACCEPTED_IMAGE_TYPES,
+  ACCEPTED_IMAGE_TYPES_ERROR,
+  MAX_CANVAS_DIMENSION,
+  MAX_IMAGE_FILE_SIZE,
+} from "./constants";
 
 /** D&D で許可する URL スキーム */
 const ALLOWED_URL_SCHEMES = ["http:", "https:", "data:"];
@@ -158,6 +163,19 @@ const urlToFile = (url: string): Promise<File> => {
     img.referrerPolicy = "no-referrer";
 
     img.onload = () => {
+      /**
+       * 巨大解像度画像は Canvas のメモリ確保でタブがフリーズ/クラッシュするため、
+       * MAX_IMAGE_FILE_SIZE チェックより先に解像度をガードする。
+       */
+      if (img.naturalWidth > MAX_CANVAS_DIMENSION || img.naturalHeight > MAX_CANVAS_DIMENSION) {
+        reject(
+          new Error(
+            `画像の解像度が大きすぎます（最大 ${MAX_CANVAS_DIMENSION}×${MAX_CANVAS_DIMENSION}px）`
+          )
+        );
+        return;
+      }
+
       const canvas = document.createElement("canvas");
       canvas.width = img.naturalWidth;
       canvas.height = img.naturalHeight;

--- a/components/ImageUpload/index.tsx
+++ b/components/ImageUpload/index.tsx
@@ -6,6 +6,25 @@ import clsx from "clsx";
 import { ImageIcon, LoaderCircle } from "lucide-react";
 import { ACCEPTED_IMAGE_TYPES, MAX_IMAGE_FILE_SIZE } from "./constants";
 
+/** D&D で許可する URL スキーム */
+const ALLOWED_URL_SCHEMES = ["http:", "https:", "data:"];
+
+/**
+ * `text/uri-list` 文字列から最初の有効な URL を抽出する
+ *
+ * RFC 2483 に従い、コメント行（`#` 始まり）と空行を除外して先頭 URL を返す。
+ *
+ * @param uriList - DataTransfer から取得した `text/uri-list` 文字列
+ * @returns 最初の有効 URL、または null
+ */
+const extractUrlFromUriList = (uriList: string): string | null => {
+  for (const line of uriList.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (trimmed && !trimmed.startsWith("#")) return trimmed;
+  }
+  return null;
+};
+
 /**
  * `text/html` 文字列から最初の `<img>` タグの `src` 属性を抽出する
  *
@@ -19,10 +38,30 @@ const extractImageUrlFromHtml = (html: string): string | null => {
 };
 
 /**
+ * URL のスキームを検証し、許可外スキームの場合は null を返す
+ *
+ * `data:` は `new URL()` でパースできない環境もあるため個別に判定する。
+ * 許可スキーム: http / https / data
+ *
+ * @param url - 検証する URL 文字列
+ * @returns 有効な URL 文字列、または null
+ */
+const validateUrlScheme = (url: string): string | null => {
+  if (url.startsWith("data:")) return url;
+  try {
+    const parsed = new URL(url);
+    return ALLOWED_URL_SCHEMES.includes(parsed.protocol) ? url : null;
+  } catch {
+    return null;
+  }
+};
+
+/**
  * 画像 URL を `<img crossOrigin="anonymous">` + Canvas `toBlob` で File に変換する
  *
  * サーバーへの画像データ送信を避けるため fetch は使用しない。
  * CORS エラーや形式不正の場合は reject される。
+ * `data:` URI の場合はファイル名をMIMEタイプから決定する。
  *
  * @param url - 画像 URL（http/https/data: URI）
  * @returns 変換した File オブジェクト
@@ -47,7 +86,10 @@ const urlToFile = (url: string): Promise<File> => {
           reject(new Error("画像の変換に失敗しました"));
           return;
         }
-        const fileName = url.split("/").pop()?.split("?")[0] ?? "image.png";
+        /** data: URI はパス分割でファイル名を取得できないため固定名にする */
+        const fileName = url.startsWith("data:")
+          ? `image.${blob.type.split("/")[1] ?? "png"}`
+          : (url.split("/").pop()?.split("?")[0] ?? "image.png");
         resolve(new File([blob], fileName, { type: blob.type }));
       }, "image/png");
     };
@@ -136,8 +178,15 @@ export function ImageUpload({
       const uriList = e.dataTransfer.getData("text/uri-list");
       const html = e.dataTransfer.getData("text/html");
 
-      const imageUrl = uriList.trim() || extractImageUrlFromHtml(html);
-      if (!imageUrl) return;
+      const rawUrl = extractUrlFromUriList(uriList) ?? extractImageUrlFromHtml(html);
+      if (!rawUrl) return;
+
+      /** 許可外スキーム（javascript: / file: 等）はエラーとして弾く */
+      const imageUrl = validateUrlScheme(rawUrl);
+      if (!imageUrl) {
+        setError("この画像は読み込めませんでした");
+        return;
+      }
 
       void (async () => {
         try {


### PR DESCRIPTION
## 概要

別タブ・外部アプリからのドラッグ＆ドロップで画像をマスキングできるようにする。`text/uri-list`（画像URL）および `text/html`（`<img>` タグ内の URL）を取得し、`<img crossOrigin="anonymous">` + Canvas `toBlob` でクライアントサイドのみで File に変換してマスキング処理を開始する。

## 関連Issue

Closes #19

## 変更内容

- [x] 機能追加
- [x] バグ修正
- [ ] リファクタリング
- [x] テスト追加・修正
- [ ] ドキュメント修正
- [ ] 設定・環境変更
- [ ] その他

## 主な変更箇所

### UI・コンポーネント

既存の D&D ハイライト・バリデーションエラー表示（ファイル形式・サイズ超過）は変更なし。外部 URL D&D 経路のエラー（CORS・スキーム不正・MIME 不正・解像度超過等）は `toast.error` でトースト表示し、自動消去される。URL D&D 経路に入った時点で以前のインラインエラーを `setError(null)` でクリアする。

### ロジック・処理

**`components/ImageUpload/index.tsx`**

新規ヘルパー関数を追加：

- `extractUrlFromUriList(uriList)` — RFC 2483 に従いコメント行・空行を除いた先頭 URL を抽出
- `extractImageUrlFromHtml(html)` — `DOMParser` で `<img src>` を抽出する純粋関数
- `validateUrlScheme(url)` — `http/https/data:` のみ許可、`javascript:/file:` 等の不正スキームを弾く
- `validateImageTypeFromUrl(url)` — `ACCEPTED_IMAGE_TYPES` 相当の MIME のみ許可（BMP/SVG 等は変換前にエラー）
- `detectOutputMimeType(url)` — URL 拡張子・`data:` MIME から `canvas.toBlob` の出力形式を決定（GIF 等は PNG フォールバック）
- `urlToFile(url)` — `<img crossOrigin="anonymous" referrerPolicy="no-referrer">` + Canvas `toBlob` で URL を `File` に変換

`handleDrop` を拡張：

- `e.dataTransfer.files` が空の場合に `text/uri-list`（複数行パース済み）→ `text/html` の順で URL を取得
- スキーム検証 → MIME 検証 → `urlToFile` 変換 → 既存の `handleFiles` へ渡す（バリデーション流用）
- CORS エラー・スキームエラー・MIME エラー等の失敗時は `toast.error` でトースト表示

**`components/ImageUpload/constants.ts`**

- `ACCEPTED_IMAGE_TYPES_ERROR` — 許可形式エラー文言（重複定義を一元化）
- `MAX_CANVAS_DIMENSION` — Canvas 変換の最大辺サイズ（8000px）

### その他

**`components/ImageUpload/ImageUpload.test.tsx`（更新）**

- 別タブ D&D テストを 13 ケース追加（全 20 テスト）

## 動作確認

- [x] ローカル環境での動作確認
- [x] テストの実行・通過確認
- [x] UI動作確認
- [x] 既存機能への影響確認
- [ ] ブラウザ動作確認（Chrome / Firefox / Safari）

## テスト

### 追加したテスト（抜粋）

- `text/uri-list` / `text/html` から onUpload が呼ばれる
- `data:image/png` URI から onUpload が呼ばれる
- 読み込み失敗（CORS）時は `toast.error` が呼ばれる
- `javascript:` / `file:` 等の不正スキームは `toast.error` でエラー
- `.bmp` / `.svg` 等の許可外形式は `toast.error` でエラー
- 許可外 MIME の `data:` URI は `toast.error` でエラー
- `text/uri-list` 複数行（コメント行・空行含む）から先頭 URL を抽出
- 解像度超過（8000px 超）は `toast.error` でエラー
- files が空で URL もない場合は何もしない

### テスト結果

- [x] 全てのテストが通過（20 tests）
- [x] 新規テストを追加
- [x] 既存テストの修正

## 破壊的変更

- [ ] 破壊的変更あり
- [x] 破壊的変更なし

## レビューポイント

- `urlToFile` で `fetch` を使わず `<img crossOrigin="anonymous">` + Canvas `toBlob` のみを使用している点（セキュリティ要件準拠）
- 外部 URL D&D エラーを `toast.error` で表示しており、ファイル選択バリデーション（`setError`）とは表示方式を分けている点
- 既存の `handleFiles` バリデーション（形式・サイズ上限）をそのまま流用している点

## チェックリスト

- [x] コードレビューの準備ができている
- [x] 適切なラベルを付けている
- [x] セルフレビューを実施している
- [x] `pnpm lint` と `pnpm type-check` が通ることを確認した
- [x] 必要に応じてドキュメントを更新している