### PR TITLE
ペイントストロークの移動・リサイズ・回転を永続化できない問題を修正

### DIFF
--- a/features/editor/components/EditorCanvas.tsx
+++ b/features/editor/components/EditorCanvas.tsx
@@ -40,6 +40,7 @@ interface EditorCanvasProps {
   onAddPaintStroke: (stroke: Omit<PaintStroke, "id">) => void;
   onUpdateStampRegion: (id: string, updates: Partial<Omit<StampRegion, "id">>) => void;
   onUpdateFillRegion: (id: string, updates: Partial<Omit<FillRegion, "id">>) => void;
+  onUpdatePaintStroke: (id: string, updates: Partial<Omit<PaintStroke, "id">>) => void;
   /** stamp-face 種別用のスタンプ画像マップ（ファイル名をキーにした HTMLImageElement の Map） */
   stampImages: Map<string, HTMLImageElement>;
   /** 現在選択中の stamp-face 画像のファイル名 */
@@ -263,6 +264,7 @@ export function EditorCanvas({
   onAddPaintStroke,
   onUpdateStampRegion,
   onUpdateFillRegion,
+  onUpdatePaintStroke,
   stampImages,
   selectedStampFileName,
   onDeleteSelected,
@@ -325,7 +327,7 @@ export function EditorCanvas({
   /**
    * 選択変化・領域サイズ変化時に Transformer を再アタッチする
    *
-   * stampRegions / fillRegions を依存に含めることで、
+   * stampRegions / fillRegions / paintStrokes を依存に含めることで、
    * リサイズ後に React state が更新された際に Transformer が
    * キャッシュ済みのバウンディングボックスを再計算する。
    */
@@ -346,7 +348,7 @@ export function EditorCanvas({
     } else {
       transformer.nodes([]);
     }
-  }, [selectedId, stampRegions, fillRegions]);
+  }, [selectedId, stampRegions, fillRegions, paintStrokes]);
 
   /**
    * ステージのマウスダウン/タッチスタートハンドラ
@@ -466,6 +468,76 @@ export function EditorCanvas({
     } else {
       onUpdateFillRegion(id, { x: newX, y: newY });
     }
+  }
+
+  /**
+   * ペイントストロークのドラッグ終了時に、ノードの x/y オフセットを points 配列に
+   * 焼き込んで state を更新する。
+   *
+   * Konva.Line は points が node のローカル座標で保持されるため、
+   * ドラッグ後の x/y を points に加算してからノードの x/y をリセットする。
+   *
+   * @param id - ストロークのID
+   * @param node - Konva.Line ノード
+   */
+  function handlePaintStrokeDragEnd(id: string, node: Konva.Line) {
+    const dx = node.x();
+    const dy = node.y();
+    if (dx === 0 && dy === 0) return;
+
+    const localPoints = node.points();
+    const newImagePoints: { x: number; y: number }[] = [];
+    for (let i = 0; i < localPoints.length; i += 2) {
+      newImagePoints.push({
+        x: ((localPoints[i] ?? 0) + dx) / scaleX,
+        y: ((localPoints[i + 1] ?? 0) + dy) / scaleY,
+      });
+    }
+
+    node.x(0);
+    node.y(0);
+    node.points(newImagePoints.flatMap((p) => [p.x * scaleX, p.y * scaleY]));
+
+    onUpdatePaintStroke(id, { points: newImagePoints });
+  }
+
+  /**
+   * ペイントストロークのトランスフォーム終了時に、回転・拡縮・移動を points と
+   * brushSize に焼き込んで state を更新する。
+   *
+   * brushSize は scaleX/scaleY の絶対値の平均で再計算する（非一様スケール時の近似）。
+   *
+   * @param id - ストロークのID
+   * @param stroke - 元のストローク
+   * @param node - Konva.Line ノード
+   */
+  function handlePaintStrokeTransformEnd(id: string, stroke: PaintStroke, node: Konva.Line) {
+    const transform = node.getTransform();
+    const localPoints = node.points();
+    const scaleAbsX = Math.abs(node.scaleX());
+    const scaleAbsY = Math.abs(node.scaleY());
+
+    const newImagePoints: { x: number; y: number }[] = [];
+    for (let i = 0; i < localPoints.length; i += 2) {
+      const worldPoint = transform.point({
+        x: localPoints[i] ?? 0,
+        y: localPoints[i + 1] ?? 0,
+      });
+      newImagePoints.push({
+        x: worldPoint.x / scaleX,
+        y: worldPoint.y / scaleY,
+      });
+    }
+
+    node.x(0);
+    node.y(0);
+    node.scaleX(1);
+    node.scaleY(1);
+    node.rotation(0);
+    node.points(newImagePoints.flatMap((p) => [p.x * scaleX, p.y * scaleY]));
+
+    const newBrushSize = stroke.brushSize * ((scaleAbsX + scaleAbsY) / 2);
+    onUpdatePaintStroke(id, { points: newImagePoints, brushSize: newBrushSize });
   }
 
   /**
@@ -632,8 +704,14 @@ export function EditorCanvas({
               lineCap="round"
               lineJoin="round"
               opacity={stroke.isEnabled ? 1 : 0.3}
+              hitStrokeWidth={Math.max(stroke.brushSize * scaleX, 12)}
+              draggable={isInteractive}
               onClick={() => isInteractive && onSelectItem(stroke.id)}
               onTap={() => isInteractive && onSelectItem(stroke.id)}
+              onDragEnd={(e) => handlePaintStrokeDragEnd(stroke.id, e.target as Konva.Line)}
+              onTransformEnd={(e) =>
+                handlePaintStrokeTransformEnd(stroke.id, stroke, e.target as Konva.Line)
+              }
             />
           ))}
 

--- a/features/editor/hooks/useEditorState.test.ts
+++ b/features/editor/hooks/useEditorState.test.ts
@@ -161,6 +161,56 @@ describe("useEditorState", () => {
     });
   });
 
+  it("updatePaintStroke でペイントストロークの points と brushSize を更新できる", () => {
+    vi.stubGlobal("crypto", { randomUUID: vi.fn().mockReturnValue("stroke-update-uuid") });
+    const { result } = renderHook(() => useEditorState());
+    act(() => {
+      result.current.addPaintStroke({
+        points: [
+          { x: 0, y: 0 },
+          { x: 10, y: 10 },
+        ],
+        brushSize: 20,
+        isEnabled: true,
+      });
+    });
+    act(() => {
+      result.current.updatePaintStroke("stroke-update-uuid", {
+        points: [
+          { x: 100, y: 100 },
+          { x: 110, y: 110 },
+        ],
+        brushSize: 40,
+      });
+    });
+    expect(result.current.paintStrokes[0]).toMatchObject({
+      id: "stroke-update-uuid",
+      points: [
+        { x: 100, y: 100 },
+        { x: 110, y: 110 },
+      ],
+      brushSize: 40,
+      isEnabled: true,
+    });
+  });
+
+  it("updatePaintStroke は存在しないIDでは何も変更しない", () => {
+    vi.stubGlobal("crypto", { randomUUID: vi.fn().mockReturnValue("noop-uuid") });
+    const { result } = renderHook(() => useEditorState());
+    act(() => {
+      result.current.addPaintStroke({
+        points: [{ x: 0, y: 0 }],
+        brushSize: 10,
+        isEnabled: true,
+      });
+    });
+    act(() => {
+      result.current.updatePaintStroke("not-exist", { brushSize: 99 });
+    });
+    expect(result.current.paintStrokes).toHaveLength(1);
+    expect(result.current.paintStrokes[0].brushSize).toBe(10);
+  });
+
   it("toggleFillRegion で isEnabled を切り替えられる", () => {
     vi.stubGlobal("crypto", { randomUUID: vi.fn().mockReturnValue("tog-uuid") });
     const { result } = renderHook(() => useEditorState());

--- a/features/editor/hooks/useEditorState.ts
+++ b/features/editor/hooks/useEditorState.ts
@@ -61,6 +61,7 @@ export interface UseEditorStateReturn {
   addPaintStroke: (stroke: Omit<PaintStroke, "id">) => void;
   updateStampRegion: (id: string, updates: Partial<Omit<StampRegion, "id">>) => void;
   updateFillRegion: (id: string, updates: Partial<Omit<FillRegion, "id">>) => void;
+  updatePaintStroke: (id: string, updates: Partial<Omit<PaintStroke, "id">>) => void;
   toggleFillRegion: (id: string) => void;
   removeItem: (id: string) => void;
   removeSelectedItem: () => void;
@@ -244,6 +245,16 @@ export function useEditorState(initialStampFileName = ""): UseEditorStateReturn 
   }, []);
 
   /**
+   * ペイントストロークを更新する
+   *
+   * @param id - 更新するストロークのID
+   * @param updates - 更新内容
+   */
+  const updatePaintStroke = useCallback((id: string, updates: Partial<Omit<PaintStroke, "id">>) => {
+    setPaintStrokes((prev) => prev.map((s) => (s.id === id ? { ...s, ...updates } : s)));
+  }, []);
+
+  /**
    * 塗りつぶし領域の有効/無効を切り替える
    *
    * @param id - 切り替える領域のID
@@ -307,6 +318,7 @@ export function useEditorState(initialStampFileName = ""): UseEditorStateReturn 
     addPaintStroke,
     updateStampRegion,
     updateFillRegion,
+    updatePaintStroke,
     toggleFillRegion,
     removeItem,
     removeSelectedItem,

--- a/features/masking/components/GalleryItem.tsx
+++ b/features/masking/components/GalleryItem.tsx
@@ -276,6 +276,7 @@ export function GalleryItem({
                   onAddPaintStroke={editor.addPaintStroke}
                   onUpdateStampRegion={editor.updateStampRegion}
                   onUpdateFillRegion={editor.updateFillRegion}
+                  onUpdatePaintStroke={editor.updatePaintStroke}
                   stampImages={stampImages}
                   selectedStampFileName={editor.selectedStampFileName}
                   onDeleteSelected={editor.removeSelectedItem}


### PR DESCRIPTION
## 概要

エディタのペイントモードで作成したストロークが、選択モードで **移動できない**、また **サイズ変更・回転を行っても永続化されない**（再レンダリング後・エクスポート時に変形が失われる）バグを修正する。

`<Line>` への `draggable` / `onDragEnd` / `onTransformEnd` の欠落と、`useEditorState` に `updatePaintStroke` 相当の更新関数が無いことが原因だった。

## 関連Issue

Closes #39

## 変更内容

- [ ] 機能追加
- [x] バグ修正
- [ ] リファクタリング
- [x] テスト追加・修正
- [ ] ドキュメント修正
- [ ] 設定・環境変更
- [ ] その他

## 主な変更箇所

### UI・コンポーネント

- `features/editor/components/EditorCanvas.tsx`
  - ペイントストローク `<Line>` に以下を追加
    - `draggable={isInteractive}`
    - `onDragEnd`：ノードの `x/y` オフセットを `points` に焼き込み、ノード側 `x/y` をリセット
    - `onTransformEnd`：`getTransform()` で回転・拡縮・移動を `points` に焼き込み、ノード側 transform をリセット。`brushSize` も拡縮の平均値に応じて更新
    - `hitStrokeWidth`：細いストロークでも掴みやすくするため最小 12px のヒット領域を確保
  - Transformer 再アタッチの依存配列に `paintStrokes` を追加（更新後にバウンディングボックスを再計算させる）
- `features/masking/components/GalleryItem.tsx`
  - `EditorCanvas` に `onUpdatePaintStroke={editor.updatePaintStroke}` を接続

### ロジック・処理

- `features/editor/hooks/useEditorState.ts`
  - `updatePaintStroke(id, updates)` を追加（`stampRegions` / `fillRegions` の `update*` と同等の API）
  - `UseEditorStateReturn` に型を追加し、戻り値にも追加

### その他

- `features/editor/hooks/useEditorState.test.ts`
  - `updatePaintStroke` の正常系（points・brushSize の更新）と境界値（存在しないID）のテストを追加

## 動作確認

- [x] ローカル環境での動作確認
- [x] テストの実行・通過確認（115件 すべて通過）
- [x] UI動作確認（移動・リサイズ・回転 → 別操作後も保持・エクスポートに反映）
- [x] 既存機能への影響確認（スタンプ・塗りつぶしの移動／変形は従来どおり）
- [ ] ブラウザ動作確認（Chrome / Firefox / Safari）

## スクリーンショット・動画

<!-- 必要に応じて添付 -->

## テスト

### 追加したテスト

- `features/editor/hooks/useEditorState.test.ts`
  - 「`updatePaintStroke` でペイントストロークの points と brushSize を更新できる」
  - 「`updatePaintStroke` は存在しないIDでは何も変更しない」

### テスト結果

- [x] 全てのテストが通過
- [x] 新規テストを追加
- [ ] 既存テストの修正

## 破壊的変更

- [ ] 破壊的変更あり
- [x] 破壊的変更なし

### 破壊的変更の詳細

`EditorCanvas` の Props に `onUpdatePaintStroke` が **必須** で追加される。リポジトリ内で `EditorCanvas` を呼び出している箇所は `GalleryItem.tsx` のみで、本 PR で同時に対応済み。

## レビューポイント

- `handlePaintStrokeTransformEnd` で Konva の `getTransform()` を用いて回転・拡縮・移動を `points` に焼き込み、ノード側の `x/y/scaleX/scaleY/rotation` をリセットしている設計が妥当か（スタンプ／塗りつぶし側の `getClientRect` ベースとは異なる方針）
- `brushSize` の拡縮反映を `(|scaleX| + |scaleY|) / 2` の単純平均で計算している点（非一様スケール時の近似として妥当か）
- `hitStrokeWidth` の最小 12px が UX 観点で妥当か

## 補足

- 元画像座標系で管理されている `points` を維持するため、ノードのローカル座標 (`stage 空間`) → ステージ空間 → 画像空間の変換を経て state を更新している
- `onTransformEnd` の存在しなかった旧実装では、Transformer による視覚上の変形が React の再レンダリングで失われ、エクスポート画像にも反映されない状態だった

## チェックリスト

- [x] コードレビューの準備ができている
- [x] 適切なラベルを付けている
- [x] セルフレビューを実施している
- [x] `pnpm lint` と `pnpm type-check` が通ることを確認した
- [ ] 必要に応じてドキュメントを更新している
