### PR TITLE
既定の公開サイトURLをfusely-app.pages.devに合わせる

### DIFF
--- a/lib/siteUrl.ts
+++ b/lib/siteUrl.ts
@@ -1,4 +1,5 @@
-const DEFAULT_SITE_URL = "https://privacy-masking-app.pages.dev";
+/** `NEXT_PUBLIC_SITE_URL` 未設定時の本番既定URL（Cloudflare Pages の公開ドメイン）。 */
+const DEFAULT_SITE_URL = "https://fusely-app.pages.dev";
 
 /**
  * サイトURL文字列の末尾スラッシュを除去して正規化する。


### PR DESCRIPTION
## 概要

`NEXT_PUBLIC_SITE_URL` 未設定時のフォールバックを、実際の本番公開ドメイン `https://fusely-app.pages.dev` に合わせる。sitemap・metadata 等で `privacy-masking-app.pages.dev` が出て Search Console と噛み合わない問題を解消する。

## 関連Issue

該当なし。

## 変更内容

- [ ] 機能追加
- [x] バグ修正
- [ ] リファクタリング
- [ ] テスト追加・修正
- [ ] ドキュメント修正
- [ ] 設定・環境変更
- [ ] その他

## 主な変更箇所

### UI・コンポーネント

なし。

### ロジック・処理

- `lib/siteUrl.ts` の `DEFAULT_SITE_URL` を `https://fusely-app.pages.dev` に更新。`getSiteUrl()` のフォールバックが本番ドメインと一致する。

### その他

- ビルド時に `NEXT_PUBLIC_SITE_URL` を設定している環境では従来どおりその値が優先される。

## 動作確認

- [ ] ローカル環境での動作確認
- [x] テストの実行・通過確認
- [ ] UI動作確認
- [x] 既存機能への影響確認
- [ ] ブラウザ動作確認（Chrome / Firefox / Safari）

`pnpm lint lib/siteUrl.ts` および `pnpm type-check` を実行し、いずれも成功。

## スクリーンショット・動画

なし（URL 定数の変更のみ）。

## テスト

### 追加したテスト

なし。

### テスト結果

- [x] 全てのテストが通過（本PRでは `pnpm lint lib/siteUrl.ts` と `pnpm type-check` のみ実行）
- [ ] 新規テストを追加
- [ ] 既存テストの修正

## 破壊的変更

- [ ] 破壊的変更あり
- [x] 破壊的変更なし

### 破壊的変更の詳細

なし。

## レビューポイント

- 本番が `fusely-app.pages.dev` で固定である前提で問題ないか。
- `docs/` 等の静的成果物はマージ後のビルド・デプロイで更新される運用でよいか（本PRはソースのみ）。

## 補足

Cloudflare Pages で `NEXT_PUBLIC_SITE_URL` を本番 URL に設定済みなら、本変更は主にローカル・プレビュー・変数未設定時の一貫性向け。

## チェックリスト

- [x] コードレビューの準備ができている
- [x] 適切なラベルを付けている
- [x] セルフレビューを実施している
- [x] `pnpm lint` と `pnpm type-check` が通ることを確認した
- [ ] 必要に応じてドキュメントを更新している（ビルド成果物はデプロイフローに委ねる）
