### PR TITLE
SP時のみギャラリーをプレビュー(img)と編集(Konva)に切り替え

### DIFF
--- a/features/masking/components/GalleryItem.test.tsx
+++ b/features/masking/components/GalleryItem.test.tsx
@@ -1,0 +1,114 @@
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { GalleryItem } from "./GalleryItem";
+import type { MaskingImageItem } from "../types";
+
+vi.mock("@/features/editor/utils/exportCanvas", () => ({
+  exportEditorCanvas: vi.fn().mockResolvedValue("blob:export-result"),
+}));
+
+vi.mock("@/features/editor/components/EditorCanvas", () => ({
+  EditorCanvas: () => <div data-testid="mock-editor-canvas" />,
+}));
+
+/** 1×1 PNG（data URL）— jsdom で naturalWidth が取れるようにする */
+const TINY_DATA_URL =
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==";
+
+function createImage(overrides: Partial<MaskingImageItem> = {}): MaskingImageItem {
+  return {
+    id: "img-1",
+    name: "test.png",
+    size: 1024,
+    imageUrl: TINY_DATA_URL,
+    detections: [],
+    ocrRegions: [],
+    maskedBlobUrl: "blob:masked-preview",
+    isProcessing: false,
+    processingError: false,
+    ...overrides,
+  };
+}
+
+describe("GalleryItem", () => {
+  const handlers = {
+    onSelect: vi.fn(),
+    onRedetect: vi.fn(),
+    onRendered: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    /** `new Image()` の onload / naturalWidth を再現し、EditorCanvas の表示条件を満たす */
+    vi.stubGlobal(
+      "Image",
+      class MockImage {
+        onload: (() => void) | null = null;
+        onerror: (() => void) | null = null;
+        naturalWidth = 800;
+        naturalHeight = 600;
+        private _src = "";
+        set src(value: string) {
+          this._src = value;
+          queueMicrotask(() => {
+            this.onload?.();
+          });
+        }
+        get src(): string {
+          return this._src;
+        }
+      }
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("広い幅では編集ボタンなしでツールバーが常に表示される", async () => {
+    render(
+      <GalleryItem
+        image={createImage()}
+        isActive={false}
+        isModelLoading={false}
+        isNarrow={false}
+        {...handlers}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "選択" })).toBeInTheDocument();
+    });
+    expect(screen.queryByRole("button", { name: "画像を編集" })).not.toBeInTheDocument();
+  });
+
+  it("狭い幅ではプレビュー img のみで、編集押下後にツールバーとキャンバスが表示される", async () => {
+    render(
+      <GalleryItem
+        image={createImage()}
+        isActive={false}
+        isModelLoading={false}
+        isNarrow={true}
+        {...handlers}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "画像を編集" })).toBeInTheDocument();
+    });
+    expect(screen.queryByRole("button", { name: "選択" })).not.toBeInTheDocument();
+    expect(screen.queryByTestId("mock-editor-canvas")).not.toBeInTheDocument();
+
+    const previewImg = screen.getByRole("img", { name: "test.png" });
+    expect(previewImg).toHaveAttribute("src", "blob:masked-preview");
+
+    fireEvent.click(screen.getByRole("button", { name: "画像を編集" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "選択" })).toBeInTheDocument();
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId("mock-editor-canvas")).toBeInTheDocument();
+    });
+  });
+});

--- a/features/masking/components/GalleryItem.test.tsx
+++ b/features/masking/components/GalleryItem.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { exportEditorCanvas } from "@/features/editor/utils/exportCanvas";
 import { GalleryItem } from "./GalleryItem";
 import type { MaskingImageItem } from "../types";
 
@@ -110,5 +111,20 @@ describe("GalleryItem", () => {
     await waitFor(() => {
       expect(screen.getByTestId("mock-editor-canvas")).toBeInTheDocument();
     });
+  });
+
+  it("検出失敗時は exportEditorCanvas を呼ばない", async () => {
+    render(
+      <GalleryItem
+        image={createImage({ processingError: true })}
+        isActive={false}
+        isModelLoading={false}
+        isNarrow={false}
+        {...handlers}
+      />
+    );
+
+    expect(await screen.findByText("検出に失敗しました。再検出してください。")).toBeInTheDocument();
+    expect(vi.mocked(exportEditorCanvas)).not.toHaveBeenCalled();
   });
 });

--- a/features/masking/components/GalleryItem.tsx
+++ b/features/masking/components/GalleryItem.tsx
@@ -212,9 +212,9 @@ export function GalleryItem({
                 setIsEditing((prev) => !prev);
               }}
               className={clsx([
-                "min-h-[44px] min-w-[44px] rounded-lg px-3 py-1.5 text-sm font-medium transition-colors",
+                "rounded-lg px-3 py-1.5 text-sm font-medium transition-colors",
                 isEditing
-                  ? "bg-zinc-100 text-zinc-700 hover:bg-zinc-200"
+                  ? "bg-zinc-600 text-white hover:bg-zinc-700"
                   : "bg-emerald-600 text-white hover:bg-emerald-700",
               ])}
             >
@@ -231,7 +231,6 @@ export function GalleryItem({
             className={clsx([
               "rounded-lg px-3 py-1.5 text-sm font-medium transition-colors",
               "bg-blue-600 text-white hover:bg-blue-700",
-              isNarrow && "min-h-[44px] min-w-[44px]",
               isRedetectDisabled && "cursor-not-allowed opacity-50",
             ])}
           >

--- a/features/masking/components/GalleryItem.tsx
+++ b/features/masking/components/GalleryItem.tsx
@@ -229,8 +229,9 @@ export function GalleryItem({
             }}
             disabled={isRedetectDisabled}
             className={clsx([
-              "min-h-[44px] min-w-[44px] rounded-lg px-3 py-1.5 text-sm font-medium transition-colors",
+              "rounded-lg px-3 py-1.5 text-sm font-medium transition-colors",
               "bg-blue-600 text-white hover:bg-blue-700",
+              isNarrow && "min-h-[44px] min-w-[44px]",
               isRedetectDisabled && "cursor-not-allowed opacity-50",
             ])}
           >

--- a/features/masking/components/GalleryItem.tsx
+++ b/features/masking/components/GalleryItem.tsx
@@ -90,6 +90,8 @@ export function GalleryItem({
   const [imageNaturalHeight, setImageNaturalHeight] = useState(0);
   const [stampImages, setStampImages] = useState<Map<string, HTMLImageElement>>(new Map());
   const exportedBlobUrlRef = useRef<string | null>(null);
+  /** 親の `maskedBlobUrl` が更新されたあとにのみ古い Blob URL を revoke する（同期 revoke だと img がまだ旧 URL 参照中に切れる） */
+  const prevMaskedBlobUrlForRevokeRef = useRef<string | null>(null);
   const onRenderedRef = useRef(onRendered);
   /** SP 時の編集モードフラグ（PC では常に編集 UI を表示するため未使用） */
   const [isEditing, setIsEditing] = useState(false);
@@ -151,10 +153,8 @@ export function GalleryItem({
           URL.revokeObjectURL(blobUrl);
           return;
         }
-        const prev = exportedBlobUrlRef.current;
         exportedBlobUrlRef.current = blobUrl;
         onRenderedRef.current(image.id, blobUrl);
-        if (prev) URL.revokeObjectURL(prev);
       })
       .catch((err: unknown) => {
         if (!cancelled) {
@@ -174,6 +174,24 @@ export function GalleryItem({
     editor.paintStrokes,
     stampImages,
   ]);
+
+  /**
+   * マスク結果 Blob URL の解放
+   *
+   * `onRendered` 直後に旧 URL を revoke すると、親 state 反映前の img が壊れるため、
+   * `image.maskedBlobUrl` が更新されたタイミングで直前の blob のみ revoke する。
+   */
+  useEffect(() => {
+    const current = image.maskedBlobUrl;
+    const prev = prevMaskedBlobUrlForRevokeRef.current;
+    if (prev !== null && prev !== current && prev.startsWith("blob:")) {
+      URL.revokeObjectURL(prev);
+      if (exportedBlobUrlRef.current === prev) {
+        exportedBlobUrlRef.current = null;
+      }
+    }
+    prevMaskedBlobUrlForRevokeRef.current = current;
+  }, [image.maskedBlobUrl]);
 
   /** アンマウント時に Blob URL を解放する */
   useEffect(() => {
@@ -209,6 +227,8 @@ export function GalleryItem({
           {isNarrow && !image.isProcessing && !image.processingError && (
             <button
               type="button"
+              aria-pressed={isEditing}
+              aria-label={isEditing ? "編集を完了してプレビューを表示" : "画像を編集"}
               onClick={(e) => {
                 e.stopPropagation();
                 setIsEditing((prev) => !prev);

--- a/features/masking/components/GalleryItem.tsx
+++ b/features/masking/components/GalleryItem.tsx
@@ -7,6 +7,7 @@ import { useEditorState } from "@/features/editor/hooks/useEditorState";
 import { EditorToolbar } from "@/features/editor/components/EditorToolbar";
 import { exportEditorCanvas } from "@/features/editor/utils/exportCanvas";
 import { STAMP_CATALOG, STAMP_FILE_NAMES } from "@/features/editor/constants";
+import { useNarrowViewport } from "@/lib/useNarrowViewport";
 import { type MaskingImageItem, createDownloadFileName } from "../types";
 
 /** Konva は window を module ロード時に参照するため SSR を無効化して動的インポートする */
@@ -81,6 +82,7 @@ export function GalleryItem({
   onRendered,
 }: GalleryItemProps) {
   const isRedetectDisabled = image.isProcessing || isModelLoading;
+  const isNarrow = useNarrowViewport();
 
   const editor = useEditorState(STAMP_FILE_NAMES[0] ?? "");
   const selectedStampRegion = editor.stampRegions.find((region) => region.id === editor.selectedId);
@@ -90,6 +92,11 @@ export function GalleryItem({
   const [stampImages, setStampImages] = useState<Map<string, HTMLImageElement>>(new Map());
   const exportedBlobUrlRef = useRef<string | null>(null);
   const onRenderedRef = useRef(onRendered);
+  /** SP 時の編集モードフラグ（PC では常に編集 UI を表示するため未使用） */
+  const [isEditing, setIsEditing] = useState(false);
+
+  /** SP かつ非編集中のときはプレビュー img を表示し、Konva をマウントしない */
+  const showPreviewOnly = isNarrow && !isEditing;
 
   useEffect(() => {
     onRenderedRef.current = onRendered;
@@ -195,21 +202,41 @@ export function GalleryItem({
         >
           {image.name}
         </p>
-        <button
-          type="button"
-          onClick={(e) => {
-            e.stopPropagation();
-            void onRedetect(image.id);
-          }}
-          disabled={isRedetectDisabled}
-          className={clsx([
-            "relative z-10 rounded-lg px-3 py-1.5 text-sm font-medium transition-colors",
-            "bg-blue-600 text-white hover:bg-blue-700",
-            isRedetectDisabled && "cursor-not-allowed opacity-50",
-          ])}
-        >
-          再検出
-        </button>
+        <div className="relative z-10 flex items-center gap-2">
+          {/* SP のみ: 編集 / 完了 ボタン */}
+          {isNarrow && !image.isProcessing && !image.processingError && (
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                setIsEditing((prev) => !prev);
+              }}
+              className={clsx([
+                "min-h-[44px] min-w-[44px] rounded-lg px-3 py-1.5 text-sm font-medium transition-colors",
+                isEditing
+                  ? "bg-zinc-100 text-zinc-700 hover:bg-zinc-200"
+                  : "bg-emerald-600 text-white hover:bg-emerald-700",
+              ])}
+            >
+              {isEditing ? "完了" : "編集"}
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              void onRedetect(image.id);
+            }}
+            disabled={isRedetectDisabled}
+            className={clsx([
+              "min-h-[44px] min-w-[44px] rounded-lg px-3 py-1.5 text-sm font-medium transition-colors",
+              "bg-blue-600 text-white hover:bg-blue-700",
+              isRedetectDisabled && "cursor-not-allowed opacity-50",
+            ])}
+          >
+            再検出
+          </button>
+        </div>
       </div>
 
       <p className="mt-2 text-xs text-zinc-500">
@@ -235,7 +262,18 @@ export function GalleryItem({
           <div className="flex justify-center p-3">
             <p className="text-sm text-red-500">検出に失敗しました。再検出してください。</p>
           </div>
+        ) : showPreviewOnly ? (
+          /* SP・非編集中: マスク適用済みプレビュー img（Konva はマウントしない） */
+          <div className="flex justify-center p-2">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={image.maskedBlobUrl ?? image.imageUrl}
+              alt={image.name}
+              className="max-h-full max-w-full rounded-lg object-contain"
+            />
+          </div>
         ) : (
+          /* PC 常時 / SP 編集中: ツールバー + Konva Canvas */
           <>
             <div className="relative z-10 p-2">
               <EditorToolbar

--- a/features/masking/components/GalleryItem.tsx
+++ b/features/masking/components/GalleryItem.tsx
@@ -236,7 +236,7 @@ export function GalleryItem({
                 setIsEditing((prev) => !prev);
               }}
               className={clsx([
-                "min-h-[44px] rounded-lg px-3 py-1.5 text-sm font-medium transition-colors",
+                "rounded-lg px-3 py-1.5 text-sm font-medium transition-colors",
                 isEditing
                   ? "bg-zinc-600 text-white hover:bg-zinc-700"
                   : "bg-emerald-600 text-white hover:bg-emerald-700",

--- a/features/masking/components/GalleryItem.tsx
+++ b/features/masking/components/GalleryItem.tsx
@@ -7,7 +7,6 @@ import { useEditorState } from "@/features/editor/hooks/useEditorState";
 import { EditorToolbar } from "@/features/editor/components/EditorToolbar";
 import { exportEditorCanvas } from "@/features/editor/utils/exportCanvas";
 import { STAMP_CATALOG, STAMP_FILE_NAMES } from "@/features/editor/constants";
-import { useNarrowViewport } from "@/lib/useNarrowViewport";
 import { type MaskingImageItem, createDownloadFileName } from "../types";
 
 /** Konva は window を module ロード時に参照するため SSR を無効化して動的インポートする */
@@ -21,6 +20,8 @@ interface GalleryItemProps {
   isActive: boolean;
   /** face-api モデルのロード中フラグ（ロード中は再検出を無効化する） */
   isModelLoading: boolean;
+  /** Tailwind `md` 未満の狭いビューポートか（親で1回だけ matchMedia を購読する） */
+  isNarrow: boolean;
   onSelect: (id: string) => void;
   onRedetect: (id: string) => void | Promise<void>;
   onRendered: (id: string, blobUrl: string) => void;
@@ -77,12 +78,11 @@ export function GalleryItem({
   image,
   isActive,
   isModelLoading,
+  isNarrow,
   onSelect,
   onRedetect,
   onRendered,
 }: GalleryItemProps) {
-  const isNarrow = useNarrowViewport();
-
   const editor = useEditorState(STAMP_FILE_NAMES[0] ?? "");
   const selectedStampRegion = editor.stampRegions.find((region) => region.id === editor.selectedId);
   const [imageElement, setImageElement] = useState<HTMLImageElement | null>(null);

--- a/features/masking/components/GalleryItem.tsx
+++ b/features/masking/components/GalleryItem.tsx
@@ -214,7 +214,7 @@ export function GalleryItem({
                 setIsEditing((prev) => !prev);
               }}
               className={clsx([
-                "rounded-lg px-3 py-1.5 text-sm font-medium transition-colors",
+                "min-h-[44px] rounded-lg px-3 py-1.5 text-sm font-medium transition-colors",
                 isEditing
                   ? "bg-zinc-600 text-white hover:bg-zinc-700"
                   : "bg-emerald-600 text-white hover:bg-emerald-700",

--- a/features/masking/components/GalleryItem.tsx
+++ b/features/masking/components/GalleryItem.tsx
@@ -138,7 +138,8 @@ export function GalleryItem({
    * エディタ状態の変化に応じて自動エクスポートを行い onRendered に通知する
    */
   useEffect(() => {
-    if (!imageElement || image.isProcessing) return;
+    /** 親は `processingError` 時に `handleRendered` で `maskedBlobUrl` を更新しないため、Blob がリークしないようエクスポートしない */
+    if (!imageElement || image.isProcessing || image.processingError) return;
     let cancelled = false;
 
     void exportEditorCanvas(
@@ -169,6 +170,7 @@ export function GalleryItem({
     imageElement,
     image.id,
     image.isProcessing,
+    image.processingError,
     editor.stampRegions,
     editor.fillRegions,
     editor.paintStrokes,

--- a/features/masking/components/GalleryItem.tsx
+++ b/features/masking/components/GalleryItem.tsx
@@ -81,7 +81,6 @@ export function GalleryItem({
   onRedetect,
   onRendered,
 }: GalleryItemProps) {
-  const isRedetectDisabled = image.isProcessing || isModelLoading;
   const isNarrow = useNarrowViewport();
 
   const editor = useEditorState(STAMP_FILE_NAMES[0] ?? "");
@@ -97,6 +96,9 @@ export function GalleryItem({
 
   /** SP かつ非編集中のときはプレビュー img を表示し、Konva をマウントしない */
   const showPreviewOnly = isNarrow && !isEditing;
+  /** SP 編集中は再検出・ダウンロードを無効化する */
+  const isEditingOnSp = isNarrow && isEditing;
+  const isRedetectDisabled = image.isProcessing || isModelLoading || isEditingOnSp;
 
   useEffect(() => {
     onRenderedRef.current = onRendered;
@@ -335,7 +337,9 @@ export function GalleryItem({
         <p className="text-xs text-zinc-400">{(image.size / 1024 / 1024).toFixed(2)} MB</p>
 
         <div className="flex items-center gap-2">
-          {image.maskedBlobUrl && !image.isProcessing && !image.processingError ? (
+          {isEditingOnSp ? (
+            <span className="text-xs text-zinc-400">編集中…</span>
+          ) : image.maskedBlobUrl && !image.isProcessing && !image.processingError ? (
             <a
               href={image.maskedBlobUrl}
               download={createDownloadFileName(image.name)}

--- a/features/masking/components/MaskingGallery.tsx
+++ b/features/masking/components/MaskingGallery.tsx
@@ -9,6 +9,7 @@ import { ACCEPTED_IMAGE_TYPES, MAX_IMAGE_FILE_SIZE } from "@/components/ImageUpl
 import { useFaceDetection } from "@/features/face-detection";
 import { useOcr } from "@/features/ocr";
 import { useConfirmStore } from "@/lib/confirmStore";
+import { useNarrowViewport } from "@/lib/useNarrowViewport";
 import { type MaskingImageItem, createDownloadFileName } from "../types";
 import { GalleryItem } from "./GalleryItem";
 
@@ -33,6 +34,8 @@ const loadImageElement = (src: string): Promise<HTMLImageElement> => {
  * 画像アップロード、顔検出、Canvas表示を統合する。
  */
 export function MaskingGallery() {
+  /** ビューポート幅はギャラリー全体で共通のため、ここで1回だけ matchMedia を購読する */
+  const isNarrow = useNarrowViewport();
   const [images, setImages] = useState<MaskingImageItem[]>([]);
   const imagesRef = useRef(images);
   const isMountedRef = useRef(true);
@@ -457,6 +460,7 @@ export function MaskingGallery() {
                 image={image}
                 isActive={image.id === activeImageId}
                 isModelLoading={isModelLoading}
+                isNarrow={isNarrow}
                 onSelect={setActiveImageId}
                 onRedetect={handleRedetect}
                 onRendered={handleRendered}

--- a/lib/useNarrowViewport.ts
+++ b/lib/useNarrowViewport.ts
@@ -1,0 +1,29 @@
+import { useSyncExternalStore } from "react";
+
+/** SP 判定のブレークポイント（Tailwind の `md` と同じ 768px 未満） */
+const NARROW_BREAKPOINT = "(max-width: 767px)";
+
+function subscribeToNarrow(callback: () => void): () => void {
+  const mq = window.matchMedia(NARROW_BREAKPOINT);
+  mq.addEventListener("change", callback);
+  return () => mq.removeEventListener("change", callback);
+}
+
+function getSnapshot(): boolean {
+  return window.matchMedia(NARROW_BREAKPOINT).matches;
+}
+
+/** SSR 時はチラつき防止のため `false` を返す */
+function getServerSnapshot(): boolean {
+  return false;
+}
+
+/**
+ * ビューポート幅が Tailwind の `md`（768px）未満かどうかを返すフック
+ *
+ * SSR では `false` を返し、クライアントで確定した値に更新する。
+ * @returns 幅が 767px 以下のとき `true`
+ */
+export function useNarrowViewport(): boolean {
+  return useSyncExternalStore(subscribeToNarrow, getSnapshot, getServerSnapshot);
+}

--- a/lib/useNarrowViewport.ts
+++ b/lib/useNarrowViewport.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { useSyncExternalStore } from "react";
 
 /** SP 判定のブレークポイント（Tailwind の `md` と同じ 768px 未満） */
@@ -5,8 +7,13 @@ const NARROW_BREAKPOINT = "(max-width: 767px)";
 
 function subscribeToNarrow(callback: () => void): () => void {
   const mq = window.matchMedia(NARROW_BREAKPOINT);
-  mq.addEventListener("change", callback);
-  return () => mq.removeEventListener("change", callback);
+  if (typeof mq.addEventListener === "function") {
+    mq.addEventListener("change", callback);
+    return () => mq.removeEventListener("change", callback);
+  }
+  // 古い環境向けフォールバック（addListener は deprecated だが一部環境で必要）
+  mq.addListener(callback);
+  return () => mq.removeListener(callback);
 }
 
 function getSnapshot(): boolean {

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,1 +1,16 @@
 import "@testing-library/jest-dom/vitest";
+
+// jsdom は window.matchMedia を実装しないため、テスト環境用のスタブを設定する
+Object.defineProperty(window, "matchMedia", {
+  writable: true,
+  value: (query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  }),
+});

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,16 +1,18 @@
 import "@testing-library/jest-dom/vitest";
 
-// jsdom は window.matchMedia を実装しないため、テスト環境用のスタブを設定する
-Object.defineProperty(window, "matchMedia", {
-  writable: true,
-  value: (query: string) => ({
-    matches: false,
-    media: query,
-    onchange: null,
-    addListener: () => {},
-    removeListener: () => {},
-    addEventListener: () => {},
-    removeEventListener: () => {},
-    dispatchEvent: () => false,
-  }),
-});
+// jsdom が matchMedia を未実装のときのみスタブし、将来の jsdom 実装やテスト個別のモックを上書きしない
+if (typeof window.matchMedia !== "function") {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: (query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    }),
+  });
+}


### PR DESCRIPTION
## 概要

SP（768px 未満）のギャラリーで、Konva `Stage` が常時マウントされていることで縦スクロールが阻害されたり、スクロール操作でオブジェクトが意図せず動いてしまう問題を解消する。

SP 時のみ「プレビュー（`img`）」と「ツールバー＋ Konva Canvas（編集中）」を切り替える仕組みを追加した。PC では従来どおり常時ツールバー＋ Canvas を表示する。

## 関連Issue

Closes #50

## 変更内容

- [x] 機能追加
- [x] バグ修正
- [x] リファクタリング
- [x] テスト追加・修正
- [ ] ドキュメント修正
- [ ] 設定・環境変更
- [ ] その他

## 主な変更箇所

### UI・コンポーネント

- `features/masking/components/MaskingGallery.tsx`
  - `useNarrowViewport()` を1回だけ呼び、各 `GalleryItem` に `isNarrow` を prop で渡す
- `features/masking/components/GalleryItem.tsx`
  - 親から受け取った `isNarrow` で SP（`max-width: 767px` 相当）かどうかを判定
  - `isEditing` state を追加（SP 時のみ有効）
  - SP かつ非編集中（`showPreviewOnly`）の場合: `maskedBlobUrl`（なければ `imageUrl`）を `img` で表示し、Konva はマウントしない
  - SP かつ編集中 / PC の場合: 従来どおり `EditorToolbar` + `EditorCanvas` を表示
  - ヘッダー行に SP 専用の「編集」「完了」ボタンを追加（最小タップ領域 44×44px、`stopPropagation` 付き）
  - 編集トグルに `aria-pressed` / `aria-label` を付与（レビュー対応）

### ロジック・処理

- `lib/useNarrowViewport.ts`（新規）
  - `useSyncExternalStore` + `matchMedia` で「ビューポート幅 767px 以下か」を購読するフック
  - SSR 時は `false` を返し、クライアント確定後に実際の値へ更新
- `GalleryItem`：`image.maskedBlobUrl` 更新後にのみ直前のマスク用 Blob URL を `revoke`（SP プレビュー img のチラつき防止）。再検出で URL が無効化された場合は `exportedBlobUrlRef` を整合
- `GalleryItem`：`processingError` 時は自動エクスポートをスキップ（親が `maskedBlobUrl` を更新しないため Blob リーク防止）

### その他

- `vitest.setup.ts`：`window.matchMedia` が未定義のときのみスタブを設定（jsdom 将来実装やテスト個別モックを上書きしない）

## 動作確認

- [x] ローカル環境での動作確認
- [x] テストの実行・通過確認
- [x] UI動作確認
- [x] 既存機能への影響確認
- [ ] ブラウザ動作確認（Chrome / Firefox / Safari）

## スクリーンショット・動画

<!-- 動作確認後に追加予定 -->

## テスト

### 追加したテスト

- `features/masking/components/GalleryItem.test.tsx`：広い幅ではツールバー常時表示、狭い幅ではプレビュー img のみ→編集でツールバー＋モック Canvas が出ること、検出失敗時は `exportEditorCanvas` を呼ばないこと

### テスト結果

- [x] 全てのテストが通過
- [x] 新規テストを追加
- [ ] 既存テストの修正

## 破壊的変更

- [ ] 破壊的変更あり
- [x] 破壊的変更なし

## レビューポイント

- `useNarrowViewport` の `useSyncExternalStore` 実装（SSR との整合）
- SP 編集→完了 の切り替えタイミングで `maskedBlobUrl` が正しく反映されているか（`exportEditorCanvas` は Canvas マウント有無によらず state 変化で実行されるため、完了時には最新プレビューが出ているはず）
- ヘッダーのボタン群が狭い幅でも折り返さずに収まるかどうか（長いファイル名との競合）

## 補足

- **第2段**（モーダル化）は未実装。本 PR の効果を確認してから別 Issue で判断する。
- 編集 state（スタンプ・塗り・矩形）は SP / PC 問わず保持し続けるため、「完了→再編集」で内容がリセットされることはない。

## チェックリスト

- [x] コードレビューの準備ができている
- [x] 適切なラベルを付けている
- [x] セルフレビューを実施している
- [x] `pnpm lint` と `pnpm type-check` が通ることを確認した
- [ ] 必要に応じてドキュメントを更新している
