### PR TITLE
refactor(editor): 塗り・スタンプ領域の Konva ノードを分割

### DIFF
--- a/features/editor/components/EditorCanvas.tsx
+++ b/features/editor/components/EditorCanvas.tsx
@@ -2,7 +2,7 @@
 
 import Konva from "konva";
 import type { KonvaEventObject } from "konva/lib/Node";
-import { Fragment, useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   Circle,
   Group,
@@ -23,6 +23,8 @@ import type {
 } from "../types";
 import { stagePointerToContentSpace } from "../lib/viewZoom";
 import { useEditorViewport } from "../hooks/useEditorViewport";
+import { EditorFillRegionNode } from "./EditorFillRegionNode";
+import { EditorStampRegionNode } from "./EditorStampRegionNode";
 import { EditorViewportControls } from "./EditorViewportControls";
 
 interface EditorCanvasProps {
@@ -64,14 +66,6 @@ interface DrawingRect {
 interface DrawingStroke {
   points: { x: number; y: number }[];
 }
-
-/** スタンプ種別ごとの表示色 */
-const STAMP_TYPE_COLORS: Record<StampType, string> = {
-  "fill-black": "#000000",
-  mosaic: "#6b7280",
-  blur: "#93c5fd",
-  "stamp-face": "#fb923c",
-};
 
 /** 矩形描画の最小サイズ閾値（px）。この値以下の矩形は追加しない */
 const MIN_RECT_SIZE = 5;
@@ -120,135 +114,6 @@ function toImageSpace(
  * 選択・矩形追加・ペイントの 3 モードをサポートし、
  * 顔検出・OCR 結果からマスキング領域をインタラクティブに編集できる。
  */
-/**
- * スタンプ画像マップから画像を選択する
- *
- * region.stampFileName が設定されている場合はそれを優先し、
- * 未設定の場合は region.id ハッシュで決定的に選択する。
- *
- * @param region - StampRegion
- * @param stampImages - ファイル名をキーにした HTMLImageElement の Map
- * @returns 選択された HTMLImageElement、見つからない場合は null
- */
-function pickStampImage(
-  region: StampRegion,
-  stampImages: Map<string, HTMLImageElement>
-): HTMLImageElement | null {
-  if (region.stampFileName) {
-    return stampImages.get(region.stampFileName) ?? null;
-  }
-  const values = Array.from(stampImages.values());
-  if (values.length === 0) return null;
-  const idHash = region.id.split("").reduce((acc, char) => (acc * 31 + char.charCodeAt(0)) | 0, 0);
-  return values[Math.abs(idHash) % values.length] ?? null;
-}
-
-/** filters プロパティの要素型（Konva.Filter は v10 では直接エクスポートされないため NodeConfig から取得） */
-type KonvaFilter = NonNullable<Konva.NodeConfig["filters"]>[number];
-
-/** モザイクブロックの最小サイズ（px） */
-const MIN_MOSAIC_BLOCK_SIZE = 3;
-
-/** モザイクブロックサイズ算出用の除数（短辺に対する割合の逆数） */
-const MOSAIC_BLOCK_SIZE_DIVISOR = 24;
-
-/**
- * モザイク（ピクセレーション）プレビュー用 Konva カスタムフィルター
- *
- * ブロックサイズは領域短辺の 1/24（最小 3px）で自動算出する。
- */
-const pixelateFilter: KonvaFilter = function (imageData: ImageData) {
-  const size = Math.max(
-    MIN_MOSAIC_BLOCK_SIZE,
-    Math.round(Math.min(imageData.width, imageData.height) / MOSAIC_BLOCK_SIZE_DIVISOR)
-  );
-  for (let y = 0; y < imageData.height; y += size) {
-    for (let x = 0; x < imageData.width; x += size) {
-      const idx = (y * imageData.width + x) * 4;
-      const r = imageData.data[idx] ?? 0;
-      const g = imageData.data[idx + 1] ?? 0;
-      const b = imageData.data[idx + 2] ?? 0;
-      for (let dy = y; dy < Math.min(y + size, imageData.height); dy++) {
-        for (let dx = x; dx < Math.min(x + size, imageData.width); dx++) {
-          const i = (dy * imageData.width + dx) * 4;
-          imageData.data[i] = r;
-          imageData.data[i + 1] = g;
-          imageData.data[i + 2] = b;
-        }
-      }
-    }
-  }
-};
-
-/**
- * ぼかし・モザイクのリアルタイムプレビューコンポーネント
- *
- * 背景画像を領域でクリップし Konva フィルターを適用してエディタ上でリアルタイムプレビューを表示する。
- * cache() の呼び出しによりフィルターが有効になる。
- *
- * @param kind - エフェクト種別（"blur" | "mosaic"）
- * @param bgImage - 背景画像
- * @param offsetX - グループ内での画像 X オフセット（= -(領域X * scaleX)）
- * @param offsetY - グループ内での画像 Y オフセット（= -(領域Y * scaleY)）
- * @param stageWidth - ステージ幅（px）
- * @param stageHeight - ステージ高さ（px）
- * @param w - 領域の幅（px）
- * @param h - 領域の高さ（px）
- */
-function EffectPreviewGroup({
-  kind,
-  bgImage,
-  offsetX,
-  offsetY,
-  stageWidth,
-  stageHeight,
-  w,
-  h,
-}: {
-  kind: "blur" | "mosaic";
-  bgImage: HTMLImageElement;
-  offsetX: number;
-  offsetY: number;
-  stageWidth: number;
-  stageHeight: number;
-  w: number;
-  h: number;
-}) {
-  const groupRef = useRef<Konva.Group>(null);
-
-  useEffect(() => {
-    const group = groupRef.current;
-    if (!group) return;
-    if (kind === "blur") {
-      group.setAttr("blurRadius", Math.max(4, Math.round(Math.min(w, h) / 8)));
-    }
-    group.clearCache();
-    group.cache({
-      x: 0,
-      y: 0,
-      width: Math.max(1, w),
-      height: Math.max(1, h),
-      pixelRatio: 1,
-    });
-    group.getLayer()?.batchDraw();
-  }, [kind, bgImage, offsetX, offsetY, stageWidth, stageHeight, w, h]);
-
-  const filters = kind === "blur" ? [Konva.Filters.Blur] : [pixelateFilter];
-
-  return (
-    <Group ref={groupRef} clipX={0} clipY={0} clipWidth={w} clipHeight={h} filters={filters}>
-      <KonvaImage
-        image={bgImage}
-        x={offsetX}
-        y={offsetY}
-        width={stageWidth}
-        height={stageHeight}
-        listening={false}
-      />
-    </Group>
-  );
-}
-
 export function EditorCanvas({
   imageUrl,
   imageNaturalWidth,
@@ -627,107 +492,36 @@ export function EditorCanvas({
 
       {/* 塗りつぶし領域 */}
       {fillRegions.map((region) => (
-        <Group
+        <EditorFillRegionNode
           key={region.id}
-          id={region.id}
-          x={region.x * scaleX}
-          y={region.y * scaleY}
-          draggable={isInteractive}
-          onClick={() => isInteractive && onSelectItem(region.id)}
-          onTap={() => isInteractive && onSelectItem(region.id)}
-          onDragEnd={(e) => handleDragEnd(region.id, "fill", e.target)}
-          onTransformEnd={(e) => handleTransformEnd(region.id, "fill", e.target)}
-        >
-          <Rect
-            width={region.width * scaleX}
-            height={region.height * scaleY}
-            fill={region.isEnabled ? "#000000" : undefined}
-            stroke={region.isEnabled ? "#3b82f6" : "#9ca3af"}
-            strokeWidth={1}
-            dash={region.isEnabled ? undefined : [6, 3]}
-            opacity={region.isEnabled ? 1 : 0.6}
-          />
-        </Group>
+          region={region}
+          scaleX={scaleX}
+          scaleY={scaleY}
+          isInteractive={isInteractive}
+          onSelect={() => onSelectItem(region.id)}
+          onDragEnd={(node) => handleDragEnd(region.id, "fill", node)}
+          onTransformEnd={(node) => handleTransformEnd(region.id, "fill", node)}
+        />
       ))}
 
       {/* スタンプ領域 */}
-      {stampRegions.map((region) => {
-        const rx = region.x * scaleX;
-        const ry = region.y * scaleY;
-        const w = region.width * scaleX;
-        const h = region.height * scaleY;
-        const squareStampSize = Math.max(w, h);
-        const squareStampX = (w - squareStampSize) / 2;
-        const squareStampY = (h - squareStampSize) / 2;
-        const stampImg =
-          region.stampType === "stamp-face" ? pickStampImage(region, stampImages) : null;
-        const isEffectStamp =
-          (region.stampType === "blur" || region.stampType === "mosaic") && bgImage !== null;
-        return (
-          <Fragment key={region.id}>
-            {isEffectStamp && (
-              /* blur / mosaic の見た目は操作ノードと分離し、Transformer の計算へ影響させない */
-              <Group x={rx} y={ry} listening={false}>
-                <EffectPreviewGroup
-                  kind={region.stampType as "blur" | "mosaic"}
-                  bgImage={bgImage}
-                  offsetX={-rx}
-                  offsetY={-ry}
-                  stageWidth={stageWidth}
-                  stageHeight={stageHeight}
-                  w={w}
-                  h={h}
-                />
-              </Group>
-            )}
-
-            <Group
-              id={region.id}
-              x={rx}
-              y={ry}
-              draggable={isInteractive}
-              onClick={() => isInteractive && onSelectItem(region.id)}
-              onTap={() => isInteractive && onSelectItem(region.id)}
-              onDragEnd={(e) => handleDragEnd(region.id, "stamp", e.target)}
-              onTransformEnd={(e) => handleTransformEnd(region.id, "stamp", e.target)}
-            >
-              {stampImg ? (
-                /* stamp-face: 顔領域中心を基準に正方形スタンプを表示（旧仕様互換） */
-                <KonvaImage
-                  image={stampImg}
-                  x={squareStampX}
-                  y={squareStampY}
-                  width={squareStampSize}
-                  height={squareStampSize}
-                  opacity={region.isEnabled ? 1 : 0.4}
-                  stroke={selectedId === region.id ? "#1d4ed8" : "#6b7280"}
-                  strokeWidth={1}
-                />
-              ) : isEffectStamp ? (
-                /* blur / mosaic: クリック/変形用の矩形ハンドル */
-                <Rect
-                  width={w}
-                  height={h}
-                  fill="rgba(0,0,0,0.001)"
-                  stroke={selectedId === region.id ? "#1d4ed8" : "#6b7280"}
-                  strokeWidth={1}
-                  listening={true}
-                />
-              ) : (
-                /* fill-black またはフォールバック: 不透明な塗りつぶし矩形 */
-                <Rect
-                  width={w}
-                  height={h}
-                  fill={STAMP_TYPE_COLORS[region.stampType]}
-                  opacity={1}
-                  stroke={selectedId === region.id ? "#1d4ed8" : "#6b7280"}
-                  strokeWidth={1}
-                />
-              )}
-            </Group>
-          </Fragment>
-        );
-      })}
+      {stampRegions.map((region) => (
+        <EditorStampRegionNode
+          key={region.id}
+          region={region}
+          scaleX={scaleX}
+          scaleY={scaleY}
+          isInteractive={isInteractive}
+          selected={selectedId === region.id}
+          stampImages={stampImages}
+          bgImage={bgImage}
+          stageWidth={stageWidth}
+          stageHeight={stageHeight}
+          onSelect={() => onSelectItem(region.id)}
+          onDragEnd={(node) => handleDragEnd(region.id, "stamp", node)}
+          onTransformEnd={(node) => handleTransformEnd(region.id, "stamp", node)}
+        />
+      ))}
 
       {/* ペイントストローク */}
       {paintStrokes.map((stroke) => (

--- a/features/editor/components/EditorFillRegionNode.tsx
+++ b/features/editor/components/EditorFillRegionNode.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import Konva from "konva";
+import { Group, Rect } from "react-konva";
+import type { FillRegion } from "../types";
+
+export interface EditorFillRegionNodeProps {
+  region: FillRegion;
+  scaleX: number;
+  scaleY: number;
+  isInteractive: boolean;
+  onSelect: () => void;
+  onDragEnd: (node: Konva.Node) => void;
+  onTransformEnd: (node: Konva.Node) => void;
+}
+
+/**
+ * 塗りつぶし（黒塗り）領域 1 件分の Konva ノード
+ */
+export function EditorFillRegionNode({
+  region,
+  scaleX,
+  scaleY,
+  isInteractive,
+  onSelect,
+  onDragEnd,
+  onTransformEnd,
+}: EditorFillRegionNodeProps) {
+  return (
+    <Group
+      id={region.id}
+      x={region.x * scaleX}
+      y={region.y * scaleY}
+      draggable={isInteractive}
+      onClick={() => isInteractive && onSelect()}
+      onTap={() => isInteractive && onSelect()}
+      onDragEnd={(e) => onDragEnd(e.target)}
+      onTransformEnd={(e) => onTransformEnd(e.target)}
+    >
+      <Rect
+        width={region.width * scaleX}
+        height={region.height * scaleY}
+        fill={region.isEnabled ? "#000000" : undefined}
+        stroke={region.isEnabled ? "#3b82f6" : "#9ca3af"}
+        strokeWidth={1}
+        dash={region.isEnabled ? undefined : [6, 3]}
+        opacity={region.isEnabled ? 1 : 0.6}
+      />
+    </Group>
+  );
+}

--- a/features/editor/components/EditorStampEffectPreview.tsx
+++ b/features/editor/components/EditorStampEffectPreview.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import Konva from "konva";
+import { useEffect, useRef } from "react";
+import { Group, Image as KonvaImage } from "react-konva";
+
+/** filters プロパティの要素型（Konva.Filter は v10 では直接エクスポートされないため NodeConfig から取得） */
+type KonvaFilter = NonNullable<Konva.NodeConfig["filters"]>[number];
+
+/** モザイクブロックの最小サイズ（px） */
+const MIN_MOSAIC_BLOCK_SIZE = 3;
+
+/** モザイクブロックサイズ算出用の除数（短辺に対する割合の逆数） */
+const MOSAIC_BLOCK_SIZE_DIVISOR = 24;
+
+/**
+ * モザイク（ピクセレーション）プレビュー用 Konva カスタムフィルター
+ *
+ * ブロックサイズは領域短辺の 1/24（最小 3px）で自動算出する。
+ */
+const pixelateFilter: KonvaFilter = function (imageData: ImageData) {
+  const size = Math.max(
+    MIN_MOSAIC_BLOCK_SIZE,
+    Math.round(Math.min(imageData.width, imageData.height) / MOSAIC_BLOCK_SIZE_DIVISOR)
+  );
+  for (let y = 0; y < imageData.height; y += size) {
+    for (let x = 0; x < imageData.width; x += size) {
+      const idx = (y * imageData.width + x) * 4;
+      const r = imageData.data[idx] ?? 0;
+      const g = imageData.data[idx + 1] ?? 0;
+      const b = imageData.data[idx + 2] ?? 0;
+      for (let dy = y; dy < Math.min(y + size, imageData.height); dy++) {
+        for (let dx = x; dx < Math.min(x + size, imageData.width); dx++) {
+          const i = (dy * imageData.width + dx) * 4;
+          imageData.data[i] = r;
+          imageData.data[i + 1] = g;
+          imageData.data[i + 2] = b;
+        }
+      }
+    }
+  }
+};
+
+export interface EditorStampEffectPreviewProps {
+  kind: "blur" | "mosaic";
+  bgImage: HTMLImageElement;
+  /** グループ内での画像 X オフセット（= -(領域X * scaleX)） */
+  offsetX: number;
+  /** グループ内での画像 Y オフセット（= -(領域Y * scaleY)） */
+  offsetY: number;
+  stageWidth: number;
+  stageHeight: number;
+  w: number;
+  h: number;
+}
+
+/**
+ * ぼかし・モザイクのリアルタイムプレビュー
+ *
+ * 背景画像を領域でクリップし Konva フィルターを適用してエディタ上で表示する。
+ */
+export function EditorStampEffectPreview({
+  kind,
+  bgImage,
+  offsetX,
+  offsetY,
+  stageWidth,
+  stageHeight,
+  w,
+  h,
+}: EditorStampEffectPreviewProps) {
+  const groupRef = useRef<Konva.Group>(null);
+
+  useEffect(() => {
+    const group = groupRef.current;
+    if (!group) return;
+    if (kind === "blur") {
+      group.setAttr("blurRadius", Math.max(4, Math.round(Math.min(w, h) / 8)));
+    }
+    group.clearCache();
+    group.cache({
+      x: 0,
+      y: 0,
+      width: Math.max(1, w),
+      height: Math.max(1, h),
+      pixelRatio: 1,
+    });
+    group.getLayer()?.batchDraw();
+  }, [kind, bgImage, offsetX, offsetY, stageWidth, stageHeight, w, h]);
+
+  const filters = kind === "blur" ? [Konva.Filters.Blur] : [pixelateFilter];
+
+  return (
+    <Group ref={groupRef} clipX={0} clipY={0} clipWidth={w} clipHeight={h} filters={filters}>
+      <KonvaImage
+        image={bgImage}
+        x={offsetX}
+        y={offsetY}
+        width={stageWidth}
+        height={stageHeight}
+        listening={false}
+      />
+    </Group>
+  );
+}

--- a/features/editor/components/EditorStampRegionNode.tsx
+++ b/features/editor/components/EditorStampRegionNode.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import Konva from "konva";
+import { Fragment } from "react";
+import { Group, Image as KonvaImage, Rect } from "react-konva";
+import { pickStampImage } from "../lib/pickStampImage";
+import type { StampRegion, StampType } from "../types";
+import { EditorStampEffectPreview } from "./EditorStampEffectPreview";
+
+/** スタンプ種別ごとの表示色（不透明矩形フォールバック用） */
+const STAMP_TYPE_COLORS: Record<StampType, string> = {
+  "fill-black": "#000000",
+  mosaic: "#6b7280",
+  blur: "#93c5fd",
+  "stamp-face": "#fb923c",
+};
+
+export interface EditorStampRegionNodeProps {
+  region: StampRegion;
+  scaleX: number;
+  scaleY: number;
+  isInteractive: boolean;
+  selected: boolean;
+  stampImages: Map<string, HTMLImageElement>;
+  bgImage: HTMLImageElement | null;
+  stageWidth: number;
+  stageHeight: number;
+  onSelect: () => void;
+  onDragEnd: (node: Konva.Node) => void;
+  onTransformEnd: (node: Konva.Node) => void;
+}
+
+/**
+ * スタンプ領域 1 件分の Konva ノード（エフェクトプレビュー付き）
+ */
+export function EditorStampRegionNode({
+  region,
+  scaleX,
+  scaleY,
+  isInteractive,
+  selected,
+  stampImages,
+  bgImage,
+  stageWidth,
+  stageHeight,
+  onSelect,
+  onDragEnd,
+  onTransformEnd,
+}: EditorStampRegionNodeProps) {
+  const rx = region.x * scaleX;
+  const ry = region.y * scaleY;
+  const w = region.width * scaleX;
+  const h = region.height * scaleY;
+  const squareStampSize = Math.max(w, h);
+  const squareStampX = (w - squareStampSize) / 2;
+  const squareStampY = (h - squareStampSize) / 2;
+  const stampImg = region.stampType === "stamp-face" ? pickStampImage(region, stampImages) : null;
+  const isEffectStamp =
+    (region.stampType === "blur" || region.stampType === "mosaic") && bgImage !== null;
+  const strokeColor = selected ? "#1d4ed8" : "#6b7280";
+
+  return (
+    <Fragment>
+      {isEffectStamp && (
+        /* blur / mosaic の見た目は操作ノードと分離し、Transformer の計算へ影響させない */
+        <Group x={rx} y={ry} listening={false}>
+          <EditorStampEffectPreview
+            kind={region.stampType as "blur" | "mosaic"}
+            bgImage={bgImage}
+            offsetX={-rx}
+            offsetY={-ry}
+            stageWidth={stageWidth}
+            stageHeight={stageHeight}
+            w={w}
+            h={h}
+          />
+        </Group>
+      )}
+
+      <Group
+        id={region.id}
+        x={rx}
+        y={ry}
+        draggable={isInteractive}
+        onClick={() => isInteractive && onSelect()}
+        onTap={() => isInteractive && onSelect()}
+        onDragEnd={(e) => onDragEnd(e.target)}
+        onTransformEnd={(e) => onTransformEnd(e.target)}
+      >
+        {stampImg ? (
+          /* stamp-face: 顔領域中心を基準に正方形スタンプを表示（旧仕様互換） */
+          <KonvaImage
+            image={stampImg}
+            x={squareStampX}
+            y={squareStampY}
+            width={squareStampSize}
+            height={squareStampSize}
+            opacity={region.isEnabled ? 1 : 0.4}
+            stroke={strokeColor}
+            strokeWidth={1}
+          />
+        ) : isEffectStamp ? (
+          /* blur / mosaic: クリック/変形用の矩形ハンドル */
+          <Rect
+            width={w}
+            height={h}
+            fill="rgba(0,0,0,0.001)"
+            stroke={strokeColor}
+            strokeWidth={1}
+            listening={true}
+          />
+        ) : (
+          /* fill-black またはフォールバック: 不透明な塗りつぶし矩形 */
+          <Rect
+            width={w}
+            height={h}
+            fill={STAMP_TYPE_COLORS[region.stampType]}
+            opacity={1}
+            stroke={strokeColor}
+            strokeWidth={1}
+          />
+        )}
+      </Group>
+    </Fragment>
+  );
+}

--- a/features/editor/lib/pickStampImage.test.ts
+++ b/features/editor/lib/pickStampImage.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import type { StampRegion } from "../types";
+import { pickStampImage } from "./pickStampImage";
+
+describe("pickStampImage", () => {
+  it("stampFileName があればそのキーの画像を返す", () => {
+    const img = new Image();
+    const region: StampRegion = {
+      id: "a",
+      x: 0,
+      y: 0,
+      width: 10,
+      height: 10,
+      stampType: "stamp-face",
+      stampFileName: "face.png",
+      isEnabled: true,
+      source: "manual",
+    };
+    const map = new Map([["face.png", img]]);
+    expect(pickStampImage(region, map)).toBe(img);
+  });
+
+  it("stampFileName が無ければ id ハッシュで決定的に選択する", () => {
+    const img0 = new Image();
+    const img1 = new Image();
+    const region: StampRegion = {
+      id: "stable-id",
+      x: 0,
+      y: 0,
+      width: 10,
+      height: 10,
+      stampType: "stamp-face",
+      isEnabled: true,
+      source: "manual",
+    };
+    const map = new Map<string, HTMLImageElement>([
+      ["a", img0],
+      ["b", img1],
+    ]);
+    const first = pickStampImage(region, map);
+    expect([img0, img1]).toContain(first);
+    expect(pickStampImage(region, map)).toBe(first);
+  });
+
+  it("マップが空なら null", () => {
+    const region: StampRegion = {
+      id: "x",
+      x: 0,
+      y: 0,
+      width: 1,
+      height: 1,
+      stampType: "stamp-face",
+      isEnabled: true,
+      source: "manual",
+    };
+    expect(pickStampImage(region, new Map())).toBeNull();
+  });
+});

--- a/features/editor/lib/pickStampImage.ts
+++ b/features/editor/lib/pickStampImage.ts
@@ -1,0 +1,24 @@
+import type { StampRegion } from "../types";
+
+/**
+ * スタンプ画像マップから画像を選択する
+ *
+ * region.stampFileName が設定されている場合はそれを優先し、
+ * 未設定の場合は region.id ハッシュで決定的に選択する。
+ *
+ * @param region - StampRegion
+ * @param stampImages - ファイル名をキーにした HTMLImageElement の Map
+ * @returns 選択された HTMLImageElement、見つからない場合は null
+ */
+export function pickStampImage(
+  region: StampRegion,
+  stampImages: Map<string, HTMLImageElement>
+): HTMLImageElement | null {
+  if (region.stampFileName) {
+    return stampImages.get(region.stampFileName) ?? null;
+  }
+  const values = Array.from(stampImages.values());
+  if (values.length === 0) return null;
+  const idHash = region.id.split("").reduce((acc, char) => (acc * 31 + char.charCodeAt(0)) | 0, 0);
+  return values[Math.abs(idHash) % values.length] ?? null;
+}


### PR DESCRIPTION
## 概要

#53 マージ後の `EditorCanvas` を読みやすくするため、塗りつぶし・スタンプ（含むぼかし・モザイクプレビュー）を専用コンポーネントおよび `pickStampImage` の lib に切り出しました。挙動の変更は意図していません。

## 関連Issue

なし（#52 / #53 のフォローアップのリファクタです）。

## 変更内容

- [ ] 機能追加
- [ ] バグ修正
- [x] リファクタリング
- [x] テスト追加・修正
- [ ] ドキュメント修正
- [ ] 設定・環境変更
- [ ] その他

## 主な変更箇所

### UI・コンポーネント

- `EditorFillRegionNode` / `EditorStampRegionNode` / `EditorStampEffectPreview` を新設し、`EditorCanvas` のマッピング部分を削減。

### ロジック・処理

- `pickStampImage` を `features/editor/lib/pickStampImage.ts` に移動し単体テストを追加。

### その他

- 変更対象ファイルは Konva / スタンプ関連に限定。

## 動作確認

- [x] テストの実行・通過確認（`pnpm test:run features/editor/lib/pickStampImage.test.ts`）
- [x] `pnpm lint` と `pnpm type-check` が通ることを確認（pre-commit と同等）

## 追加したテスト

- `features/editor/lib/pickStampImage.test.ts`（ファイル名優先・ハッシュによる決定論・空マップ）

## 破壊的変更

- [ ] 破壊的変更あり
- [x] 破壊的変更なし

## レビューポイント

- 子コンポーネントへ渡しているコールバック（選択・ドラッグ・変形終了）の閉じ方と、`EditorStampRegionNode` 内の `stamp-face` / エフェクト / 不透明矩形の分岐が従来と一致しているか。

## チェックリスト

- [x] セルフレビューを実施している
- [x] `pnpm lint` と `pnpm type-check` が通ることを確認した