### PR TITLE
404 Not Found ページの追加

### DIFF
--- a/app/not-found.test.tsx
+++ b/app/not-found.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import NotFound from "./not-found";
+
+describe("NotFound", () => {
+  it("404 ラベルと見出しが表示される", () => {
+    render(<NotFound />);
+    expect(screen.getByText("404")).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { level: 1, name: "ページが見つかりません" })
+    ).toBeInTheDocument();
+  });
+
+  it("説明文が表示される", () => {
+    render(<NotFound />);
+    expect(
+      screen.getByText(/お探しのページは移動または削除された可能性があります/)
+    ).toBeInTheDocument();
+  });
+
+  it("トップへのリンクが / である", () => {
+    render(<NotFound />);
+    const topLink = screen.getByRole("link", { name: "トップに戻る" });
+    expect(topLink).toHaveAttribute("href", "/");
+  });
+
+  it("サービス紹介へのリンクが /lp である", () => {
+    render(<NotFound />);
+    const lpLink = screen.getByRole("link", { name: "サービス紹介を見る" });
+    expect(lpLink).toHaveAttribute("href", "/lp");
+  });
+});

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,57 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { clsx } from "clsx";
+
+const NOT_FOUND_PAGE_TITLE = "ページが見つかりません | 伏せ太郎 | Fusely";
+const NOT_FOUND_DESCRIPTION =
+  "お探しのページは移動または削除された可能性があります。URL をご確認のうえ、トップからお試しください。";
+
+export const metadata: Metadata = {
+  title: NOT_FOUND_PAGE_TITLE,
+  description: NOT_FOUND_DESCRIPTION,
+  robots: {
+    index: false,
+    follow: true,
+  },
+};
+
+/**
+ * 404 Not Found ページ
+ *
+ * 存在しないパスへのアクセス時に表示する。ルートレイアウトのヘッダー配下に描画される。
+ */
+export default function NotFound() {
+  return (
+    <div
+      className={clsx([
+        "mx-auto flex w-full max-w-5xl flex-1 flex-col items-center justify-center px-4 py-16 text-center",
+      ])}
+    >
+      <p className="text-sm font-medium tracking-wide text-indigo-600">404</p>
+      <h1 className="mt-2 text-2xl font-bold tracking-tight text-zinc-900 sm:text-3xl">
+        ページが見つかりません
+      </h1>
+      <p className="mt-4 max-w-md text-pretty text-zinc-600">{NOT_FOUND_DESCRIPTION}</p>
+      <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:justify-center">
+        <Link
+          href="/"
+          className={clsx([
+            "inline-flex items-center justify-center rounded-lg bg-indigo-600 px-5 py-2.5 text-sm font-semibold text-white",
+            "transition-colors hover:bg-indigo-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600",
+          ])}
+        >
+          トップに戻る
+        </Link>
+        <Link
+          href="/lp"
+          className={clsx([
+            "inline-flex items-center justify-center rounded-lg border border-zinc-300 bg-white px-5 py-2.5 text-sm font-semibold text-zinc-800",
+            "transition-colors hover:bg-zinc-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-zinc-400",
+          ])}
+        >
+          サービス紹介を見る
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -22,11 +22,7 @@ export const metadata: Metadata = {
  */
 export default function NotFound() {
   return (
-    <div
-      className={clsx([
-        "mx-auto flex w-full max-w-5xl flex-1 flex-col items-center justify-center px-4 py-16 text-center",
-      ])}
-    >
+    <div className="mx-auto flex w-full max-w-5xl flex-1 flex-col items-center justify-center px-4 py-16 text-center">
       <p
         className={clsx([
           "text-5xl font-bold tabular-nums tracking-tight text-indigo-600 sm:text-6xl",

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -27,8 +27,14 @@ export default function NotFound() {
         "mx-auto flex w-full max-w-5xl flex-1 flex-col items-center justify-center px-4 py-16 text-center",
       ])}
     >
-      <p className="text-sm font-medium tracking-wide text-indigo-600">404</p>
-      <h1 className="mt-2 text-2xl font-bold tracking-tight text-zinc-900 sm:text-3xl">
+      <p
+        className={clsx([
+          "text-5xl font-bold tabular-nums tracking-tight text-indigo-600 sm:text-6xl",
+        ])}
+      >
+        404
+      </p>
+      <h1 className="mt-4 text-2xl font-bold tracking-tight text-zinc-900 sm:mt-5 sm:text-3xl">
         ページが見つかりません
       </h1>
       <p className="mt-4 max-w-md text-pretty text-zinc-600">{NOT_FOUND_DESCRIPTION}</p>

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -23,11 +23,7 @@ export const metadata: Metadata = {
 export default function NotFound() {
   return (
     <div className="mx-auto flex w-full max-w-5xl flex-1 flex-col items-center justify-center px-4 py-16 text-center">
-      <p
-        className={clsx([
-          "text-5xl font-bold tabular-nums tracking-tight text-indigo-600 sm:text-6xl",
-        ])}
-      >
+      <p className="text-5xl font-bold tabular-nums tracking-tight text-indigo-600 sm:text-6xl">
         404
       </p>
       <h1 className="mt-4 text-2xl font-bold tracking-tight text-zinc-900 sm:mt-5 sm:text-3xl">


### PR DESCRIPTION
## 概要

App Router の `app/not-found.tsx` を追加し、存在しない URL へアクセスした際にアプリのトーンに合った 404 ページを表示する。トップおよびサービス紹介への導線と、検索エンジン向けに `noindex` を設定したメタデータを含む。

## 関連Issue

Closes #43

## 変更内容

- [x] 機能追加
- [ ] バグ修正
- [ ] リファクタリング
- [x] テスト追加・修正
- [ ] ドキュメント修正
- [ ] 設定・環境変更
- [ ] その他

## 主な変更箇所

### UI・コンポーネント

- `app/not-found.tsx`: ステータス「404」を大型表示（`text-5xl` / `sm:text-6xl`）、説明文、`/` と `/lp` へのリンク（zinc / indigo に合わせたボタン・セカンダリリンク）

### ロジック・処理

- 該当なし（静的 UI のみ）

### その他

- `app/not-found.test.tsx`: 表示文言とリンク先の単体テスト

## 動作確認

- [x] ローカル環境での動作確認
- [x] テストの実行・通過確認
- [x] UI動作確認
- [x] 既存機能への影響確認
- [ ] ブラウザ動作確認（Chrome / Firefox / Safari）

※ ビルドで `/_not-found` が静的生成されることを確認済み。

## スクリーンショット・動画

<!-- 必要ならレビュー時に追加 -->

## テスト

### 追加したテスト

- `app/not-found.test.tsx`（見出し・説明・`/`・`/lp` リンク）

### テスト結果

- [x] 全てのテストが通過
- [x] 新規テストを追加
- [ ] 既存テストの修正

実行: `pnpm test:run app/not-found.test.tsx`

## 破壊的変更

- [ ] 破壊的変更あり
- [x] 破壊的変更なし

### 破壊的変更の詳細

該当なし

## レビューポイント

- 404 用メタデータの `robots.index: false` がプロダクト方針と合うか
- コピー（説明文）のトーンが LP / トップと揃っているか

## 補足

- 画像や外部 API への送信は行っていない

## チェックリスト

- [x] コードレビューの準備ができている
- [x] 適切なラベルを付けている
- [x] セルフレビューを実施している
- [x] `pnpm lint` と `pnpm type-check` が通ることを確認した
- [ ] 必要に応じてドキュメントを更新している
