### PR TITLE
EditorCanvas の表示ズームと表示移動を追加

### DIFF
--- a/features/editor/components/EditorCanvas.tsx
+++ b/features/editor/components/EditorCanvas.tsx
@@ -290,6 +290,8 @@ export function EditorCanvas({
     viewCenter,
     contentCenter,
     canPan,
+    canZoomOut,
+    canZoomIn,
     nudgeViewCenter,
     resetViewCenter,
     zoomOut,
@@ -326,7 +328,7 @@ export function EditorCanvas({
       }
     });
     observer.observe(container);
-    const w0 = container.offsetWidth || 600;
+    const w0 = container.clientWidth || 600;
     setStageWidth(w0);
     return () => observer.disconnect();
   }, [imageNaturalHeight, imageNaturalWidth]);
@@ -797,6 +799,8 @@ export function EditorCanvas({
     <div ref={containerRef} className="w-full overflow-hidden rounded-xl border border-zinc-200">
       <EditorViewportControls
         canPan={canPan}
+        canZoomOut={canZoomOut}
+        canZoomIn={canZoomIn}
         viewZoom={viewZoom}
         onNudgeViewCenter={nudgeViewCenter}
         onResetViewCenter={resetViewCenter}

--- a/features/editor/components/EditorCanvas.tsx
+++ b/features/editor/components/EditorCanvas.tsx
@@ -411,6 +411,11 @@ export function EditorCanvas({
    */
   function handlePointerMove(e: KonvaEventObject<MouseEvent> | KonvaEventObject<TouchEvent>) {
     if (!isDrawing.current) return;
+    // canvas / .konvajs-content は touch-action が継承されないため SP でページスクロールと競合する。
+    // Konva が passive:false で登録している touchmove でも念のため抑止する。
+    if ((mode === "rect" || mode === "paint") && "touches" in e.evt && e.evt.cancelable) {
+      e.evt.preventDefault();
+    }
     const stage = e.target.getStage();
     if (!stage) return;
     const pos = pointerToContentSpace(stage);
@@ -810,30 +815,37 @@ export function EditorCanvas({
         onResetViewport={resetViewport}
         onZoomIn={zoomIn}
       />
-      <Stage
-        width={stageWidth}
-        height={stageHeight}
-        onMouseDown={handlePointerDown}
-        onMouseMove={handlePointerMove}
-        onMouseUp={handlePointerUp}
-        onTouchStart={handlePointerDown}
-        onTouchMove={handlePointerMove}
-        onTouchEnd={handlePointerUp}
-        style={{ cursor: MODE_CURSORS[mode] }}
-      >
-        <Layer>
-          <Group
-            x={stageWidth / 2}
-            y={stageHeight / 2}
-            offsetX={contentCenter.x}
-            offsetY={contentCenter.y}
-            scaleX={viewZoom}
-            scaleY={viewZoom}
-          >
-            {layerContent}
-          </Group>
-        </Layer>
-      </Stage>
+      {/*
+       * Stage 直下の DOM のみ style が当たり、Konva が差し込む .konvajs-content / canvas には伝わらない。
+       * そのため descendant に touch-none を適用して SP でのドラッグとスクロールの競合を防ぐ。
+       */}
+      <div className="[&_.konvajs-content]:touch-none [&_canvas]:touch-none">
+        <Stage
+          width={stageWidth}
+          height={stageHeight}
+          onMouseDown={handlePointerDown}
+          onMouseMove={handlePointerMove}
+          onMouseUp={handlePointerUp}
+          onTouchStart={handlePointerDown}
+          onTouchMove={handlePointerMove}
+          onTouchEnd={handlePointerUp}
+          // StageWrap のコンテナ側でも指定（親 div と canvas 側のクラス指定と併用）
+          style={{ cursor: MODE_CURSORS[mode], touchAction: "none" }}
+        >
+          <Layer>
+            <Group
+              x={stageWidth / 2}
+              y={stageHeight / 2}
+              offsetX={contentCenter.x}
+              offsetY={contentCenter.y}
+              scaleX={viewZoom}
+              scaleY={viewZoom}
+            >
+              {layerContent}
+            </Group>
+          </Layer>
+        </Stage>
+      </div>
     </div>
   );
 }

--- a/features/editor/components/EditorCanvas.tsx
+++ b/features/editor/components/EditorCanvas.tsx
@@ -616,7 +616,9 @@ export function EditorCanvas({
   const layerContent = (
     <>
       {/* 背景画像 */}
-      {bgImage && <KonvaImage image={bgImage} width={stageWidth} height={stageHeight} />}
+      {bgImage && (
+        <KonvaImage image={bgImage} width={stageWidth} height={stageHeight} listening={false} />
+      )}
 
       {/* 塗りつぶし領域 */}
       {fillRegions.map((region) => (

--- a/features/editor/components/EditorCanvas.tsx
+++ b/features/editor/components/EditorCanvas.tsx
@@ -23,10 +23,10 @@ import type {
   StampType,
 } from "../types";
 import {
-  DEFAULT_VIEW_PAN,
-  VIEW_PAN_NUDGE_PX,
+  VIEW_CENTER_NUDGE_PX,
   VIEW_ZOOM,
-  clampViewPan,
+  clampViewCenter,
+  getDefaultViewCenter,
   roundViewZoomStep,
   stagePointerToContentSpace,
 } from "../lib/viewZoom";
@@ -286,20 +286,23 @@ export function EditorCanvas({
   const [drawingStroke, setDrawingStroke] = useState<DrawingStroke | null>(null);
   /** 表示のみの倍率（1 = 等倍）。論理領域・エクスポートは画像自然サイズ基準のまま */
   const [viewZoom, setViewZoom] = useState<number>(VIEW_ZOOM.default);
-  /** 表示のみのパン（ステージ px）。論理マスク座標は変えない */
-  const [viewPan, setViewPan] = useState(DEFAULT_VIEW_PAN);
+  /** 表示中心（画像自然サイズ座標）。この点がステージ中央に来るよう表示する。 */
+  const [viewCenter, setViewCenter] = useState(() =>
+    getDefaultViewCenter(imageNaturalWidth, imageNaturalHeight)
+  );
   const isDrawing = useRef(false);
   const drawStart = useRef<{ x: number; y: number } | null>(null);
-  const viewZoomRef = useRef(viewZoom);
-
-  useEffect(() => {
-    viewZoomRef.current = viewZoom;
-  }, [viewZoom]);
+  const defaultViewCenter = getDefaultViewCenter(imageNaturalWidth, imageNaturalHeight);
 
   const stageHeight =
     imageNaturalWidth > 0 ? stageWidth * (imageNaturalHeight / imageNaturalWidth) : 400;
   const scaleX = imageNaturalWidth > 0 ? stageWidth / imageNaturalWidth : 1;
   const scaleY = imageNaturalHeight > 0 ? stageHeight / imageNaturalHeight : 1;
+  const contentCenter = {
+    x: viewCenter.x * scaleX,
+    y: viewCenter.y * scaleY,
+  };
+  const canPan = viewZoom > 1;
 
   /**
    * キーボードショートカット
@@ -326,10 +329,7 @@ export function EditorCanvas({
     const observer = new ResizeObserver((entries) => {
       const entry = entries[0];
       if (entry) {
-        const w = entry.contentRect.width || 600;
-        setStageWidth(w);
-        const h = imageNaturalWidth > 0 ? w * (imageNaturalHeight / imageNaturalWidth) : 400;
-        setViewPan((p) => clampViewPan(p, w, h, viewZoomRef.current));
+        setStageWidth(entry.contentRect.width || 600);
       }
     });
     observer.observe(container);
@@ -347,30 +347,42 @@ export function EditorCanvas({
   }, [imageUrl]);
 
   /**
-   * 選択変化・領域サイズ変化時に Transformer を再アタッチする
+   * 選択変化・領域サイズ変化・表示中心／表示倍率変化時に Transformer を再アタッチする
    *
-   * stampRegions / fillRegions / paintStrokes を依存に含めることで、
-   * リサイズ後に React state が更新された際に Transformer が
-   * キャッシュ済みのバウンディングボックスを再計算する。
+   * 親 Group の offset/scale が変わると、同じ selectedId でも
+   * Transformer の対象ノードを付け直した方がハンドル表示が安定する。
    */
   useEffect(() => {
     const transformer = transformerRef.current;
     if (!transformer) return;
-    if (selectedId) {
-      const stage = transformer.getStage();
-      const node = stage?.findOne(
+
+    if (!selectedId) {
+      transformer.nodes([]);
+      transformer.getLayer()?.batchDraw();
+      return;
+    }
+
+    const stage = transformer.getStage();
+    const node =
+      stage?.findOne(
         (n: Konva.Node) =>
           n.id() === selectedId && n.getType() !== "Stage" && n.getType() !== "Layer"
-      );
-      if (node) {
-        transformer.nodes([node]);
-      } else {
-        transformer.nodes([]);
-      }
-    } else {
-      transformer.nodes([]);
-    }
-  }, [selectedId, stampRegions, fillRegions, paintStrokes]);
+      ) ?? null;
+
+    transformer.nodes(node ? [node] : []);
+    transformer.getLayer()?.batchDraw();
+  }, [
+    selectedId,
+    stampRegions,
+    fillRegions,
+    paintStrokes,
+    viewZoom,
+    viewCenter.x,
+    viewCenter.y,
+    stageWidth,
+    stageHeight,
+    mode,
+  ]);
 
   /**
    * ステージのマウスダウン/タッチスタートハンドラ
@@ -603,7 +615,38 @@ export function EditorCanvas({
   function pointerToContentSpace(stage: Konva.Stage): { x: number; y: number } | null {
     const stagePos = getStagePos(stage);
     if (!stagePos) return null;
-    return stagePointerToContentSpace(stagePos, stageWidth, stageHeight, viewZoom, viewPan);
+    return stagePointerToContentSpace(stagePos, stageWidth, stageHeight, viewZoom, contentCenter);
+  }
+
+  /**
+   * 表示中心を現在のズーム倍率に対して有効範囲へ収める
+   *
+   * @param center - 次の表示中心
+   * @param zoom - 次の表示倍率
+   * @returns クランプ後の表示中心
+   */
+  function clampCurrentViewCenter(center: { x: number; y: number }, zoom = viewZoom) {
+    return clampViewCenter(center, imageNaturalWidth, imageNaturalHeight, zoom);
+  }
+
+  /**
+   * ボタン操作で表示中心を移動する
+   *
+   * ボタンの移動量は見た目上の一貫性を保つためステージ px で定義し、
+   * 現在のフィット倍率と表示ズーム倍率から画像座標へ逆変換して加算する。
+   *
+   * @param dxImageDir - X 方向の移動係数（左:-1 / 右:+1）
+   * @param dyImageDir - Y 方向の移動係数（上:-1 / 下:+1）
+   */
+  function nudgeViewCenter(dxImageDir: -1 | 0 | 1, dyImageDir: -1 | 0 | 1) {
+    const deltaX = scaleX > 0 ? VIEW_CENTER_NUDGE_PX / (scaleX * viewZoom) : 0;
+    const deltaY = scaleY > 0 ? VIEW_CENTER_NUDGE_PX / (scaleY * viewZoom) : 0;
+    setViewCenter((center) =>
+      clampCurrentViewCenter({
+        x: center.x + deltaX * dxImageDir,
+        y: center.y + deltaY * dyImageDir,
+      })
+    );
   }
 
   const layerContent = (
@@ -793,23 +836,14 @@ export function EditorCanvas({
       <div className="flex flex-col gap-1 border-b border-zinc-200 bg-zinc-50 px-2 py-1.5">
         <span className="text-xs text-zinc-600">表示ズーム</span>
         <div className="flex w-full flex-wrap items-center gap-2">
-          {viewZoom !== 1 && (
+          {canPan && (
             <div className="flex flex-wrap items-center gap-1 border-r border-zinc-300 pr-1.5">
               <span className="text-xs text-zinc-600">移動</span>
               <button
                 type="button"
                 className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded border border-zinc-300 bg-white text-zinc-800 hover:bg-zinc-100"
                 aria-label="表示を左へ移動"
-                onClick={() =>
-                  setViewPan((p) =>
-                    clampViewPan(
-                      { x: p.x + VIEW_PAN_NUDGE_PX, y: p.y },
-                      stageWidth,
-                      stageHeight,
-                      viewZoom
-                    )
-                  )
-                }
+                onClick={() => nudgeViewCenter(-1, 0)}
               >
                 <ChevronLeft className="h-4 w-4" aria-hidden />
               </button>
@@ -817,16 +851,7 @@ export function EditorCanvas({
                 type="button"
                 className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded border border-zinc-300 bg-white text-zinc-800 hover:bg-zinc-100"
                 aria-label="表示を上へ移動"
-                onClick={() =>
-                  setViewPan((p) =>
-                    clampViewPan(
-                      { x: p.x, y: p.y + VIEW_PAN_NUDGE_PX },
-                      stageWidth,
-                      stageHeight,
-                      viewZoom
-                    )
-                  )
-                }
+                onClick={() => nudgeViewCenter(0, -1)}
               >
                 <ChevronUp className="h-4 w-4" aria-hidden />
               </button>
@@ -834,16 +859,7 @@ export function EditorCanvas({
                 type="button"
                 className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded border border-zinc-300 bg-white text-zinc-800 hover:bg-zinc-100"
                 aria-label="表示を下へ移動"
-                onClick={() =>
-                  setViewPan((p) =>
-                    clampViewPan(
-                      { x: p.x, y: p.y - VIEW_PAN_NUDGE_PX },
-                      stageWidth,
-                      stageHeight,
-                      viewZoom
-                    )
-                  )
-                }
+                onClick={() => nudgeViewCenter(0, 1)}
               >
                 <ChevronDown className="h-4 w-4" aria-hidden />
               </button>
@@ -851,16 +867,7 @@ export function EditorCanvas({
                 type="button"
                 className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded border border-zinc-300 bg-white text-zinc-800 hover:bg-zinc-100"
                 aria-label="表示を右へ移動"
-                onClick={() =>
-                  setViewPan((p) =>
-                    clampViewPan(
-                      { x: p.x - VIEW_PAN_NUDGE_PX, y: p.y },
-                      stageWidth,
-                      stageHeight,
-                      viewZoom
-                    )
-                  )
-                }
+                onClick={() => nudgeViewCenter(1, 0)}
               >
                 <ChevronRight className="h-4 w-4" aria-hidden />
               </button>
@@ -868,7 +875,7 @@ export function EditorCanvas({
                 type="button"
                 className="rounded border border-zinc-300 bg-white px-2 py-0.5 text-xs text-zinc-800 hover:bg-zinc-100"
                 aria-label="表示位置を中央に戻す"
-                onClick={() => setViewPan(DEFAULT_VIEW_PAN)}
+                onClick={() => setViewCenter(defaultViewCenter)}
               >
                 中央
               </button>
@@ -885,7 +892,7 @@ export function EditorCanvas({
               onClick={() => {
                 const nz = roundViewZoomStep(viewZoom - VIEW_ZOOM.step);
                 setViewZoom(nz);
-                setViewPan((p) => clampViewPan(p, stageWidth, stageHeight, nz));
+                setViewCenter((center) => clampCurrentViewCenter(center, nz));
               }}
             >
               <Minus className="h-4 w-4" aria-hidden />
@@ -896,7 +903,7 @@ export function EditorCanvas({
               aria-label="表示ズームを等倍に戻す"
               onClick={() => {
                 setViewZoom(VIEW_ZOOM.default);
-                setViewPan(DEFAULT_VIEW_PAN);
+                setViewCenter(defaultViewCenter);
               }}
             >
               等倍
@@ -908,7 +915,7 @@ export function EditorCanvas({
               onClick={() => {
                 const nz = roundViewZoomStep(viewZoom + VIEW_ZOOM.step);
                 setViewZoom(nz);
-                setViewPan((p) => clampViewPan(p, stageWidth, stageHeight, nz));
+                setViewCenter((center) => clampCurrentViewCenter(center, nz));
               }}
             >
               <Plus className="h-4 w-4" aria-hidden />
@@ -928,21 +935,15 @@ export function EditorCanvas({
         style={{ cursor: MODE_CURSORS[mode] }}
       >
         <Layer>
-          <Group x={viewPan.x} y={viewPan.y}>
-            {viewZoom !== 1 ? (
-              <Group
-                x={stageWidth / 2}
-                y={stageHeight / 2}
-                offsetX={stageWidth / 2}
-                offsetY={stageHeight / 2}
-                scaleX={viewZoom}
-                scaleY={viewZoom}
-              >
-                {layerContent}
-              </Group>
-            ) : (
-              layerContent
-            )}
+          <Group
+            x={stageWidth / 2}
+            y={stageHeight / 2}
+            offsetX={contentCenter.x}
+            offsetY={contentCenter.y}
+            scaleX={viewZoom}
+            scaleY={viewZoom}
+          >
+            {layerContent}
           </Group>
         </Layer>
       </Stage>

--- a/features/editor/components/EditorCanvas.tsx
+++ b/features/editor/components/EditorCanvas.tsx
@@ -13,6 +13,7 @@ import {
   Stage,
   Transformer,
 } from "react-konva";
+import { Minus, Plus } from "lucide-react";
 import type {
   EditorMode,
   FillRegion,
@@ -21,6 +22,7 @@ import type {
   StampRegion,
   StampType,
 } from "../types";
+import { VIEW_ZOOM, roundViewZoomStep, stagePointerToContentSpace } from "../lib/viewZoom";
 
 interface EditorCanvasProps {
   imageUrl: string;
@@ -275,6 +277,8 @@ export function EditorCanvas({
   const [bgImage, setBgImage] = useState<HTMLImageElement | null>(null);
   const [drawingRect, setDrawingRect] = useState<DrawingRect | null>(null);
   const [drawingStroke, setDrawingStroke] = useState<DrawingStroke | null>(null);
+  /** 表示のみの倍率（1 = 等倍）。論理領域・エクスポートは画像自然サイズ基準のまま */
+  const [viewZoom, setViewZoom] = useState<number>(VIEW_ZOOM.default);
   const isDrawing = useRef(false);
   const drawStart = useRef<{ x: number; y: number } | null>(null);
 
@@ -356,7 +360,7 @@ export function EditorCanvas({
   function handlePointerDown(e: KonvaEventObject<MouseEvent> | KonvaEventObject<TouchEvent>) {
     const stage = e.target.getStage();
     if (!stage) return;
-    const pos = getStagePos(stage);
+    const pos = pointerToContentSpace(stage);
     if (!pos) return;
 
     if (mode === "select") {
@@ -384,7 +388,7 @@ export function EditorCanvas({
     if (!isDrawing.current) return;
     const stage = e.target.getStage();
     if (!stage) return;
-    const pos = getStagePos(stage);
+    const pos = pointerToContentSpace(stage);
     if (!pos || !drawStart.current) return;
 
     if (mode === "rect") {
@@ -572,8 +576,232 @@ export function EditorCanvas({
 
   const isInteractive = mode === "select";
 
+  /**
+   * ステージ上のポインタを、ズーム補正後のコンテンツ座標（領域描画と同じ系）に変換する
+   *
+   * @param stage - Konva ステージ
+   * @returns コンテンツ座標、取得できない場合は null
+   */
+  function pointerToContentSpace(stage: Konva.Stage): { x: number; y: number } | null {
+    const stagePos = getStagePos(stage);
+    if (!stagePos) return null;
+    return stagePointerToContentSpace(stagePos, stageWidth, stageHeight, viewZoom);
+  }
+
+  const layerContent = (
+    <>
+      {/* 背景画像 */}
+      {bgImage && <KonvaImage image={bgImage} width={stageWidth} height={stageHeight} />}
+
+      {/* 塗りつぶし領域 */}
+      {fillRegions.map((region) => (
+        <Group
+          key={region.id}
+          id={region.id}
+          x={region.x * scaleX}
+          y={region.y * scaleY}
+          draggable={isInteractive}
+          onClick={() => isInteractive && onSelectItem(region.id)}
+          onTap={() => isInteractive && onSelectItem(region.id)}
+          onDragEnd={(e) => handleDragEnd(region.id, "fill", e.target)}
+          onTransformEnd={(e) => handleTransformEnd(region.id, "fill", e.target)}
+        >
+          <Rect
+            width={region.width * scaleX}
+            height={region.height * scaleY}
+            fill={region.isEnabled ? "#000000" : undefined}
+            stroke={region.isEnabled ? "#3b82f6" : "#9ca3af"}
+            strokeWidth={1}
+            dash={region.isEnabled ? undefined : [6, 3]}
+            opacity={region.isEnabled ? 1 : 0.6}
+          />
+        </Group>
+      ))}
+
+      {/* スタンプ領域 */}
+      {stampRegions.map((region) => {
+        const rx = region.x * scaleX;
+        const ry = region.y * scaleY;
+        const w = region.width * scaleX;
+        const h = region.height * scaleY;
+        const squareStampSize = Math.max(w, h);
+        const squareStampX = (w - squareStampSize) / 2;
+        const squareStampY = (h - squareStampSize) / 2;
+        const stampImg =
+          region.stampType === "stamp-face" ? pickStampImage(region, stampImages) : null;
+        const isEffectStamp =
+          (region.stampType === "blur" || region.stampType === "mosaic") && bgImage !== null;
+        return (
+          <Fragment key={region.id}>
+            {isEffectStamp && (
+              /* blur / mosaic の見た目は操作ノードと分離し、Transformer の計算へ影響させない */
+              <Group x={rx} y={ry} listening={false}>
+                <EffectPreviewGroup
+                  kind={region.stampType as "blur" | "mosaic"}
+                  bgImage={bgImage}
+                  offsetX={-rx}
+                  offsetY={-ry}
+                  stageWidth={stageWidth}
+                  stageHeight={stageHeight}
+                  w={w}
+                  h={h}
+                />
+              </Group>
+            )}
+
+            <Group
+              id={region.id}
+              x={rx}
+              y={ry}
+              draggable={isInteractive}
+              onClick={() => isInteractive && onSelectItem(region.id)}
+              onTap={() => isInteractive && onSelectItem(region.id)}
+              onDragEnd={(e) => handleDragEnd(region.id, "stamp", e.target)}
+              onTransformEnd={(e) => handleTransformEnd(region.id, "stamp", e.target)}
+            >
+              {stampImg ? (
+                /* stamp-face: 顔領域中心を基準に正方形スタンプを表示（旧仕様互換） */
+                <KonvaImage
+                  image={stampImg}
+                  x={squareStampX}
+                  y={squareStampY}
+                  width={squareStampSize}
+                  height={squareStampSize}
+                  opacity={region.isEnabled ? 1 : 0.4}
+                  stroke={selectedId === region.id ? "#1d4ed8" : "#6b7280"}
+                  strokeWidth={1}
+                />
+              ) : isEffectStamp ? (
+                /* blur / mosaic: クリック/変形用の矩形ハンドル */
+                <Rect
+                  width={w}
+                  height={h}
+                  fill="rgba(0,0,0,0.001)"
+                  stroke={selectedId === region.id ? "#1d4ed8" : "#6b7280"}
+                  strokeWidth={1}
+                  listening={true}
+                />
+              ) : (
+                /* fill-black またはフォールバック: 不透明な塗りつぶし矩形 */
+                <Rect
+                  width={w}
+                  height={h}
+                  fill={STAMP_TYPE_COLORS[region.stampType]}
+                  opacity={1}
+                  stroke={selectedId === region.id ? "#1d4ed8" : "#6b7280"}
+                  strokeWidth={1}
+                />
+              )}
+            </Group>
+          </Fragment>
+        );
+      })}
+
+      {/* ペイントストローク */}
+      {paintStrokes.map((stroke) => (
+        <Line
+          key={stroke.id}
+          id={stroke.id}
+          points={stroke.points.flatMap((p) => [p.x * scaleX, p.y * scaleY])}
+          stroke="#000000"
+          strokeWidth={stroke.brushSize * scaleX}
+          lineCap="round"
+          lineJoin="round"
+          opacity={stroke.isEnabled ? 1 : 0.3}
+          hitStrokeWidth={Math.max(stroke.brushSize * scaleX, 12)}
+          draggable={isInteractive}
+          onClick={() => isInteractive && onSelectItem(stroke.id)}
+          onTap={() => isInteractive && onSelectItem(stroke.id)}
+          onDragEnd={(e) => handlePaintStrokeDragEnd(stroke.id, e.target as Konva.Line)}
+          onTransformEnd={(e) =>
+            handlePaintStrokeTransformEnd(stroke.id, stroke, e.target as Konva.Line)
+          }
+        />
+      ))}
+
+      {/* 描画中の矩形プレビュー */}
+      {drawingRect && mode === "rect" && (
+        <Rect
+          x={drawingRect.x}
+          y={drawingRect.y}
+          width={drawingRect.width}
+          height={drawingRect.height}
+          fill={rectTarget === "fill" ? "rgba(0,0,0,0.3)" : "rgba(251,146,60,0.3)"}
+          stroke={rectTarget === "fill" ? "#3b82f6" : "#f97316"}
+          strokeWidth={1}
+          dash={[6, 3]}
+        />
+      )}
+
+      {/* 描画中のペイントプレビュー */}
+      {drawingStroke && mode === "paint" && drawingStroke.points.length >= 2 && (
+        <Line
+          points={drawingStroke.points.flatMap((p) => [p.x * scaleX, p.y * scaleY])}
+          stroke="#000000"
+          strokeWidth={brushSize * scaleX}
+          lineCap="round"
+          lineJoin="round"
+          opacity={0.6}
+        />
+      )}
+
+      {/* ペイント中のカーソルインジケーター */}
+      {drawingStroke && mode === "paint" && drawingStroke.points.length >= 1 && (
+        <Circle
+          x={(drawingStroke.points[drawingStroke.points.length - 1]?.x ?? 0) * scaleX}
+          y={(drawingStroke.points[drawingStroke.points.length - 1]?.y ?? 0) * scaleY}
+          radius={(brushSize * scaleX) / 2}
+          fill="rgba(0,0,0,0.2)"
+          listening={false}
+        />
+      )}
+
+      {/* Transformer（選択モードのみ） */}
+      {mode === "select" && (
+        <Transformer
+          ref={transformerRef}
+          boundBoxFunc={(oldBox, newBox) => {
+            if (newBox.width < MIN_TRANSFORM_SIZE || newBox.height < MIN_TRANSFORM_SIZE)
+              return oldBox;
+            return newBox;
+          }}
+        />
+      )}
+    </>
+  );
+
   return (
     <div ref={containerRef} className="w-full overflow-hidden rounded-xl border border-zinc-200">
+      <div className="flex flex-wrap items-center justify-end gap-1.5 border-b border-zinc-200 bg-zinc-50 px-2 py-1">
+        <span className="mr-auto text-xs text-zinc-600">表示ズーム</span>
+        <span className="min-w-[3rem] text-center text-xs tabular-nums text-zinc-700">
+          {Math.round(viewZoom * 100)}%
+        </span>
+        <button
+          type="button"
+          className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded border border-zinc-300 bg-white text-zinc-800 hover:bg-zinc-100"
+          aria-label="ズームアウト"
+          onClick={() => setViewZoom((z) => roundViewZoomStep(z - VIEW_ZOOM.step))}
+        >
+          <Minus className="h-4 w-4" aria-hidden />
+        </button>
+        <button
+          type="button"
+          className="rounded border border-zinc-300 bg-white px-2 py-0.5 text-xs text-zinc-800 hover:bg-zinc-100"
+          aria-label="表示ズームを等倍に戻す"
+          onClick={() => setViewZoom(VIEW_ZOOM.default)}
+        >
+          等倍
+        </button>
+        <button
+          type="button"
+          className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded border border-zinc-300 bg-white text-zinc-800 hover:bg-zinc-100"
+          aria-label="ズームイン"
+          onClick={() => setViewZoom((z) => roundViewZoomStep(z + VIEW_ZOOM.step))}
+        >
+          <Plus className="h-4 w-4" aria-hidden />
+        </button>
+      </div>
       <Stage
         width={stageWidth}
         height={stageHeight}
@@ -586,182 +814,19 @@ export function EditorCanvas({
         style={{ cursor: MODE_CURSORS[mode] }}
       >
         <Layer>
-          {/* 背景画像 */}
-          {bgImage && <KonvaImage image={bgImage} width={stageWidth} height={stageHeight} />}
-
-          {/* 塗りつぶし領域 */}
-          {fillRegions.map((region) => (
+          {viewZoom !== 1 ? (
             <Group
-              key={region.id}
-              id={region.id}
-              x={region.x * scaleX}
-              y={region.y * scaleY}
-              draggable={isInteractive}
-              onClick={() => isInteractive && onSelectItem(region.id)}
-              onTap={() => isInteractive && onSelectItem(region.id)}
-              onDragEnd={(e) => handleDragEnd(region.id, "fill", e.target)}
-              onTransformEnd={(e) => handleTransformEnd(region.id, "fill", e.target)}
+              x={stageWidth / 2}
+              y={stageHeight / 2}
+              offsetX={stageWidth / 2}
+              offsetY={stageHeight / 2}
+              scaleX={viewZoom}
+              scaleY={viewZoom}
             >
-              <Rect
-                width={region.width * scaleX}
-                height={region.height * scaleY}
-                fill={region.isEnabled ? "#000000" : undefined}
-                stroke={region.isEnabled ? "#3b82f6" : "#9ca3af"}
-                strokeWidth={1}
-                dash={region.isEnabled ? undefined : [6, 3]}
-                opacity={region.isEnabled ? 1 : 0.6}
-              />
+              {layerContent}
             </Group>
-          ))}
-
-          {/* スタンプ領域 */}
-          {stampRegions.map((region) => {
-            const rx = region.x * scaleX;
-            const ry = region.y * scaleY;
-            const w = region.width * scaleX;
-            const h = region.height * scaleY;
-            const squareStampSize = Math.max(w, h);
-            const squareStampX = (w - squareStampSize) / 2;
-            const squareStampY = (h - squareStampSize) / 2;
-            const stampImg =
-              region.stampType === "stamp-face" ? pickStampImage(region, stampImages) : null;
-            const isEffectStamp =
-              (region.stampType === "blur" || region.stampType === "mosaic") && bgImage !== null;
-            return (
-              <Fragment key={region.id}>
-                {isEffectStamp && (
-                  /* blur / mosaic の見た目は操作ノードと分離し、Transformer の計算へ影響させない */
-                  <Group x={rx} y={ry} listening={false}>
-                    <EffectPreviewGroup
-                      kind={region.stampType as "blur" | "mosaic"}
-                      bgImage={bgImage}
-                      offsetX={-rx}
-                      offsetY={-ry}
-                      stageWidth={stageWidth}
-                      stageHeight={stageHeight}
-                      w={w}
-                      h={h}
-                    />
-                  </Group>
-                )}
-
-                <Group
-                  id={region.id}
-                  x={rx}
-                  y={ry}
-                  draggable={isInteractive}
-                  onClick={() => isInteractive && onSelectItem(region.id)}
-                  onTap={() => isInteractive && onSelectItem(region.id)}
-                  onDragEnd={(e) => handleDragEnd(region.id, "stamp", e.target)}
-                  onTransformEnd={(e) => handleTransformEnd(region.id, "stamp", e.target)}
-                >
-                  {stampImg ? (
-                    /* stamp-face: 顔領域中心を基準に正方形スタンプを表示（旧仕様互換） */
-                    <KonvaImage
-                      image={stampImg}
-                      x={squareStampX}
-                      y={squareStampY}
-                      width={squareStampSize}
-                      height={squareStampSize}
-                      opacity={region.isEnabled ? 1 : 0.4}
-                      stroke={selectedId === region.id ? "#1d4ed8" : "#6b7280"}
-                      strokeWidth={1}
-                    />
-                  ) : isEffectStamp ? (
-                    /* blur / mosaic: クリック/変形用の矩形ハンドル */
-                    <Rect
-                      width={w}
-                      height={h}
-                      fill="rgba(0,0,0,0.001)"
-                      stroke={selectedId === region.id ? "#1d4ed8" : "#6b7280"}
-                      strokeWidth={1}
-                      listening={true}
-                    />
-                  ) : (
-                    /* fill-black またはフォールバック: 不透明な塗りつぶし矩形 */
-                    <Rect
-                      width={w}
-                      height={h}
-                      fill={STAMP_TYPE_COLORS[region.stampType]}
-                      opacity={1}
-                      stroke={selectedId === region.id ? "#1d4ed8" : "#6b7280"}
-                      strokeWidth={1}
-                    />
-                  )}
-                </Group>
-              </Fragment>
-            );
-          })}
-
-          {/* ペイントストローク */}
-          {paintStrokes.map((stroke) => (
-            <Line
-              key={stroke.id}
-              id={stroke.id}
-              points={stroke.points.flatMap((p) => [p.x * scaleX, p.y * scaleY])}
-              stroke="#000000"
-              strokeWidth={stroke.brushSize * scaleX}
-              lineCap="round"
-              lineJoin="round"
-              opacity={stroke.isEnabled ? 1 : 0.3}
-              hitStrokeWidth={Math.max(stroke.brushSize * scaleX, 12)}
-              draggable={isInteractive}
-              onClick={() => isInteractive && onSelectItem(stroke.id)}
-              onTap={() => isInteractive && onSelectItem(stroke.id)}
-              onDragEnd={(e) => handlePaintStrokeDragEnd(stroke.id, e.target as Konva.Line)}
-              onTransformEnd={(e) =>
-                handlePaintStrokeTransformEnd(stroke.id, stroke, e.target as Konva.Line)
-              }
-            />
-          ))}
-
-          {/* 描画中の矩形プレビュー */}
-          {drawingRect && mode === "rect" && (
-            <Rect
-              x={drawingRect.x}
-              y={drawingRect.y}
-              width={drawingRect.width}
-              height={drawingRect.height}
-              fill={rectTarget === "fill" ? "rgba(0,0,0,0.3)" : "rgba(251,146,60,0.3)"}
-              stroke={rectTarget === "fill" ? "#3b82f6" : "#f97316"}
-              strokeWidth={1}
-              dash={[6, 3]}
-            />
-          )}
-
-          {/* 描画中のペイントプレビュー */}
-          {drawingStroke && mode === "paint" && drawingStroke.points.length >= 2 && (
-            <Line
-              points={drawingStroke.points.flatMap((p) => [p.x * scaleX, p.y * scaleY])}
-              stroke="#000000"
-              strokeWidth={brushSize * scaleX}
-              lineCap="round"
-              lineJoin="round"
-              opacity={0.6}
-            />
-          )}
-
-          {/* ペイント中のカーソルインジケーター */}
-          {drawingStroke && mode === "paint" && drawingStroke.points.length >= 1 && (
-            <Circle
-              x={(drawingStroke.points[drawingStroke.points.length - 1]?.x ?? 0) * scaleX}
-              y={(drawingStroke.points[drawingStroke.points.length - 1]?.y ?? 0) * scaleY}
-              radius={(brushSize * scaleX) / 2}
-              fill="rgba(0,0,0,0.2)"
-              listening={false}
-            />
-          )}
-
-          {/* Transformer（選択モードのみ） */}
-          {mode === "select" && (
-            <Transformer
-              ref={transformerRef}
-              boundBoxFunc={(oldBox, newBox) => {
-                if (newBox.width < MIN_TRANSFORM_SIZE || newBox.height < MIN_TRANSFORM_SIZE)
-                  return oldBox;
-                return newBox;
-              }}
-            />
+          ) : (
+            layerContent
           )}
         </Layer>
       </Stage>

--- a/features/editor/components/EditorCanvas.tsx
+++ b/features/editor/components/EditorCanvas.tsx
@@ -835,91 +835,100 @@ export function EditorCanvas({
     <div ref={containerRef} className="w-full overflow-hidden rounded-xl border border-zinc-200">
       <div className="flex flex-col gap-1 border-b border-zinc-200 bg-zinc-50 px-2 py-1.5">
         <span className="text-xs text-zinc-600">表示ズーム</span>
-        <div className="flex w-full flex-wrap items-center gap-2">
+        <div className="flex w-full flex-wrap items-start gap-2 md:items-center">
           {canPan && (
-            <div className="flex flex-wrap items-center gap-1 border-r border-zinc-300 pr-1.5">
-              <span className="text-xs text-zinc-600">移動</span>
-              <button
-                type="button"
-                className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded border border-zinc-300 bg-white text-zinc-800 hover:bg-zinc-100"
-                aria-label="表示を左へ移動"
-                onClick={() => nudgeViewCenter(-1, 0)}
-              >
-                <ChevronLeft className="h-4 w-4" aria-hidden />
-              </button>
-              <button
-                type="button"
-                className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded border border-zinc-300 bg-white text-zinc-800 hover:bg-zinc-100"
-                aria-label="表示を上へ移動"
-                onClick={() => nudgeViewCenter(0, -1)}
-              >
-                <ChevronUp className="h-4 w-4" aria-hidden />
-              </button>
-              <button
-                type="button"
-                className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded border border-zinc-300 bg-white text-zinc-800 hover:bg-zinc-100"
-                aria-label="表示を下へ移動"
-                onClick={() => nudgeViewCenter(0, 1)}
-              >
-                <ChevronDown className="h-4 w-4" aria-hidden />
-              </button>
-              <button
-                type="button"
-                className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded border border-zinc-300 bg-white text-zinc-800 hover:bg-zinc-100"
-                aria-label="表示を右へ移動"
-                onClick={() => nudgeViewCenter(1, 0)}
-              >
-                <ChevronRight className="h-4 w-4" aria-hidden />
-              </button>
-              <button
-                type="button"
-                className="rounded border border-zinc-300 bg-white px-2 py-0.5 text-xs text-zinc-800 hover:bg-zinc-100"
-                aria-label="表示位置を中央に戻す"
-                onClick={() => setViewCenter(defaultViewCenter)}
-              >
-                中央
-              </button>
+            <div className="flex flex-col gap-1 border-r border-zinc-300 pr-1.5 md:flex-row md:items-center md:gap-2">
+              <div className="flex items-center justify-between gap-2 md:justify-start">
+                <span className="text-xs text-zinc-600">移動</span>
+                <button
+                  type="button"
+                  className="rounded border border-zinc-300 bg-white px-2 py-0.5 text-xs text-zinc-800 hover:bg-zinc-100"
+                  aria-label="表示位置を中央に戻す"
+                  onClick={() => setViewCenter(defaultViewCenter)}
+                >
+                  中央
+                </button>
+              </div>
+              <div className="flex flex-wrap items-center gap-1 md:flex-nowrap">
+                <button
+                  type="button"
+                  className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded border border-zinc-300 bg-white text-zinc-800 hover:bg-zinc-100"
+                  aria-label="表示を左へ移動"
+                  onClick={() => nudgeViewCenter(-1, 0)}
+                >
+                  <ChevronLeft className="h-4 w-4" aria-hidden />
+                </button>
+                <button
+                  type="button"
+                  className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded border border-zinc-300 bg-white text-zinc-800 hover:bg-zinc-100"
+                  aria-label="表示を上へ移動"
+                  onClick={() => nudgeViewCenter(0, -1)}
+                >
+                  <ChevronUp className="h-4 w-4" aria-hidden />
+                </button>
+                <button
+                  type="button"
+                  className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded border border-zinc-300 bg-white text-zinc-800 hover:bg-zinc-100"
+                  aria-label="表示を下へ移動"
+                  onClick={() => nudgeViewCenter(0, 1)}
+                >
+                  <ChevronDown className="h-4 w-4" aria-hidden />
+                </button>
+                <button
+                  type="button"
+                  className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded border border-zinc-300 bg-white text-zinc-800 hover:bg-zinc-100"
+                  aria-label="表示を右へ移動"
+                  onClick={() => nudgeViewCenter(1, 0)}
+                >
+                  <ChevronRight className="h-4 w-4" aria-hidden />
+                </button>
+              </div>
             </div>
           )}
-          <div className="ml-auto flex shrink-0 items-center gap-1.5">
-            <span className="min-w-[3rem] text-center text-xs tabular-nums text-zinc-700">
-              {Math.round(viewZoom * 100)}%
-            </span>
-            <button
-              type="button"
-              className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded border border-zinc-300 bg-white text-zinc-800 hover:bg-zinc-100"
-              aria-label="ズームアウト"
-              onClick={() => {
-                const nz = roundViewZoomStep(viewZoom - VIEW_ZOOM.step);
-                setViewZoom(nz);
-                setViewCenter((center) => clampCurrentViewCenter(center, nz));
-              }}
-            >
-              <Minus className="h-4 w-4" aria-hidden />
-            </button>
-            <button
-              type="button"
-              className="rounded border border-zinc-300 bg-white px-2 py-0.5 text-xs text-zinc-800 hover:bg-zinc-100"
-              aria-label="表示ズームを等倍に戻す"
-              onClick={() => {
-                setViewZoom(VIEW_ZOOM.default);
-                setViewCenter(defaultViewCenter);
-              }}
-            >
-              等倍
-            </button>
-            <button
-              type="button"
-              className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded border border-zinc-300 bg-white text-zinc-800 hover:bg-zinc-100"
-              aria-label="ズームイン"
-              onClick={() => {
-                const nz = roundViewZoomStep(viewZoom + VIEW_ZOOM.step);
-                setViewZoom(nz);
-                setViewCenter((center) => clampCurrentViewCenter(center, nz));
-              }}
-            >
-              <Plus className="h-4 w-4" aria-hidden />
-            </button>
+          <div className="ml-auto flex shrink-0 flex-col items-end gap-1">
+            <div className="flex items-center justify-between gap-2 md:justify-start">
+              <span className="text-xs text-zinc-600">拡大縮小</span>
+              <span className="text-xs tabular-nums text-zinc-500">
+                {Math.round(viewZoom * 100)}%
+              </span>
+            </div>
+            <div className="flex items-center gap-1.5">
+              <button
+                type="button"
+                className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded border border-zinc-300 bg-white text-zinc-800 hover:bg-zinc-100"
+                aria-label="ズームアウト"
+                onClick={() => {
+                  const nz = roundViewZoomStep(viewZoom - VIEW_ZOOM.step);
+                  setViewZoom(nz);
+                  setViewCenter((center) => clampCurrentViewCenter(center, nz));
+                }}
+              >
+                <Minus className="h-4 w-4" aria-hidden />
+              </button>
+              <button
+                type="button"
+                className="inline-flex h-7 items-center justify-center rounded border border-zinc-300 bg-white px-2 text-xs text-zinc-800 hover:bg-zinc-100"
+                aria-label={`表示ズームを等倍に戻す。現在 ${Math.round(viewZoom * 100)}%`}
+                onClick={() => {
+                  setViewZoom(VIEW_ZOOM.default);
+                  setViewCenter(defaultViewCenter);
+                }}
+              >
+                等倍
+              </button>
+              <button
+                type="button"
+                className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded border border-zinc-300 bg-white text-zinc-800 hover:bg-zinc-100"
+                aria-label="ズームイン"
+                onClick={() => {
+                  const nz = roundViewZoomStep(viewZoom + VIEW_ZOOM.step);
+                  setViewZoom(nz);
+                  setViewCenter((center) => clampCurrentViewCenter(center, nz));
+                }}
+              >
+                <Plus className="h-4 w-4" aria-hidden />
+              </button>
+            </div>
           </div>
         </div>
       </div>

--- a/features/editor/components/EditorCanvas.tsx
+++ b/features/editor/components/EditorCanvas.tsx
@@ -13,7 +13,6 @@ import {
   Stage,
   Transformer,
 } from "react-konva";
-import { ChevronDown, ChevronLeft, ChevronRight, ChevronUp, Minus, Plus } from "lucide-react";
 import type {
   EditorMode,
   FillRegion,
@@ -22,14 +21,9 @@ import type {
   StampRegion,
   StampType,
 } from "../types";
-import {
-  VIEW_CENTER_NUDGE_PX,
-  VIEW_ZOOM,
-  clampViewCenter,
-  getDefaultViewCenter,
-  roundViewZoomStep,
-  stagePointerToContentSpace,
-} from "../lib/viewZoom";
+import { stagePointerToContentSpace } from "../lib/viewZoom";
+import { useEditorViewport } from "../hooks/useEditorViewport";
+import { EditorViewportControls } from "./EditorViewportControls";
 
 interface EditorCanvasProps {
   imageUrl: string;
@@ -284,25 +278,24 @@ export function EditorCanvas({
   const [bgImage, setBgImage] = useState<HTMLImageElement | null>(null);
   const [drawingRect, setDrawingRect] = useState<DrawingRect | null>(null);
   const [drawingStroke, setDrawingStroke] = useState<DrawingStroke | null>(null);
-  /** 表示のみの倍率（1 = 等倍）。論理領域・エクスポートは画像自然サイズ基準のまま */
-  const [viewZoom, setViewZoom] = useState<number>(VIEW_ZOOM.default);
-  /** 表示中心（画像自然サイズ座標）。この点がステージ中央に来るよう表示する。 */
-  const [viewCenter, setViewCenter] = useState(() =>
-    getDefaultViewCenter(imageNaturalWidth, imageNaturalHeight)
-  );
   const isDrawing = useRef(false);
   const drawStart = useRef<{ x: number; y: number } | null>(null);
-  const defaultViewCenter = getDefaultViewCenter(imageNaturalWidth, imageNaturalHeight);
 
   const stageHeight =
     imageNaturalWidth > 0 ? stageWidth * (imageNaturalHeight / imageNaturalWidth) : 400;
   const scaleX = imageNaturalWidth > 0 ? stageWidth / imageNaturalWidth : 1;
   const scaleY = imageNaturalHeight > 0 ? stageHeight / imageNaturalHeight : 1;
-  const contentCenter = {
-    x: viewCenter.x * scaleX,
-    y: viewCenter.y * scaleY,
-  };
-  const canPan = viewZoom > 1;
+  const {
+    viewZoom,
+    viewCenter,
+    contentCenter,
+    canPan,
+    nudgeViewCenter,
+    resetViewCenter,
+    zoomOut,
+    resetViewport,
+    zoomIn,
+  } = useEditorViewport(imageNaturalWidth, imageNaturalHeight, scaleX, scaleY);
 
   /**
    * キーボードショートカット
@@ -618,37 +611,6 @@ export function EditorCanvas({
     return stagePointerToContentSpace(stagePos, stageWidth, stageHeight, viewZoom, contentCenter);
   }
 
-  /**
-   * 表示中心を現在のズーム倍率に対して有効範囲へ収める
-   *
-   * @param center - 次の表示中心
-   * @param zoom - 次の表示倍率
-   * @returns クランプ後の表示中心
-   */
-  function clampCurrentViewCenter(center: { x: number; y: number }, zoom = viewZoom) {
-    return clampViewCenter(center, imageNaturalWidth, imageNaturalHeight, zoom);
-  }
-
-  /**
-   * ボタン操作で表示中心を移動する
-   *
-   * ボタンの移動量は見た目上の一貫性を保つためステージ px で定義し、
-   * 現在のフィット倍率と表示ズーム倍率から画像座標へ逆変換して加算する。
-   *
-   * @param dxImageDir - X 方向の移動係数（左:-1 / 右:+1）
-   * @param dyImageDir - Y 方向の移動係数（上:-1 / 下:+1）
-   */
-  function nudgeViewCenter(dxImageDir: -1 | 0 | 1, dyImageDir: -1 | 0 | 1) {
-    const deltaX = scaleX > 0 ? VIEW_CENTER_NUDGE_PX / (scaleX * viewZoom) : 0;
-    const deltaY = scaleY > 0 ? VIEW_CENTER_NUDGE_PX / (scaleY * viewZoom) : 0;
-    setViewCenter((center) =>
-      clampCurrentViewCenter({
-        x: center.x + deltaX * dxImageDir,
-        y: center.y + deltaY * dyImageDir,
-      })
-    );
-  }
-
   const layerContent = (
     <>
       {/* 背景画像 */}
@@ -833,105 +795,15 @@ export function EditorCanvas({
 
   return (
     <div ref={containerRef} className="w-full overflow-hidden rounded-xl border border-zinc-200">
-      <div className="flex flex-col gap-1 border-b border-zinc-200 bg-zinc-50 px-2 py-1.5">
-        <span className="text-xs text-zinc-600">表示ズーム</span>
-        <div className="flex w-full flex-wrap items-start gap-2 md:items-center">
-          {canPan && (
-            <div className="flex flex-col gap-1 border-r border-zinc-300 pr-1.5 md:flex-row md:items-center md:gap-2">
-              <div className="flex items-center justify-between gap-2 md:justify-start">
-                <span className="text-xs text-zinc-600">移動</span>
-                <button
-                  type="button"
-                  className="rounded border border-zinc-300 bg-white px-2 py-0.5 text-xs text-zinc-800 hover:bg-zinc-100"
-                  aria-label="表示位置を中央に戻す"
-                  onClick={() => setViewCenter(defaultViewCenter)}
-                >
-                  中央
-                </button>
-              </div>
-              <div className="flex flex-wrap items-center gap-1 md:flex-nowrap">
-                <button
-                  type="button"
-                  className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded border border-zinc-300 bg-white text-zinc-800 hover:bg-zinc-100"
-                  aria-label="表示を左へ移動"
-                  onClick={() => nudgeViewCenter(-1, 0)}
-                >
-                  <ChevronLeft className="h-4 w-4" aria-hidden />
-                </button>
-                <button
-                  type="button"
-                  className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded border border-zinc-300 bg-white text-zinc-800 hover:bg-zinc-100"
-                  aria-label="表示を上へ移動"
-                  onClick={() => nudgeViewCenter(0, -1)}
-                >
-                  <ChevronUp className="h-4 w-4" aria-hidden />
-                </button>
-                <button
-                  type="button"
-                  className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded border border-zinc-300 bg-white text-zinc-800 hover:bg-zinc-100"
-                  aria-label="表示を下へ移動"
-                  onClick={() => nudgeViewCenter(0, 1)}
-                >
-                  <ChevronDown className="h-4 w-4" aria-hidden />
-                </button>
-                <button
-                  type="button"
-                  className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded border border-zinc-300 bg-white text-zinc-800 hover:bg-zinc-100"
-                  aria-label="表示を右へ移動"
-                  onClick={() => nudgeViewCenter(1, 0)}
-                >
-                  <ChevronRight className="h-4 w-4" aria-hidden />
-                </button>
-              </div>
-            </div>
-          )}
-          <div className="ml-auto flex shrink-0 flex-col items-end gap-1">
-            <div className="flex items-center justify-between gap-2 md:justify-start">
-              <span className="text-xs text-zinc-600">拡大縮小</span>
-              <span className="text-xs tabular-nums text-zinc-500">
-                {Math.round(viewZoom * 100)}%
-              </span>
-            </div>
-            <div className="flex items-center gap-1.5">
-              <button
-                type="button"
-                className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded border border-zinc-300 bg-white text-zinc-800 hover:bg-zinc-100"
-                aria-label="ズームアウト"
-                onClick={() => {
-                  const nz = roundViewZoomStep(viewZoom - VIEW_ZOOM.step);
-                  setViewZoom(nz);
-                  setViewCenter((center) => clampCurrentViewCenter(center, nz));
-                }}
-              >
-                <Minus className="h-4 w-4" aria-hidden />
-              </button>
-              <button
-                type="button"
-                className="inline-flex h-7 items-center justify-center rounded border border-zinc-300 bg-white px-2 text-xs text-zinc-800 hover:bg-zinc-100"
-                aria-label={`表示ズームを等倍に戻す。現在 ${Math.round(viewZoom * 100)}%`}
-                onClick={() => {
-                  setViewZoom(VIEW_ZOOM.default);
-                  setViewCenter(defaultViewCenter);
-                }}
-              >
-                等倍
-              </button>
-              <button
-                type="button"
-                className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded border border-zinc-300 bg-white text-zinc-800 hover:bg-zinc-100"
-                aria-label="ズームイン"
-                onClick={() => {
-                  const nz = roundViewZoomStep(viewZoom + VIEW_ZOOM.step);
-                  setViewZoom(nz);
-                  setViewCenter((center) => clampCurrentViewCenter(center, nz));
-                }}
-              >
-                <Plus className="h-4 w-4" aria-hidden />
-              </button>
-            </div>
-          </div>
-        </div>
-      </div>
+      <EditorViewportControls
+        canPan={canPan}
+        viewZoom={viewZoom}
+        onNudgeViewCenter={nudgeViewCenter}
+        onResetViewCenter={resetViewCenter}
+        onZoomOut={zoomOut}
+        onResetViewport={resetViewport}
+        onZoomIn={zoomIn}
+      />
       <Stage
         width={stageWidth}
         height={stageHeight}

--- a/features/editor/components/EditorCanvas.tsx
+++ b/features/editor/components/EditorCanvas.tsx
@@ -13,7 +13,7 @@ import {
   Stage,
   Transformer,
 } from "react-konva";
-import { Minus, Plus } from "lucide-react";
+import { ChevronDown, ChevronLeft, ChevronRight, ChevronUp, Minus, Plus } from "lucide-react";
 import type {
   EditorMode,
   FillRegion,
@@ -22,7 +22,14 @@ import type {
   StampRegion,
   StampType,
 } from "../types";
-import { VIEW_ZOOM, roundViewZoomStep, stagePointerToContentSpace } from "../lib/viewZoom";
+import {
+  DEFAULT_VIEW_PAN,
+  VIEW_PAN_NUDGE_PX,
+  VIEW_ZOOM,
+  clampViewPan,
+  roundViewZoomStep,
+  stagePointerToContentSpace,
+} from "../lib/viewZoom";
 
 interface EditorCanvasProps {
   imageUrl: string;
@@ -279,8 +286,15 @@ export function EditorCanvas({
   const [drawingStroke, setDrawingStroke] = useState<DrawingStroke | null>(null);
   /** 表示のみの倍率（1 = 等倍）。論理領域・エクスポートは画像自然サイズ基準のまま */
   const [viewZoom, setViewZoom] = useState<number>(VIEW_ZOOM.default);
+  /** 表示のみのパン（ステージ px）。論理マスク座標は変えない */
+  const [viewPan, setViewPan] = useState(DEFAULT_VIEW_PAN);
   const isDrawing = useRef(false);
   const drawStart = useRef<{ x: number; y: number } | null>(null);
+  const viewZoomRef = useRef(viewZoom);
+
+  useEffect(() => {
+    viewZoomRef.current = viewZoom;
+  }, [viewZoom]);
 
   const stageHeight =
     imageNaturalWidth > 0 ? stageWidth * (imageNaturalHeight / imageNaturalWidth) : 400;
@@ -312,13 +326,17 @@ export function EditorCanvas({
     const observer = new ResizeObserver((entries) => {
       const entry = entries[0];
       if (entry) {
-        setStageWidth(entry.contentRect.width || 600);
+        const w = entry.contentRect.width || 600;
+        setStageWidth(w);
+        const h = imageNaturalWidth > 0 ? w * (imageNaturalHeight / imageNaturalWidth) : 400;
+        setViewPan((p) => clampViewPan(p, w, h, viewZoomRef.current));
       }
     });
     observer.observe(container);
-    setStageWidth(container.offsetWidth || 600);
+    const w0 = container.offsetWidth || 600;
+    setStageWidth(w0);
     return () => observer.disconnect();
-  }, []);
+  }, [imageNaturalHeight, imageNaturalWidth]);
 
   /** 背景画像を読み込む */
   useEffect(() => {
@@ -585,7 +603,7 @@ export function EditorCanvas({
   function pointerToContentSpace(stage: Konva.Stage): { x: number; y: number } | null {
     const stagePos = getStagePos(stage);
     if (!stagePos) return null;
-    return stagePointerToContentSpace(stagePos, stageWidth, stageHeight, viewZoom);
+    return stagePointerToContentSpace(stagePos, stageWidth, stageHeight, viewZoom, viewPan);
   }
 
   const layerContent = (
@@ -772,35 +790,131 @@ export function EditorCanvas({
 
   return (
     <div ref={containerRef} className="w-full overflow-hidden rounded-xl border border-zinc-200">
-      <div className="flex flex-wrap items-center justify-end gap-1.5 border-b border-zinc-200 bg-zinc-50 px-2 py-1">
-        <span className="mr-auto text-xs text-zinc-600">表示ズーム</span>
-        <span className="min-w-[3rem] text-center text-xs tabular-nums text-zinc-700">
-          {Math.round(viewZoom * 100)}%
-        </span>
-        <button
-          type="button"
-          className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded border border-zinc-300 bg-white text-zinc-800 hover:bg-zinc-100"
-          aria-label="ズームアウト"
-          onClick={() => setViewZoom((z) => roundViewZoomStep(z - VIEW_ZOOM.step))}
-        >
-          <Minus className="h-4 w-4" aria-hidden />
-        </button>
-        <button
-          type="button"
-          className="rounded border border-zinc-300 bg-white px-2 py-0.5 text-xs text-zinc-800 hover:bg-zinc-100"
-          aria-label="表示ズームを等倍に戻す"
-          onClick={() => setViewZoom(VIEW_ZOOM.default)}
-        >
-          等倍
-        </button>
-        <button
-          type="button"
-          className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded border border-zinc-300 bg-white text-zinc-800 hover:bg-zinc-100"
-          aria-label="ズームイン"
-          onClick={() => setViewZoom((z) => roundViewZoomStep(z + VIEW_ZOOM.step))}
-        >
-          <Plus className="h-4 w-4" aria-hidden />
-        </button>
+      <div className="flex flex-col gap-1 border-b border-zinc-200 bg-zinc-50 px-2 py-1.5">
+        <span className="text-xs text-zinc-600">表示ズーム</span>
+        <div className="flex w-full flex-wrap items-center gap-2">
+          {viewZoom !== 1 && (
+            <div className="flex flex-wrap items-center gap-1 border-r border-zinc-300 pr-1.5">
+              <span className="text-xs text-zinc-600">移動</span>
+              <button
+                type="button"
+                className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded border border-zinc-300 bg-white text-zinc-800 hover:bg-zinc-100"
+                aria-label="表示を左へ移動"
+                onClick={() =>
+                  setViewPan((p) =>
+                    clampViewPan(
+                      { x: p.x + VIEW_PAN_NUDGE_PX, y: p.y },
+                      stageWidth,
+                      stageHeight,
+                      viewZoom
+                    )
+                  )
+                }
+              >
+                <ChevronLeft className="h-4 w-4" aria-hidden />
+              </button>
+              <button
+                type="button"
+                className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded border border-zinc-300 bg-white text-zinc-800 hover:bg-zinc-100"
+                aria-label="表示を上へ移動"
+                onClick={() =>
+                  setViewPan((p) =>
+                    clampViewPan(
+                      { x: p.x, y: p.y + VIEW_PAN_NUDGE_PX },
+                      stageWidth,
+                      stageHeight,
+                      viewZoom
+                    )
+                  )
+                }
+              >
+                <ChevronUp className="h-4 w-4" aria-hidden />
+              </button>
+              <button
+                type="button"
+                className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded border border-zinc-300 bg-white text-zinc-800 hover:bg-zinc-100"
+                aria-label="表示を下へ移動"
+                onClick={() =>
+                  setViewPan((p) =>
+                    clampViewPan(
+                      { x: p.x, y: p.y - VIEW_PAN_NUDGE_PX },
+                      stageWidth,
+                      stageHeight,
+                      viewZoom
+                    )
+                  )
+                }
+              >
+                <ChevronDown className="h-4 w-4" aria-hidden />
+              </button>
+              <button
+                type="button"
+                className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded border border-zinc-300 bg-white text-zinc-800 hover:bg-zinc-100"
+                aria-label="表示を右へ移動"
+                onClick={() =>
+                  setViewPan((p) =>
+                    clampViewPan(
+                      { x: p.x - VIEW_PAN_NUDGE_PX, y: p.y },
+                      stageWidth,
+                      stageHeight,
+                      viewZoom
+                    )
+                  )
+                }
+              >
+                <ChevronRight className="h-4 w-4" aria-hidden />
+              </button>
+              <button
+                type="button"
+                className="rounded border border-zinc-300 bg-white px-2 py-0.5 text-xs text-zinc-800 hover:bg-zinc-100"
+                aria-label="表示位置を中央に戻す"
+                onClick={() => setViewPan(DEFAULT_VIEW_PAN)}
+              >
+                中央
+              </button>
+            </div>
+          )}
+          <div className="ml-auto flex shrink-0 items-center gap-1.5">
+            <span className="min-w-[3rem] text-center text-xs tabular-nums text-zinc-700">
+              {Math.round(viewZoom * 100)}%
+            </span>
+            <button
+              type="button"
+              className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded border border-zinc-300 bg-white text-zinc-800 hover:bg-zinc-100"
+              aria-label="ズームアウト"
+              onClick={() => {
+                const nz = roundViewZoomStep(viewZoom - VIEW_ZOOM.step);
+                setViewZoom(nz);
+                setViewPan((p) => clampViewPan(p, stageWidth, stageHeight, nz));
+              }}
+            >
+              <Minus className="h-4 w-4" aria-hidden />
+            </button>
+            <button
+              type="button"
+              className="rounded border border-zinc-300 bg-white px-2 py-0.5 text-xs text-zinc-800 hover:bg-zinc-100"
+              aria-label="表示ズームを等倍に戻す"
+              onClick={() => {
+                setViewZoom(VIEW_ZOOM.default);
+                setViewPan(DEFAULT_VIEW_PAN);
+              }}
+            >
+              等倍
+            </button>
+            <button
+              type="button"
+              className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded border border-zinc-300 bg-white text-zinc-800 hover:bg-zinc-100"
+              aria-label="ズームイン"
+              onClick={() => {
+                const nz = roundViewZoomStep(viewZoom + VIEW_ZOOM.step);
+                setViewZoom(nz);
+                setViewPan((p) => clampViewPan(p, stageWidth, stageHeight, nz));
+              }}
+            >
+              <Plus className="h-4 w-4" aria-hidden />
+            </button>
+          </div>
+        </div>
       </div>
       <Stage
         width={stageWidth}
@@ -814,20 +928,22 @@ export function EditorCanvas({
         style={{ cursor: MODE_CURSORS[mode] }}
       >
         <Layer>
-          {viewZoom !== 1 ? (
-            <Group
-              x={stageWidth / 2}
-              y={stageHeight / 2}
-              offsetX={stageWidth / 2}
-              offsetY={stageHeight / 2}
-              scaleX={viewZoom}
-              scaleY={viewZoom}
-            >
-              {layerContent}
-            </Group>
-          ) : (
-            layerContent
-          )}
+          <Group x={viewPan.x} y={viewPan.y}>
+            {viewZoom !== 1 ? (
+              <Group
+                x={stageWidth / 2}
+                y={stageHeight / 2}
+                offsetX={stageWidth / 2}
+                offsetY={stageHeight / 2}
+                scaleX={viewZoom}
+                scaleY={viewZoom}
+              >
+                {layerContent}
+              </Group>
+            ) : (
+              layerContent
+            )}
+          </Group>
         </Layer>
       </Stage>
     </div>

--- a/features/editor/components/EditorViewportControls.tsx
+++ b/features/editor/components/EditorViewportControls.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import { ChevronDown, ChevronLeft, ChevronRight, ChevronUp, Minus, Plus } from "lucide-react";
+import type { ViewportDirection } from "../hooks/useEditorViewport";
+
+interface EditorViewportControlsProps {
+  canPan: boolean;
+  viewZoom: number;
+  onNudgeViewCenter: (dxImageDir: ViewportDirection, dyImageDir: ViewportDirection) => void;
+  onResetViewCenter: () => void;
+  onZoomOut: () => void;
+  onResetViewport: () => void;
+  onZoomIn: () => void;
+}
+
+/**
+ * EditorCanvas 上部の表示ズーム / 表示移動コントロール
+ *
+ * 描画ロジックとは分離し、ボタン構成とレスポンシブレイアウトだけを担当する。
+ */
+export function EditorViewportControls({
+  canPan,
+  viewZoom,
+  onNudgeViewCenter,
+  onResetViewCenter,
+  onZoomOut,
+  onResetViewport,
+  onZoomIn,
+}: EditorViewportControlsProps) {
+  return (
+    <div className="flex flex-col gap-1 border-b border-zinc-200 bg-zinc-50 px-2 py-1.5">
+      <span className="text-xs text-zinc-600">表示ズーム</span>
+      <div className="flex w-full flex-wrap items-start gap-2 md:items-center">
+        {canPan && (
+          <div className="flex flex-col gap-1 border-r border-zinc-300 pr-1.5 md:flex-row md:items-center md:gap-2">
+            <div className="flex items-center justify-between gap-2 md:justify-start">
+              <span className="text-xs text-zinc-600">移動</span>
+              <button
+                type="button"
+                className="rounded border border-zinc-300 bg-white px-2 py-0.5 text-xs text-zinc-800 hover:bg-zinc-100"
+                aria-label="表示位置を中央に戻す"
+                onClick={onResetViewCenter}
+              >
+                中央
+              </button>
+            </div>
+            <div className="flex flex-wrap items-center gap-1 md:flex-nowrap">
+              <button
+                type="button"
+                className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded border border-zinc-300 bg-white text-zinc-800 hover:bg-zinc-100"
+                aria-label="表示を左へ移動"
+                onClick={() => onNudgeViewCenter(-1, 0)}
+              >
+                <ChevronLeft className="h-4 w-4" aria-hidden />
+              </button>
+              <button
+                type="button"
+                className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded border border-zinc-300 bg-white text-zinc-800 hover:bg-zinc-100"
+                aria-label="表示を上へ移動"
+                onClick={() => onNudgeViewCenter(0, -1)}
+              >
+                <ChevronUp className="h-4 w-4" aria-hidden />
+              </button>
+              <button
+                type="button"
+                className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded border border-zinc-300 bg-white text-zinc-800 hover:bg-zinc-100"
+                aria-label="表示を下へ移動"
+                onClick={() => onNudgeViewCenter(0, 1)}
+              >
+                <ChevronDown className="h-4 w-4" aria-hidden />
+              </button>
+              <button
+                type="button"
+                className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded border border-zinc-300 bg-white text-zinc-800 hover:bg-zinc-100"
+                aria-label="表示を右へ移動"
+                onClick={() => onNudgeViewCenter(1, 0)}
+              >
+                <ChevronRight className="h-4 w-4" aria-hidden />
+              </button>
+            </div>
+          </div>
+        )}
+        <div className="ml-auto flex shrink-0 flex-col items-end gap-1">
+          <div className="flex items-center justify-between gap-2 md:justify-start">
+            <span className="text-xs text-zinc-600">拡大縮小</span>
+            <span className="text-xs tabular-nums text-zinc-500">
+              {Math.round(viewZoom * 100)}%
+            </span>
+          </div>
+          <div className="flex items-center gap-1.5">
+            <button
+              type="button"
+              className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded border border-zinc-300 bg-white text-zinc-800 hover:bg-zinc-100"
+              aria-label="ズームアウト"
+              onClick={onZoomOut}
+            >
+              <Minus className="h-4 w-4" aria-hidden />
+            </button>
+            <button
+              type="button"
+              className="inline-flex h-7 items-center justify-center rounded border border-zinc-300 bg-white px-2 text-xs text-zinc-800 hover:bg-zinc-100"
+              aria-label={`表示ズームを等倍に戻す。現在 ${Math.round(viewZoom * 100)}%`}
+              onClick={onResetViewport}
+            >
+              等倍
+            </button>
+            <button
+              type="button"
+              className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded border border-zinc-300 bg-white text-zinc-800 hover:bg-zinc-100"
+              aria-label="ズームイン"
+              onClick={onZoomIn}
+            >
+              <Plus className="h-4 w-4" aria-hidden />
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/features/editor/components/EditorViewportControls.tsx
+++ b/features/editor/components/EditorViewportControls.tsx
@@ -1,10 +1,13 @@
 "use client";
 
+import clsx from "clsx";
 import { ChevronDown, ChevronLeft, ChevronRight, ChevronUp, Minus, Plus } from "lucide-react";
 import type { ViewportDirection } from "../hooks/useEditorViewport";
 
 interface EditorViewportControlsProps {
   canPan: boolean;
+  canZoomOut: boolean;
+  canZoomIn: boolean;
   viewZoom: number;
   onNudgeViewCenter: (dxImageDir: ViewportDirection, dyImageDir: ViewportDirection) => void;
   onResetViewCenter: () => void;
@@ -20,6 +23,8 @@ interface EditorViewportControlsProps {
  */
 export function EditorViewportControls({
   canPan,
+  canZoomOut,
+  canZoomIn,
   viewZoom,
   onNudgeViewCenter,
   onResetViewCenter,
@@ -90,8 +95,15 @@ export function EditorViewportControls({
           <div className="flex items-center gap-1.5">
             <button
               type="button"
-              className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded border border-zinc-300 bg-white text-zinc-800 hover:bg-zinc-100"
+              className={clsx([
+                "inline-flex h-7 w-7 shrink-0 items-center justify-center rounded border border-zinc-300 text-zinc-800",
+                canZoomOut
+                  ? "bg-white hover:bg-zinc-100"
+                  : "cursor-not-allowed bg-zinc-100 text-zinc-400",
+              ])}
               aria-label="ズームアウト"
+              aria-disabled={!canZoomOut}
+              disabled={!canZoomOut}
               onClick={onZoomOut}
             >
               <Minus className="h-4 w-4" aria-hidden />
@@ -106,8 +118,15 @@ export function EditorViewportControls({
             </button>
             <button
               type="button"
-              className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded border border-zinc-300 bg-white text-zinc-800 hover:bg-zinc-100"
+              className={clsx([
+                "inline-flex h-7 w-7 shrink-0 items-center justify-center rounded border border-zinc-300 text-zinc-800",
+                canZoomIn
+                  ? "bg-white hover:bg-zinc-100"
+                  : "cursor-not-allowed bg-zinc-100 text-zinc-400",
+              ])}
               aria-label="ズームイン"
+              aria-disabled={!canZoomIn}
+              disabled={!canZoomIn}
               onClick={onZoomIn}
             >
               <Plus className="h-4 w-4" aria-hidden />

--- a/features/editor/hooks/useEditorViewport.test.ts
+++ b/features/editor/hooks/useEditorViewport.test.ts
@@ -1,0 +1,65 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { VIEW_ZOOM } from "../lib/viewZoom";
+import { useEditorViewport } from "./useEditorViewport";
+
+describe("useEditorViewport", () => {
+  it("nudgeViewCenter で現在の scale と zoom に応じて表示中心を移動できる", () => {
+    const { result } = renderHook(() => useEditorViewport(1000, 500, 1, 1));
+
+    act(() => {
+      result.current.zoomIn();
+    });
+
+    act(() => {
+      result.current.nudgeViewCenter(1, 0);
+    });
+
+    expect(result.current.viewZoom).toBeCloseTo(1.1);
+    expect(result.current.viewCenter.x).toBeCloseTo(500 + 24 / 1.1);
+    expect(result.current.viewCenter.y).toBe(250);
+  });
+
+  it("resetViewport でズーム倍率と表示中心を初期状態へ戻す", () => {
+    const { result } = renderHook(() => useEditorViewport(400, 200, 1, 1));
+
+    act(() => {
+      result.current.zoomIn();
+      result.current.nudgeViewCenter(-1, 1);
+    });
+
+    act(() => {
+      result.current.resetViewport();
+    });
+
+    expect(result.current.viewZoom).toBe(VIEW_ZOOM.default);
+    expect(result.current.viewCenter).toEqual({ x: 200, y: 100 });
+  });
+
+  it("ズーム上下限で canZoomOut / canZoomIn が切り替わる", () => {
+    const { result } = renderHook(() => useEditorViewport(400, 200, 1, 1));
+
+    expect(result.current.canZoomOut).toBe(true);
+    expect(result.current.canZoomIn).toBe(true);
+
+    for (let i = 0; i < 25; i += 1) {
+      act(() => {
+        result.current.zoomIn();
+      });
+    }
+
+    expect(result.current.viewZoom).toBe(VIEW_ZOOM.max);
+    expect(result.current.canZoomOut).toBe(true);
+    expect(result.current.canZoomIn).toBe(false);
+
+    for (let i = 0; i < 30; i += 1) {
+      act(() => {
+        result.current.zoomOut();
+      });
+    }
+
+    expect(result.current.viewZoom).toBe(VIEW_ZOOM.min);
+    expect(result.current.canZoomOut).toBe(false);
+    expect(result.current.canZoomIn).toBe(true);
+  });
+});

--- a/features/editor/hooks/useEditorViewport.ts
+++ b/features/editor/hooks/useEditorViewport.ts
@@ -20,6 +20,8 @@ export interface UseEditorViewportReturn {
   defaultViewCenter: ViewCenter;
   contentCenter: { x: number; y: number };
   canPan: boolean;
+  canZoomOut: boolean;
+  canZoomIn: boolean;
   nudgeViewCenter: (dxImageDir: ViewportDirection, dyImageDir: ViewportDirection) => void;
   resetViewCenter: () => void;
   zoomOut: () => void;
@@ -64,6 +66,8 @@ export function useEditorViewport(
   );
 
   const canPan = viewZoom > 1;
+  const canZoomOut = viewZoom > VIEW_ZOOM.min;
+  const canZoomIn = viewZoom < VIEW_ZOOM.max;
 
   /**
    * ボタン操作で表示中心を移動する
@@ -136,6 +140,8 @@ export function useEditorViewport(
     defaultViewCenter,
     contentCenter,
     canPan,
+    canZoomOut,
+    canZoomIn,
     nudgeViewCenter,
     resetViewCenter,
     zoomOut,

--- a/features/editor/hooks/useEditorViewport.ts
+++ b/features/editor/hooks/useEditorViewport.ts
@@ -1,0 +1,145 @@
+"use client";
+
+import { useCallback, useMemo, useState } from "react";
+import {
+  VIEW_CENTER_NUDGE_PX,
+  VIEW_ZOOM,
+  clampViewCenter,
+  getDefaultViewCenter,
+  roundViewZoomStep,
+  type ViewCenter,
+} from "../lib/viewZoom";
+
+/** 表示移動ボタン用の方向係数 */
+export type ViewportDirection = -1 | 0 | 1;
+
+/** `useEditorViewport` の戻り値 */
+export interface UseEditorViewportReturn {
+  viewZoom: number;
+  viewCenter: ViewCenter;
+  defaultViewCenter: ViewCenter;
+  contentCenter: { x: number; y: number };
+  canPan: boolean;
+  nudgeViewCenter: (dxImageDir: ViewportDirection, dyImageDir: ViewportDirection) => void;
+  resetViewCenter: () => void;
+  zoomOut: () => void;
+  resetViewport: () => void;
+  zoomIn: () => void;
+}
+
+/**
+ * EditorCanvas の表示ズームと表示中心を管理するフック
+ *
+ * 表示状態は stage px ではなく画像自然サイズ座標で保持し、
+ * レイアウト変化があっても「どの画像領域を見ているか」がぶれにくいようにする。
+ *
+ * @param imageNaturalWidth - 元画像の幅
+ * @param imageNaturalHeight - 元画像の高さ
+ * @param scaleX - 画像座標から stage 座標への X スケール
+ * @param scaleY - 画像座標から stage 座標への Y スケール
+ * @returns 表示ズームの状態と操作関数
+ */
+export function useEditorViewport(
+  imageNaturalWidth: number,
+  imageNaturalHeight: number,
+  scaleX: number,
+  scaleY: number
+): UseEditorViewportReturn {
+  const [viewZoom, setViewZoom] = useState<number>(VIEW_ZOOM.default);
+  const [viewCenter, setViewCenter] = useState<ViewCenter>(() =>
+    getDefaultViewCenter(imageNaturalWidth, imageNaturalHeight)
+  );
+
+  const defaultViewCenter = useMemo(
+    () => getDefaultViewCenter(imageNaturalWidth, imageNaturalHeight),
+    [imageNaturalWidth, imageNaturalHeight]
+  );
+
+  const contentCenter = useMemo(
+    () => ({
+      x: viewCenter.x * scaleX,
+      y: viewCenter.y * scaleY,
+    }),
+    [viewCenter, scaleX, scaleY]
+  );
+
+  const canPan = viewZoom > 1;
+
+  /**
+   * ボタン操作で表示中心を移動する
+   *
+   * ボタンの移動量は見た目上の一貫性を保つため stage px で定義し、
+   * 現在のフィット倍率と表示ズーム倍率から画像座標へ換算して加算する。
+   *
+   * @param dxImageDir - X 方向の移動係数（左:-1 / 右:+1）
+   * @param dyImageDir - Y 方向の移動係数（上:-1 / 下:+1）
+   */
+  const nudgeViewCenter = useCallback(
+    (dxImageDir: ViewportDirection, dyImageDir: ViewportDirection) => {
+      const deltaX = scaleX > 0 ? VIEW_CENTER_NUDGE_PX / (scaleX * viewZoom) : 0;
+      const deltaY = scaleY > 0 ? VIEW_CENTER_NUDGE_PX / (scaleY * viewZoom) : 0;
+      setViewCenter((center) =>
+        clampViewCenter(
+          {
+            x: center.x + deltaX * dxImageDir,
+            y: center.y + deltaY * dyImageDir,
+          },
+          imageNaturalWidth,
+          imageNaturalHeight,
+          viewZoom
+        )
+      );
+    },
+    [imageNaturalWidth, imageNaturalHeight, scaleX, scaleY, viewZoom]
+  );
+
+  /** 表示中心だけを画像中央へ戻す */
+  const resetViewCenter = useCallback(() => {
+    setViewCenter(defaultViewCenter);
+  }, [defaultViewCenter]);
+
+  /**
+   * 表示ズームを 1 ステップ変更する
+   *
+   * @param direction - -1 で縮小、1 で拡大
+   */
+  const stepZoom = useCallback(
+    (direction: -1 | 1) => {
+      const nextZoom = roundViewZoomStep(viewZoom + VIEW_ZOOM.step * direction);
+      setViewZoom(nextZoom);
+      setViewCenter((center) =>
+        clampViewCenter(center, imageNaturalWidth, imageNaturalHeight, nextZoom)
+      );
+    },
+    [imageNaturalWidth, imageNaturalHeight, viewZoom]
+  );
+
+  /** 表示ズームを 1 段階縮小する */
+  const zoomOut = useCallback(() => {
+    stepZoom(-1);
+  }, [stepZoom]);
+
+  /** 表示ズームと表示中心を初期状態へ戻す */
+  const resetViewport = useCallback(() => {
+    setViewZoom(VIEW_ZOOM.default);
+    setViewCenter(defaultViewCenter);
+  }, [defaultViewCenter]);
+
+  /** 表示ズームを 1 段階拡大する */
+  const zoomIn = useCallback(() => {
+    stepZoom(1);
+  }, [stepZoom]);
+
+  return {
+    viewZoom,
+    viewCenter,
+    defaultViewCenter,
+    contentCenter,
+    canPan,
+    nudgeViewCenter,
+    resetViewCenter,
+    zoomOut,
+    resetViewport,
+    zoomIn,
+  };
+}

--- a/features/editor/lib/viewZoom.test.ts
+++ b/features/editor/lib/viewZoom.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import {
+  VIEW_ZOOM,
+  clampViewZoom,
+  roundViewZoomStep,
+  stagePointerToContentSpace,
+} from "./viewZoom";
+
+describe("clampViewZoom", () => {
+  it("範囲内はそのまま返す", () => {
+    expect(clampViewZoom(1)).toBe(1);
+    expect(clampViewZoom(2)).toBe(2);
+  });
+
+  it("下限・上限でクランプする", () => {
+    expect(clampViewZoom(0)).toBe(VIEW_ZOOM.min);
+    expect(clampViewZoom(10)).toBe(VIEW_ZOOM.max);
+  });
+});
+
+describe("roundViewZoomStep", () => {
+  it("0.1 刻みに丸めてからクランプする", () => {
+    expect(roundViewZoomStep(1.04)).toBe(1);
+    expect(roundViewZoomStep(1.05)).toBe(1.1);
+  });
+});
+
+describe("stagePointerToContentSpace", () => {
+  it("等倍では座標を変えない", () => {
+    const p = { x: 10, y: 20 };
+    expect(stagePointerToContentSpace(p, 100, 80, 1)).toEqual(p);
+  });
+
+  it("ステージ中心を通る点はズーム後もコンテンツ中心と一致する", () => {
+    const w = 200;
+    const h = 100;
+    const center = { x: w / 2, y: h / 2 };
+    expect(stagePointerToContentSpace(center, w, h, 2)).toEqual(center);
+  });
+
+  it("2 倍ズーム時、ステージ左上はコンテンツ上で中心より左上に射影される", () => {
+    const w = 200;
+    const h = 200;
+    const z = 2;
+    const out = stagePointerToContentSpace({ x: 0, y: 0 }, w, h, z);
+    expect(out.x).toBeCloseTo(50);
+    expect(out.y).toBeCloseTo(50);
+  });
+});

--- a/features/editor/lib/viewZoom.test.ts
+++ b/features/editor/lib/viewZoom.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   VIEW_ZOOM,
+  clampViewPan,
   clampViewZoom,
   roundViewZoomStep,
   stagePointerToContentSpace,
@@ -25,10 +26,29 @@ describe("roundViewZoomStep", () => {
   });
 });
 
+describe("clampViewPan", () => {
+  it("等倍では常に 0", () => {
+    expect(clampViewPan({ x: 50, y: -30 }, 100, 80, 1)).toEqual({ x: 0, y: 0 });
+  });
+
+  it("2 倍ズーム時はステージ幅の半分まで許容する", () => {
+    const w = 200;
+    const h = 100;
+    const z = 2;
+    expect(clampViewPan({ x: 200, y: 0 }, w, h, z)).toEqual({ x: 100, y: 0 });
+    expect(clampViewPan({ x: -200, y: 0 }, w, h, z)).toEqual({ x: -100, y: 0 });
+  });
+});
+
 describe("stagePointerToContentSpace", () => {
-  it("等倍では座標を変えない", () => {
+  it("等倍でパンなしでは座標を変えない", () => {
     const p = { x: 10, y: 20 };
     expect(stagePointerToContentSpace(p, 100, 80, 1)).toEqual(p);
+  });
+
+  it("等倍でパンありではステージ座標からパンを差し引く", () => {
+    const p = { x: 10, y: 20 };
+    expect(stagePointerToContentSpace(p, 100, 80, 1, { x: 3, y: 4 })).toEqual({ x: 7, y: 16 });
   });
 
   it("ステージ中心を通る点はズーム後もコンテンツ中心と一致する", () => {

--- a/features/editor/lib/viewZoom.test.ts
+++ b/features/editor/lib/viewZoom.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from "vitest";
 import {
   VIEW_ZOOM,
-  clampViewPan,
+  clampViewCenter,
   clampViewZoom,
+  getDefaultViewCenter,
   roundViewZoomStep,
   stagePointerToContentSpace,
 } from "./viewZoom";
@@ -26,44 +27,53 @@ describe("roundViewZoomStep", () => {
   });
 });
 
-describe("clampViewPan", () => {
-  it("等倍では常に 0", () => {
-    expect(clampViewPan({ x: 50, y: -30 }, 100, 80, 1)).toEqual({ x: 0, y: 0 });
+describe("getDefaultViewCenter", () => {
+  it("画像中央を返す", () => {
+    expect(getDefaultViewCenter(100, 80)).toEqual({ x: 50, y: 40 });
+  });
+});
+
+describe("clampViewCenter", () => {
+  it("等倍以下では常に画像中央に戻す", () => {
+    expect(clampViewCenter({ x: 10, y: 20 }, 100, 80, 1)).toEqual({ x: 50, y: 40 });
+    expect(clampViewCenter({ x: 10, y: 20 }, 100, 80, 0.5)).toEqual({ x: 50, y: 40 });
   });
 
-  it("2 倍ズーム時はステージ幅の半分まで許容する", () => {
-    const w = 200;
-    const h = 100;
+  it("2 倍ズーム時は画像の外側を見ない範囲へ収める", () => {
+    const w = 400;
+    const h = 200;
     const z = 2;
-    expect(clampViewPan({ x: 200, y: 0 }, w, h, z)).toEqual({ x: 100, y: 0 });
-    expect(clampViewPan({ x: -200, y: 0 }, w, h, z)).toEqual({ x: -100, y: 0 });
+    expect(clampViewCenter({ x: 10, y: 10 }, w, h, z)).toEqual({ x: 100, y: 50 });
+    expect(clampViewCenter({ x: 390, y: 190 }, w, h, z)).toEqual({ x: 300, y: 150 });
   });
 });
 
 describe("stagePointerToContentSpace", () => {
-  it("等倍でパンなしでは座標を変えない", () => {
+  it("等倍で contentCenter がステージ中央なら座標を変えない", () => {
     const p = { x: 10, y: 20 };
     expect(stagePointerToContentSpace(p, 100, 80, 1)).toEqual(p);
   });
 
-  it("等倍でパンありではステージ座標からパンを差し引く", () => {
-    const p = { x: 10, y: 20 };
-    expect(stagePointerToContentSpace(p, 100, 80, 1, { x: 3, y: 4 })).toEqual({ x: 7, y: 16 });
+  it("表示中心がずれているときはステージ中央がその contentCenter に対応する", () => {
+    const center = { x: 120, y: 90 };
+    expect(stagePointerToContentSpace({ x: 100, y: 50 }, 200, 100, 1, center)).toEqual(center);
   });
 
   it("ステージ中心を通る点はズーム後もコンテンツ中心と一致する", () => {
     const w = 200;
     const h = 100;
-    const center = { x: w / 2, y: h / 2 };
-    expect(stagePointerToContentSpace(center, w, h, 2)).toEqual(center);
+    const contentCenter = { x: 140, y: 80 };
+    expect(stagePointerToContentSpace({ x: w / 2, y: h / 2 }, w, h, 2, contentCenter)).toEqual(
+      contentCenter
+    );
   });
 
   it("2 倍ズーム時、ステージ左上はコンテンツ上で中心より左上に射影される", () => {
     const w = 200;
     const h = 200;
     const z = 2;
-    const out = stagePointerToContentSpace({ x: 0, y: 0 }, w, h, z);
-    expect(out.x).toBeCloseTo(50);
-    expect(out.y).toBeCloseTo(50);
+    const out = stagePointerToContentSpace({ x: 0, y: 0 }, w, h, z, { x: 150, y: 130 });
+    expect(out.x).toBeCloseTo(100);
+    expect(out.y).toBeCloseTo(80);
   });
 });

--- a/features/editor/lib/viewZoom.ts
+++ b/features/editor/lib/viewZoom.ts
@@ -2,17 +2,14 @@
  * エディタキャンバス上の「表示のみ」のビュー倍率（論理座標は変えない）
  */
 
-/** 表示パン（ステージ座標系の平行移動量、px）。論理マスク座標は変えない */
-export interface ViewPan {
+/** 表示中心（画像自然サイズ座標）。この点がステージ中央に来るよう表示する。 */
+export interface ViewCenter {
   x: number;
   y: number;
 }
 
-/** パン未適用 */
-export const DEFAULT_VIEW_PAN: ViewPan = { x: 0, y: 0 };
-
-/** パン移動ボタン 1 回あたりの移動量（px） */
-export const VIEW_PAN_NUDGE_PX = 24;
+/** 移動ボタン 1 回あたりの基準移動量（ステージ px）。実際は画像座標へ換算する。 */
+export const VIEW_CENTER_NUDGE_PX = 24;
 
 /** 表示ズームの下限・上限・1 ステップ・既定値 */
 export const VIEW_ZOOM = {
@@ -44,58 +41,79 @@ export function roundViewZoomStep(z: number): number {
 }
 
 /**
- * 表示パンをズームとステージサイズから許容範囲に収める（等倍では常に 0）
+ * 表示中心の初期値（画像中央）を返す
  *
- * @param pan - パン量（ステージ px）
- * @param stageWidth - ステージ幅
- * @param stageHeight - ステージ高さ
+ * @param imageNaturalWidth - 元画像の幅
+ * @param imageNaturalHeight - 元画像の高さ
+ */
+export function getDefaultViewCenter(
+  imageNaturalWidth: number,
+  imageNaturalHeight: number
+): ViewCenter {
+  return {
+    x: imageNaturalWidth / 2,
+    y: imageNaturalHeight / 2,
+  };
+}
+
+/**
+ * 表示中心を画像内の有効範囲へ収める
+ *
+ * `viewZoom <= 1` では画像全体が見えるため、常に画像中央へ戻す。
+ * `viewZoom > 1` では、表示領域が画像外へはみ出さない範囲で中心をクランプする。
+ *
+ * @param center - 表示中心（画像自然サイズ座標）
+ * @param imageNaturalWidth - 元画像の幅
+ * @param imageNaturalHeight - 元画像の高さ
  * @param viewZoom - 表示倍率
  */
-export function clampViewPan(
-  pan: ViewPan,
-  stageWidth: number,
-  stageHeight: number,
+export function clampViewCenter(
+  center: ViewCenter,
+  imageNaturalWidth: number,
+  imageNaturalHeight: number,
   viewZoom: number
-): ViewPan {
-  if (viewZoom === 1) {
-    return DEFAULT_VIEW_PAN;
+): ViewCenter {
+  const defaultCenter = getDefaultViewCenter(imageNaturalWidth, imageNaturalHeight);
+  if (viewZoom <= 1) {
+    return defaultCenter;
   }
-  const maxX = (stageWidth * Math.abs(1 - viewZoom)) / 2;
-  const maxY = (stageHeight * Math.abs(1 - viewZoom)) / 2;
+
+  const halfVisibleWidth = imageNaturalWidth / (2 * viewZoom);
+  const halfVisibleHeight = imageNaturalHeight / (2 * viewZoom);
+
   return {
-    x: Math.min(maxX, Math.max(-maxX, pan.x)),
-    y: Math.min(maxY, Math.max(-maxY, pan.y)),
+    x: Math.min(imageNaturalWidth - halfVisibleWidth, Math.max(halfVisibleWidth, center.x)),
+    y: Math.min(imageNaturalHeight - halfVisibleHeight, Math.max(halfVisibleHeight, center.y)),
   };
 }
 
 /**
  * ステージ座標（ポインタ）を、ズーム前のコンテンツ座標（0…stageWidth / 0…stageHeight）に変換する
  *
- * 表示は「パン → ステージ中心を原点として viewZoom 倍」と Konva の
- * `Group`（外側パン、`x/y`+`offset` で中心ズーム）と同じ射影式を使う。
+ * 表示は「contentCenter をステージ中央に合わせて viewZoom 倍」と Konva の
+ * `Group`（`x/y` をステージ中央、`offsetX/Y` を contentCenter、`scaleX/Y` を viewZoom）
+ * と同じ射影式を使う。
  *
  * @param stagePos - ステージ上のポインタ座標
  * @param stageWidth - ステージ幅（px）
  * @param stageHeight - ステージ高さ（px）
  * @param viewZoom - 表示倍率（1 = 等倍）
- * @param viewPan - 表示パン（ステージ px、既定は無移動）
+ * @param contentCenter - コンテンツ座標系での表示中心
  */
 export function stagePointerToContentSpace(
   stagePos: { x: number; y: number },
   stageWidth: number,
   stageHeight: number,
   viewZoom: number,
-  viewPan: ViewPan = DEFAULT_VIEW_PAN
-): { x: number; y: number } {
-  const sx = stagePos.x - viewPan.x;
-  const sy = stagePos.y - viewPan.y;
-  if (viewZoom === 1) {
-    return { x: sx, y: sy };
+  contentCenter: { x: number; y: number } = {
+    x: stageWidth / 2,
+    y: stageHeight / 2,
   }
-  const cx = stageWidth / 2;
-  const cy = stageHeight / 2;
+): { x: number; y: number } {
+  const stageCenterX = stageWidth / 2;
+  const stageCenterY = stageHeight / 2;
   return {
-    x: cx + (sx - cx) / viewZoom,
-    y: cy + (sy - cy) / viewZoom,
+    x: contentCenter.x + (stagePos.x - stageCenterX) / viewZoom,
+    y: contentCenter.y + (stagePos.y - stageCenterY) / viewZoom,
   };
 }

--- a/features/editor/lib/viewZoom.ts
+++ b/features/editor/lib/viewZoom.ts
@@ -2,6 +2,18 @@
  * エディタキャンバス上の「表示のみ」のビュー倍率（論理座標は変えない）
  */
 
+/** 表示パン（ステージ座標系の平行移動量、px）。論理マスク座標は変えない */
+export interface ViewPan {
+  x: number;
+  y: number;
+}
+
+/** パン未適用 */
+export const DEFAULT_VIEW_PAN: ViewPan = { x: 0, y: 0 };
+
+/** パン移動ボタン 1 回あたりの移動量（px） */
+export const VIEW_PAN_NUDGE_PX = 24;
+
 /** 表示ズームの下限・上限・1 ステップ・既定値 */
 export const VIEW_ZOOM = {
   min: 0.5,
@@ -32,29 +44,58 @@ export function roundViewZoomStep(z: number): number {
 }
 
 /**
+ * 表示パンをズームとステージサイズから許容範囲に収める（等倍では常に 0）
+ *
+ * @param pan - パン量（ステージ px）
+ * @param stageWidth - ステージ幅
+ * @param stageHeight - ステージ高さ
+ * @param viewZoom - 表示倍率
+ */
+export function clampViewPan(
+  pan: ViewPan,
+  stageWidth: number,
+  stageHeight: number,
+  viewZoom: number
+): ViewPan {
+  if (viewZoom === 1) {
+    return DEFAULT_VIEW_PAN;
+  }
+  const maxX = (stageWidth * Math.abs(1 - viewZoom)) / 2;
+  const maxY = (stageHeight * Math.abs(1 - viewZoom)) / 2;
+  return {
+    x: Math.min(maxX, Math.max(-maxX, pan.x)),
+    y: Math.min(maxY, Math.max(-maxY, pan.y)),
+  };
+}
+
+/**
  * ステージ座標（ポインタ）を、ズーム前のコンテンツ座標（0…stageWidth / 0…stageHeight）に変換する
  *
- * 表示はステージ中心を原点として `viewZoom` 倍されている想定。Konva の
- * `Group`（`x/y` と `offset` をステージ中心に、`scaleX/Y` = viewZoom）と同じ射影式を使う。
+ * 表示は「パン → ステージ中心を原点として viewZoom 倍」と Konva の
+ * `Group`（外側パン、`x/y`+`offset` で中心ズーム）と同じ射影式を使う。
  *
  * @param stagePos - ステージ上のポインタ座標
  * @param stageWidth - ステージ幅（px）
  * @param stageHeight - ステージ高さ（px）
  * @param viewZoom - 表示倍率（1 = 等倍）
+ * @param viewPan - 表示パン（ステージ px、既定は無移動）
  */
 export function stagePointerToContentSpace(
   stagePos: { x: number; y: number },
   stageWidth: number,
   stageHeight: number,
-  viewZoom: number
+  viewZoom: number,
+  viewPan: ViewPan = DEFAULT_VIEW_PAN
 ): { x: number; y: number } {
+  const sx = stagePos.x - viewPan.x;
+  const sy = stagePos.y - viewPan.y;
   if (viewZoom === 1) {
-    return { x: stagePos.x, y: stagePos.y };
+    return { x: sx, y: sy };
   }
   const cx = stageWidth / 2;
   const cy = stageHeight / 2;
   return {
-    x: cx + (stagePos.x - cx) / viewZoom,
-    y: cy + (stagePos.y - cy) / viewZoom,
+    x: cx + (sx - cx) / viewZoom,
+    y: cy + (sy - cy) / viewZoom,
   };
 }

--- a/features/editor/lib/viewZoom.ts
+++ b/features/editor/lib/viewZoom.ts
@@ -1,0 +1,60 @@
+/**
+ * エディタキャンバス上の「表示のみ」のビュー倍率（論理座標は変えない）
+ */
+
+/** 表示ズームの下限・上限・1 ステップ・既定値 */
+export const VIEW_ZOOM = {
+  min: 0.5,
+  max: 3,
+  step: 0.1,
+  default: 1,
+} as const;
+
+/**
+ * ビュー倍率を許容範囲に収める
+ *
+ * @param z - 入力倍率
+ * @returns クランプ後の倍率
+ */
+export function clampViewZoom(z: number): number {
+  return Math.min(VIEW_ZOOM.max, Math.max(VIEW_ZOOM.min, z));
+}
+
+/**
+ * ステップ刻みに丸める（浮動小数誤差の抑制用）
+ *
+ * @param z - 入力倍率
+ * @returns 0.1 刻みに丸めた倍率（その後クランプ）
+ */
+export function roundViewZoomStep(z: number): number {
+  const rounded = Math.round(z * 10) / 10;
+  return clampViewZoom(rounded);
+}
+
+/**
+ * ステージ座標（ポインタ）を、ズーム前のコンテンツ座標（0…stageWidth / 0…stageHeight）に変換する
+ *
+ * 表示はステージ中心を原点として `viewZoom` 倍されている想定。Konva の
+ * `Group`（`x/y` と `offset` をステージ中心に、`scaleX/Y` = viewZoom）と同じ射影式を使う。
+ *
+ * @param stagePos - ステージ上のポインタ座標
+ * @param stageWidth - ステージ幅（px）
+ * @param stageHeight - ステージ高さ（px）
+ * @param viewZoom - 表示倍率（1 = 等倍）
+ */
+export function stagePointerToContentSpace(
+  stagePos: { x: number; y: number },
+  stageWidth: number,
+  stageHeight: number,
+  viewZoom: number
+): { x: number; y: number } {
+  if (viewZoom === 1) {
+    return { x: stagePos.x, y: stagePos.y };
+  }
+  const cx = stageWidth / 2;
+  const cy = stageHeight / 2;
+  return {
+    x: cx + (stagePos.x - cx) / viewZoom,
+    y: cy + (stagePos.y - cy) / viewZoom,
+  };
+}

--- a/features/editor/lib/viewZoom.ts
+++ b/features/editor/lib/viewZoom.ts
@@ -36,7 +36,8 @@ export function clampViewZoom(z: number): number {
  * @returns 0.1 刻みに丸めた倍率（その後クランプ）
  */
 export function roundViewZoomStep(z: number): number {
-  const rounded = Math.round(z * 10) / 10;
+  const stepScale = Math.round(1 / VIEW_ZOOM.step);
+  const rounded = Math.round(z * stepScale) / stepScale;
   return clampViewZoom(rounded);
 }
 

--- a/features/masking/components/GalleryItem.tsx
+++ b/features/masking/components/GalleryItem.tsx
@@ -321,6 +321,7 @@ export function GalleryItem({
             <div className="relative z-10 px-2 pb-2">
               {imageNaturalWidth > 0 && imageNaturalHeight > 0 && (
                 <EditorCanvas
+                  key={image.id}
                   imageUrl={image.imageUrl}
                   imageNaturalWidth={imageNaturalWidth}
                   imageNaturalHeight={imageNaturalHeight}


### PR DESCRIPTION
## 概要

EditorCanvas に表示ズームと表示移動を追加し、PC/SP の両方で画像の細かな編集をしやすくしました。表示状態は画像座標ベースで保持するように切り替え、ツールバーの変化でズーム表示が戻りにくいよう改善しています。

## 関連Issue

Closes #52

## 変更内容

- [x] 機能追加
- [x] バグ修正
- [x] リファクタリング
- [x] テスト追加・修正
- [ ] ドキュメント修正
- [ ] 設定・環境変更
- [ ] その他

## 主な変更箇所

### UI・コンポーネント

- `features/editor/components/EditorCanvas.tsx`
  - Konva 描画、選択、座標変換の責務に寄せて整理
- `features/editor/components/EditorViewportControls.tsx`
  - `+ / - / 等倍` の表示ズーム UI を追加
  - ズーム時のみ表示移動ボタンを表示
  - SP で収まりやすく、PC で違和感が出にくいレイアウトへ調整
  - ズーム上下限では操作不可状態を明示
- `features/masking/components/GalleryItem.tsx`
  - 画像切替時に `EditorCanvas` を適切に初期化するため `key` を付与

### ロジック・処理

- `features/editor/hooks/useEditorViewport.ts`
  - 表示ズーム、表示中心、ボタン操作、ズーム可能状態を hook に集約
- `features/editor/lib/viewZoom.ts`
  - 表示状態を stage px ベースではなく画像座標ベースの `viewCenter` で保持
  - ズーム倍率のクランプ、表示中心のクランプ、ポインタ逆変換のユーティリティを追加
- `features/editor/lib/viewZoom.test.ts`
  - `viewCenter` ベースの計算ロジックに対する単体テストを追加
- `features/editor/hooks/useEditorViewport.test.ts`
  - `nudgeViewCenter`、`resetViewport`、ズーム上下限のテストを追加

### その他

- なし

## 動作確認

- [x] ローカル環境での動作確認
- [x] テストの実行・通過確認
- [x] UI動作確認
- [x] 既存機能への影響確認
- [ ] ブラウザ動作確認（Chrome / Firefox / Safari）

## スクリーンショット・動画

<!-- UI変更や新機能がある場合、スクリーンショットや動画を添付してください -->

## テスト

### 追加したテスト

- `features/editor/lib/viewZoom.test.ts`
- `features/editor/hooks/useEditorViewport.test.ts`

### テスト結果

- [x] 全てのテストが通過
- [x] 新規テストを追加
- [ ] 既存テストの修正

## 破壊的変更

- [ ] 破壊的変更あり
- [x] 破壊的変更なし

### 破壊的変更の詳細

- なし

## レビューポイント

- 画像座標ベースの `viewCenter` に切り替えたことで、ツールバー表示切替やレイアウト変化があっても表示位置が不自然に戻らないか
- SP での操作ボタン配置と、PC の `md` 以上での見た目のバランス
- 既存の選択・矩形追加・ペイント時の座標変換にズーム表示が正しく反映されているか

## 補足

- 今回はボタンベースの表示ズーム / 表示移動を先に導入しています。PC/SP ごとの操作体系（ホイール・ジェスチャ等）は後続で検討予定です。

## チェックリスト

- [x] コードレビューの準備ができている
- [x] 適切なラベルを付けている
- [x] セルフレビューを実施している
- [x] `pnpm lint` と `pnpm type-check` が通ることを確認した
- [ ] 必要に応じてドキュメントを更新している
