### PR TITLE
LPヒーローCTAを最終CTAと同じ白背景に統一

### DIFF
--- a/app/lp/_components/HeroSection.tsx
+++ b/app/lp/_components/HeroSection.tsx
@@ -47,7 +47,7 @@ export function HeroSection() {
         <div className="mt-10 flex flex-col items-center gap-4 sm:flex-row sm:justify-center">
           <Link
             href="/"
-            className="inline-flex w-full max-w-xs items-center justify-center gap-2 rounded-xl bg-gradient-to-r from-indigo-500 to-violet-500 px-8 py-4 text-base font-bold text-white shadow-lg transition-all hover:from-indigo-400 hover:to-violet-400 hover:shadow-xl active:scale-95 sm:w-auto sm:max-w-none"
+            className="inline-flex w-full max-w-xs items-center justify-center gap-2 rounded-xl bg-white px-10 py-4 text-base font-bold text-indigo-900 shadow-lg transition-all hover:bg-indigo-50 hover:shadow-xl active:scale-95 sm:w-auto sm:max-w-none"
           >
             今すぐ使う
             <ArrowRight className="h-5 w-5" aria-hidden="true" />


### PR DESCRIPTION
## 概要

LPヒーローの「今すぐ使う」ボタンを、紫グラデ背景とのコントラストが弱かった（特にSP）問題を解消するため、`FinalCtaSection` と同じ白背景CTAに揃えました。

## 関連Issue

Closes #45

## 変更内容

- [ ] 機能追加
- [x] バグ修正
- [ ] リファクタリング
- [ ] テスト追加・修正
- [ ] ドキュメント修正
- [ ] 設定・環境変更
- [ ] その他

## 主な変更箇所

### UI・コンポーネント

- `app/lp/_components/HeroSection.tsx`
  - プライマリCTAをグラデーションから白背景（`bg-white` / `text-indigo-900` / `hover:bg-indigo-50`）に変更
  - `px-10` を最終CTAと揃え、SP時の `w-full max-w-xs` 等は維持

### ロジック・処理

- なし

### その他

- なし

## 動作確認

- [x] ローカル環境での動作確認
- [ ] テストの実行・通過確認
- [x] UI動作確認
- [x] 既存機能への影響確認
- [ ] ブラウザ動作確認（Chrome / Firefox / Safari）

## スクリーンショット・動画

- なし

## テスト

### 追加したテスト

- なし

### テスト結果

- [ ] 全てのテストが通過
- [ ] 新規テストを追加
- [ ] 既存テストの修正

## 破壊的変更

- [ ] 破壊的変更あり
- [x] 破壊的変更なし

### 破壊的変更の詳細

- なし

## レビューポイント

- ヒーロー上で白CTAが背景と十分に切り離せているか（SP含む）
- 最終CTAとの見た目の一貫性

## 補足

- 変更はスタイルのみ

## チェックリスト

- [x] コードレビューの準備ができている
- [x] 適切なラベルを付けている
- [x] セルフレビューを実施している
- [x] `pnpm lint` と `pnpm type-check` が通ることを確認した
- [ ] 必要に応じてドキュメントを更新している
