### PR TITLE
エディタ: スタンプ画像用カスタムピッカー

### DIFF
--- a/features/editor/components/EditorToolbar.tsx
+++ b/features/editor/components/EditorToolbar.tsx
@@ -6,6 +6,7 @@ import type React from "react";
 import type { LucideProps } from "lucide-react";
 import type { StampCatalogEntry } from "../constants";
 import type { EditorMode, StampType } from "../types";
+import { StampFacePicker } from "./StampFacePicker";
 import { StampTypeSelector } from "./StampTypeSelector";
 
 interface EditorToolbarProps {
@@ -63,7 +64,6 @@ export function EditorToolbar({
   onDeleteSelected,
 }: EditorToolbarProps) {
   const showStampControls = mode === "rect" || isStampSelected;
-  const selectedStampEntry = stampCatalog.find((entry) => entry.fileName === selectedStampFileName);
 
   return (
     <div className="rounded-lg border border-zinc-200 bg-zinc-50 px-2 py-1.5">
@@ -94,22 +94,12 @@ export function EditorToolbar({
           <>
             <Divider />
             <StampTypeSelector value={selectedStampType} onChange={onStampTypeChange} />
-            {selectedStampType === "stamp-face" && stampCatalog.length > 0 && (
-              <select
+            {selectedStampType === "stamp-face" && (
+              <StampFacePicker
+                catalog={stampCatalog}
                 value={selectedStampFileName}
-                onChange={(e) => onStampFileNameChange(e.target.value)}
-                aria-label={
-                  selectedStampEntry ? `スタンプ: ${selectedStampEntry.label}` : "スタンプ画像"
-                }
-                title={selectedStampEntry?.label}
-                className="w-12 shrink-0 rounded-md border border-zinc-300 bg-white px-1 py-1.5 text-center text-base shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-              >
-                {stampCatalog.map(({ fileName, emoji }) => (
-                  <option key={fileName} value={fileName}>
-                    {emoji}
-                  </option>
-                ))}
-              </select>
+                onChange={onStampFileNameChange}
+              />
             )}
           </>
         )}

--- a/features/editor/components/StampFacePicker.test.tsx
+++ b/features/editor/components/StampFacePicker.test.tsx
@@ -9,6 +9,11 @@ const CATALOG: readonly StampCatalogEntry[] = [
   { fileName: "b.png", emoji: "😂", label: "爆笑" },
 ];
 
+/** スタンプピッカーのトリガー（combobox） */
+function getTrigger(label: string) {
+  return screen.getByRole("combobox", { name: `スタンプ: ${label}` });
+}
+
 describe("StampFacePicker", () => {
   it("catalog が空のときは何も表示しない", () => {
     const { container } = render(<StampFacePicker catalog={[]} value="" onChange={vi.fn()} />);
@@ -17,12 +22,12 @@ describe("StampFacePicker", () => {
 
   it("選択中スタンプの絵文字をトリガーに表示する", () => {
     render(<StampFacePicker catalog={CATALOG} value="b.png" onChange={vi.fn()} />);
-    expect(screen.getByRole("button", { name: "スタンプ: 爆笑" })).toHaveTextContent("😂");
+    expect(getTrigger("爆笑")).toHaveTextContent("😂");
   });
 
   it("トリガーをクリックするとラベル付き一覧を表示する", async () => {
     render(<StampFacePicker catalog={CATALOG} value="a.png" onChange={vi.fn()} />);
-    await userEvent.click(screen.getByRole("button", { name: "スタンプ: 笑顔" }));
+    await userEvent.click(getTrigger("笑顔"));
     expect(screen.getByRole("listbox", { name: "スタンプ画像" })).toBeInTheDocument();
     expect(screen.getByText("笑顔")).toBeInTheDocument();
     expect(screen.getByText("爆笑")).toBeInTheDocument();
@@ -31,7 +36,7 @@ describe("StampFacePicker", () => {
   it("一覧から選択すると onChange が呼ばれ一覧が閉じる", async () => {
     const onChange = vi.fn();
     render(<StampFacePicker catalog={CATALOG} value="a.png" onChange={onChange} />);
-    await userEvent.click(screen.getByRole("button", { name: "スタンプ: 笑顔" }));
+    await userEvent.click(getTrigger("笑顔"));
     await userEvent.click(screen.getByText("爆笑"));
     expect(onChange).toHaveBeenCalledWith("b.png");
     expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
@@ -39,9 +44,47 @@ describe("StampFacePicker", () => {
 
   it("Escape で一覧を閉じる", async () => {
     render(<StampFacePicker catalog={CATALOG} value="a.png" onChange={vi.fn()} />);
-    await userEvent.click(screen.getByRole("button", { name: "スタンプ: 笑顔" }));
+    await userEvent.click(getTrigger("笑顔"));
     expect(screen.getByRole("listbox")).toBeInTheDocument();
     await userEvent.keyboard("{Escape}");
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+  });
+
+  it("開いているとき aria-activedescendant が active option を指す", async () => {
+    render(<StampFacePicker catalog={CATALOG} value="a.png" onChange={vi.fn()} />);
+    const trigger = getTrigger("笑顔");
+    await userEvent.click(trigger);
+    const firstOption = screen.getByRole("option", { name: /笑顔/ });
+    expect(trigger).toHaveAttribute("aria-activedescendant", firstOption.id);
+    await userEvent.keyboard("{ArrowDown}");
+    const secondOption = screen.getByRole("option", { name: /爆笑/ });
+    expect(trigger).toHaveAttribute("aria-activedescendant", secondOption.id);
+  });
+
+  it("ArrowDown と Enter で次の項目を選択する", async () => {
+    const onChange = vi.fn();
+    render(<StampFacePicker catalog={CATALOG} value="a.png" onChange={onChange} />);
+    await userEvent.click(getTrigger("笑顔"));
+    await userEvent.keyboard("{ArrowDown}");
+    await userEvent.keyboard("{Enter}");
+    expect(onChange).toHaveBeenCalledWith("b.png");
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+  });
+
+  it("Space で active 項目を確定する", async () => {
+    const onChange = vi.fn();
+    render(<StampFacePicker catalog={CATALOG} value="a.png" onChange={onChange} />);
+    await userEvent.click(getTrigger("笑顔"));
+    await userEvent.keyboard(" ");
+    expect(onChange).toHaveBeenCalledWith("a.png");
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+  });
+
+  it("外側クリックで一覧を閉じる", async () => {
+    render(<StampFacePicker catalog={CATALOG} value="a.png" onChange={vi.fn()} />);
+    await userEvent.click(getTrigger("笑顔"));
+    expect(screen.getByRole("listbox")).toBeInTheDocument();
+    await userEvent.click(document.body);
     expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
   });
 });

--- a/features/editor/components/StampFacePicker.test.tsx
+++ b/features/editor/components/StampFacePicker.test.tsx
@@ -103,6 +103,22 @@ describe("StampFacePicker", () => {
     expect(trigger).toHaveAttribute("aria-activedescendant", firstOption.id);
   });
 
+  it("開いている間に catalog が短くなったら activeIndex を補正する", async () => {
+    const shortCatalog: readonly StampCatalogEntry[] = [CATALOG[0]];
+    const { rerender } = render(
+      <StampFacePicker catalog={CATALOG} value="a.png" onChange={vi.fn()} />
+    );
+    const trigger = getTrigger("笑顔");
+    await userEvent.click(trigger);
+    await userEvent.keyboard("{ArrowDown}");
+    const secondOption = screen.getByRole("option", { name: /爆笑/ });
+    expect(trigger).toHaveAttribute("aria-activedescendant", secondOption.id);
+
+    rerender(<StampFacePicker catalog={shortCatalog} value="a.png" onChange={vi.fn()} />);
+    const onlyOption = screen.getByRole("option", { name: /笑顔/ });
+    expect(trigger).toHaveAttribute("aria-activedescendant", onlyOption.id);
+  });
+
   it("開いている間に catalog が空になったら一覧を閉じる", async () => {
     const { rerender } = render(
       <StampFacePicker catalog={CATALOG} value="a.png" onChange={vi.fn()} />

--- a/features/editor/components/StampFacePicker.test.tsx
+++ b/features/editor/components/StampFacePicker.test.tsx
@@ -87,4 +87,30 @@ describe("StampFacePicker", () => {
     await userEvent.click(document.body);
     expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
   });
+
+  it("一覧表示中、ピッカー外にフォーカスがあるとき矢印キーを奪わない", async () => {
+    render(
+      <div>
+        <StampFacePicker catalog={CATALOG} value="a.png" onChange={vi.fn()} />
+        <button type="button">他のボタン</button>
+      </div>
+    );
+    const trigger = getTrigger("笑顔");
+    await userEvent.click(trigger);
+    const firstOption = screen.getByRole("option", { name: /笑顔/ });
+    await userEvent.tab();
+    await userEvent.keyboard("{ArrowDown}");
+    expect(trigger).toHaveAttribute("aria-activedescendant", firstOption.id);
+  });
+
+  it("開いている間に catalog が空になったら一覧を閉じる", async () => {
+    const { rerender } = render(
+      <StampFacePicker catalog={CATALOG} value="a.png" onChange={vi.fn()} />
+    );
+    await userEvent.click(getTrigger("笑顔"));
+    expect(screen.getByRole("listbox")).toBeInTheDocument();
+    rerender(<StampFacePicker catalog={[]} value="a.png" onChange={vi.fn()} />);
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+    expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
+  });
 });

--- a/features/editor/components/StampFacePicker.test.tsx
+++ b/features/editor/components/StampFacePicker.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import type { StampCatalogEntry } from "../constants";
+import { StampFacePicker } from "./StampFacePicker";
+
+const CATALOG: readonly StampCatalogEntry[] = [
+  { fileName: "a.png", emoji: "😀", label: "笑顔" },
+  { fileName: "b.png", emoji: "😂", label: "爆笑" },
+];
+
+describe("StampFacePicker", () => {
+  it("catalog が空のときは何も表示しない", () => {
+    const { container } = render(<StampFacePicker catalog={[]} value="" onChange={vi.fn()} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("選択中スタンプの絵文字をトリガーに表示する", () => {
+    render(<StampFacePicker catalog={CATALOG} value="b.png" onChange={vi.fn()} />);
+    expect(screen.getByRole("button", { name: "スタンプ: 爆笑" })).toHaveTextContent("😂");
+  });
+
+  it("トリガーをクリックするとラベル付き一覧を表示する", async () => {
+    render(<StampFacePicker catalog={CATALOG} value="a.png" onChange={vi.fn()} />);
+    await userEvent.click(screen.getByRole("button", { name: "スタンプ: 笑顔" }));
+    expect(screen.getByRole("listbox", { name: "スタンプ画像" })).toBeInTheDocument();
+    expect(screen.getByText("笑顔")).toBeInTheDocument();
+    expect(screen.getByText("爆笑")).toBeInTheDocument();
+  });
+
+  it("一覧から選択すると onChange が呼ばれ一覧が閉じる", async () => {
+    const onChange = vi.fn();
+    render(<StampFacePicker catalog={CATALOG} value="a.png" onChange={onChange} />);
+    await userEvent.click(screen.getByRole("button", { name: "スタンプ: 笑顔" }));
+    await userEvent.click(screen.getByText("爆笑"));
+    expect(onChange).toHaveBeenCalledWith("b.png");
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+  });
+
+  it("Escape で一覧を閉じる", async () => {
+    render(<StampFacePicker catalog={CATALOG} value="a.png" onChange={vi.fn()} />);
+    await userEvent.click(screen.getByRole("button", { name: "スタンプ: 笑顔" }));
+    expect(screen.getByRole("listbox")).toBeInTheDocument();
+    await userEvent.keyboard("{Escape}");
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+  });
+});

--- a/features/editor/components/StampFacePicker.tsx
+++ b/features/editor/components/StampFacePicker.tsx
@@ -67,50 +67,6 @@ export function StampFacePicker({ catalog, value, onChange }: StampFacePickerPro
   }, [open]);
 
   useEffect(() => {
-    if (!open) return;
-
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") {
-        event.preventDefault();
-        setOpen(false);
-        return;
-      }
-      if (event.key === "ArrowDown") {
-        event.preventDefault();
-        const { length } = catalogRef.current;
-        setActiveIndex((index) => {
-          const next = (index + 1) % length;
-          activeIndexRef.current = next;
-          return next;
-        });
-        return;
-      }
-      if (event.key === "ArrowUp") {
-        event.preventDefault();
-        const { length } = catalogRef.current;
-        setActiveIndex((index) => {
-          const next = (index - 1 + length) % length;
-          activeIndexRef.current = next;
-          return next;
-        });
-        return;
-      }
-      if (event.key === "Enter" || event.key === " ") {
-        event.preventDefault();
-        const entry = catalogRef.current[activeIndexRef.current];
-        if (!entry) return;
-        onChangeRef.current(entry.fileName);
-        setOpen(false);
-      }
-    };
-
-    document.addEventListener("keydown", handleKeyDown);
-    return () => {
-      document.removeEventListener("keydown", handleKeyDown);
-    };
-  }, [open]);
-
-  useEffect(() => {
     if (!open || !listRef.current) return;
     const option = listRef.current.querySelector<HTMLElement>(`[data-index="${activeIndex}"]`);
     option?.scrollIntoView?.({ block: "nearest" });
@@ -124,12 +80,52 @@ export function StampFacePicker({ catalog, value, onChange }: StampFacePickerPro
     [onChange]
   );
 
-  const handleTriggerKeyDown = useCallback(
+  const handleComboboxKeyDown = useCallback(
     (event: React.KeyboardEvent<HTMLButtonElement>) => {
-      if (open) return;
-      if (event.key === "ArrowDown" || event.key === "Enter" || event.key === " ") {
+      if (!open) {
+        if (event.key === "ArrowDown" || event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          openList();
+        }
+        return;
+      }
+
+      if (event.key === "Escape") {
         event.preventDefault();
-        openList();
+        setOpen(false);
+        return;
+      }
+
+      const { length } = catalogRef.current;
+      if (length === 0) {
+        setOpen(false);
+        return;
+      }
+
+      if (event.key === "ArrowDown") {
+        event.preventDefault();
+        setActiveIndex((index) => {
+          const next = (index + 1) % length;
+          activeIndexRef.current = next;
+          return next;
+        });
+        return;
+      }
+      if (event.key === "ArrowUp") {
+        event.preventDefault();
+        setActiveIndex((index) => {
+          const next = (index - 1 + length) % length;
+          activeIndexRef.current = next;
+          return next;
+        });
+        return;
+      }
+      if (event.key === "Enter" || event.key === " ") {
+        event.preventDefault();
+        const entry = catalogRef.current[activeIndexRef.current];
+        if (!entry) return;
+        onChangeRef.current(entry.fileName);
+        setOpen(false);
       }
     },
     [open, openList]
@@ -157,7 +153,7 @@ export function StampFacePicker({ catalog, value, onChange }: StampFacePickerPro
             openList();
           }
         }}
-        onKeyDown={handleTriggerKeyDown}
+        onKeyDown={handleComboboxKeyDown}
         className={clsx([
           "flex items-center gap-0.5 rounded-md border border-zinc-300 bg-white px-1.5 py-1.5 shadow-sm",
           "hover:bg-zinc-50 focus:outline-none focus:ring-2 focus:ring-blue-500",

--- a/features/editor/components/StampFacePicker.tsx
+++ b/features/editor/components/StampFacePicker.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+import clsx from "clsx";
+import { ChevronDown } from "lucide-react";
+import type React from "react";
+import { useCallback, useEffect, useId, useRef, useState } from "react";
+import type { StampCatalogEntry } from "../constants";
+
+interface StampFacePickerProps {
+  catalog: readonly StampCatalogEntry[];
+  value: string;
+  onChange: (fileName: string) => void;
+}
+
+/**
+ * スタンプ画像選択ピッカー
+ *
+ * トリガーは絵文字のみのコンパクト表示。一覧では絵文字とラベルを表示する。
+ */
+export function StampFacePicker({ catalog, value, onChange }: StampFacePickerProps) {
+  const [open, setOpen] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(0);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const listRef = useRef<HTMLUListElement>(null);
+  const listboxId = useId();
+
+  const selectedIndex = catalog.findIndex((entry) => entry.fileName === value);
+  const selected = catalog[selectedIndex >= 0 ? selectedIndex : 0];
+
+  const openList = useCallback(() => {
+    setActiveIndex(selectedIndex >= 0 ? selectedIndex : 0);
+    setOpen(true);
+  }, [selectedIndex]);
+
+  useEffect(() => {
+    if (!open) return;
+
+    const handlePointerDown = (event: MouseEvent) => {
+      if (containerRef.current?.contains(event.target as Node)) return;
+      setOpen(false);
+    };
+
+    document.addEventListener("mousedown", handlePointerDown);
+    return () => {
+      document.removeEventListener("mousedown", handlePointerDown);
+    };
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        setOpen(false);
+        return;
+      }
+      if (event.key === "ArrowDown") {
+        event.preventDefault();
+        setActiveIndex((index) => (index + 1) % catalog.length);
+        return;
+      }
+      if (event.key === "ArrowUp") {
+        event.preventDefault();
+        setActiveIndex((index) => (index - 1 + catalog.length) % catalog.length);
+        return;
+      }
+      if (event.key === "Enter" || event.key === " ") {
+        event.preventDefault();
+        const entry = catalog[activeIndex];
+        if (!entry) return;
+        onChange(entry.fileName);
+        setOpen(false);
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [open, activeIndex, catalog, onChange]);
+
+  useEffect(() => {
+    if (!open || !listRef.current) return;
+    const option = listRef.current.querySelector<HTMLElement>(`[data-index="${activeIndex}"]`);
+    option?.scrollIntoView?.({ block: "nearest" });
+  }, [activeIndex, open]);
+
+  const handleSelect = useCallback(
+    (fileName: string) => {
+      onChange(fileName);
+      setOpen(false);
+    },
+    [onChange]
+  );
+
+  const handleTriggerKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLButtonElement>) => {
+      if (open) return;
+      if (event.key === "ArrowDown" || event.key === "Enter" || event.key === " ") {
+        event.preventDefault();
+        openList();
+      }
+    },
+    [open, openList]
+  );
+
+  if (catalog.length === 0) return null;
+
+  return (
+    <div ref={containerRef} className="relative shrink-0">
+      <button
+        type="button"
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        aria-controls={open ? listboxId : undefined}
+        aria-label={selected ? `スタンプ: ${selected.label}` : "スタンプ画像"}
+        onClick={() => {
+          if (open) {
+            setOpen(false);
+          } else {
+            openList();
+          }
+        }}
+        onKeyDown={handleTriggerKeyDown}
+        className={clsx([
+          "flex items-center gap-0.5 rounded-md border border-zinc-300 bg-white px-1.5 py-1.5 shadow-sm",
+          "hover:bg-zinc-50 focus:outline-none focus:ring-2 focus:ring-blue-500",
+        ])}
+      >
+        <span className="text-base leading-none" aria-hidden="true">
+          {selected?.emoji ?? "?"}
+        </span>
+        <ChevronDown size={14} className="text-zinc-500" aria-hidden="true" />
+      </button>
+
+      {open && (
+        <ul
+          ref={listRef}
+          id={listboxId}
+          role="listbox"
+          aria-label="スタンプ画像"
+          className="absolute top-full left-0 z-50 mt-1 max-h-48 w-56 overflow-y-auto rounded-md border border-zinc-200 bg-white py-1 shadow-lg"
+        >
+          {catalog.map((entry, index) => (
+            <li
+              key={entry.fileName}
+              role="option"
+              aria-selected={entry.fileName === value}
+              data-index={index}
+              className={clsx([
+                "flex cursor-pointer items-center gap-2 px-2 py-2 text-sm text-zinc-700",
+                entry.fileName === value && "bg-blue-50",
+                index === activeIndex && entry.fileName !== value && "bg-zinc-100",
+                index === activeIndex && entry.fileName === value && "bg-blue-100",
+              ])}
+              onMouseEnter={() => setActiveIndex(index)}
+              onClick={() => handleSelect(entry.fileName)}
+            >
+              <span className="text-lg leading-none" aria-hidden="true">
+                {entry.emoji}
+              </span>
+              <span className="min-w-0 truncate">{entry.label}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/features/editor/components/StampFacePicker.tsx
+++ b/features/editor/components/StampFacePicker.tsx
@@ -33,6 +33,12 @@ export function StampFacePicker({ catalog, value, onChange }: StampFacePickerPro
   /** listbox 内 option 要素の id（aria-activedescendant 用） */
   const getOptionId = (index: number) => `${listboxId}-option-${index}`;
 
+  /** catalog 長に合わせて activeIndex をクランプする */
+  const clampActiveIndex = (index: number, length: number) => {
+    if (length <= 0) return 0;
+    return Math.min(index, length - 1);
+  };
+
   useEffect(() => {
     activeIndexRef.current = activeIndex;
   }, [activeIndex]);
@@ -55,14 +61,14 @@ export function StampFacePicker({ catalog, value, onChange }: StampFacePickerPro
   useEffect(() => {
     if (!open) return;
 
-    const handlePointerDown = (event: MouseEvent) => {
+    const handlePointerDown = (event: PointerEvent) => {
       if (containerRef.current?.contains(event.target as Node)) return;
       setOpen(false);
     };
 
-    document.addEventListener("mousedown", handlePointerDown);
+    document.addEventListener("pointerdown", handlePointerDown);
     return () => {
-      document.removeEventListener("mousedown", handlePointerDown);
+      document.removeEventListener("pointerdown", handlePointerDown);
     };
   }, [open]);
 
@@ -133,7 +139,12 @@ export function StampFacePicker({ catalog, value, onChange }: StampFacePickerPro
 
   if (catalog.length === 0) return null;
 
-  const activeOptionId = getOptionId(activeIndex);
+  const resolvedActiveIndex = clampActiveIndex(activeIndex, catalog.length);
+  if (open && activeIndex !== resolvedActiveIndex) {
+    setActiveIndex(resolvedActiveIndex);
+  }
+
+  const activeOptionId = getOptionId(resolvedActiveIndex);
 
   return (
     <div ref={containerRef} className={clsx("relative shrink-0", open && "z-50")}>
@@ -193,8 +204,8 @@ export function StampFacePicker({ catalog, value, onChange }: StampFacePickerPro
                 className={clsx([
                   "flex cursor-pointer items-center gap-2 bg-white px-2 py-2 text-sm text-zinc-700",
                   entry.fileName === value && "bg-blue-50",
-                  index === activeIndex && entry.fileName !== value && "bg-zinc-100",
-                  index === activeIndex && entry.fileName === value && "bg-blue-100",
+                  index === resolvedActiveIndex && entry.fileName !== value && "bg-zinc-100",
+                  index === resolvedActiveIndex && entry.fileName === value && "bg-blue-100",
                 ])}
                 onMouseEnter={() => {
                   activeIndexRef.current = index;

--- a/features/editor/components/StampFacePicker.tsx
+++ b/features/editor/components/StampFacePicker.tsx
@@ -135,35 +135,46 @@ export function StampFacePicker({ catalog, value, onChange }: StampFacePickerPro
       </button>
 
       {open && (
-        <ul
-          ref={listRef}
-          id={listboxId}
-          role="listbox"
-          aria-label="スタンプ画像"
-          className="absolute top-full left-0 z-50 mt-1 max-h-48 w-56 overflow-y-auto rounded-md border border-zinc-200 bg-white py-1 shadow-lg"
+        <div
+          className={clsx([
+            "absolute top-full left-0 z-50 mt-1 w-56 overflow-hidden rounded-md border border-zinc-200 bg-white shadow-lg",
+            /* Safari: スクロール層の背景が透けるのを防ぐ */
+            "[transform:translateZ(0)]",
+          ])}
         >
-          {catalog.map((entry, index) => (
-            <li
-              key={entry.fileName}
-              role="option"
-              aria-selected={entry.fileName === value}
-              data-index={index}
-              className={clsx([
-                "flex cursor-pointer items-center gap-2 px-2 py-2 text-sm text-zinc-700",
-                entry.fileName === value && "bg-blue-50",
-                index === activeIndex && entry.fileName !== value && "bg-zinc-100",
-                index === activeIndex && entry.fileName === value && "bg-blue-100",
-              ])}
-              onMouseEnter={() => setActiveIndex(index)}
-              onClick={() => handleSelect(entry.fileName)}
-            >
-              <span className="text-lg leading-none" aria-hidden="true">
-                {entry.emoji}
-              </span>
-              <span className="min-w-0 truncate">{entry.label}</span>
-            </li>
-          ))}
-        </ul>
+          <ul
+            ref={listRef}
+            id={listboxId}
+            role="listbox"
+            aria-label="スタンプ画像"
+            className={clsx([
+              "m-0 max-h-48 list-none overflow-y-auto bg-white py-1",
+              "[-webkit-overflow-scrolling:touch]",
+            ])}
+          >
+            {catalog.map((entry, index) => (
+              <li
+                key={entry.fileName}
+                role="option"
+                aria-selected={entry.fileName === value}
+                data-index={index}
+                className={clsx([
+                  "flex cursor-pointer items-center gap-2 bg-white px-2 py-2 text-sm text-zinc-700",
+                  entry.fileName === value && "bg-blue-50",
+                  index === activeIndex && entry.fileName !== value && "bg-zinc-100",
+                  index === activeIndex && entry.fileName === value && "bg-blue-100",
+                ])}
+                onMouseEnter={() => setActiveIndex(index)}
+                onClick={() => handleSelect(entry.fileName)}
+              >
+                <span className="text-lg leading-none" aria-hidden="true">
+                  {entry.emoji}
+                </span>
+                <span className="min-w-0 truncate">{entry.label}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
       )}
     </div>
   );

--- a/features/editor/components/StampFacePicker.tsx
+++ b/features/editor/components/StampFacePicker.tsx
@@ -22,13 +22,33 @@ export function StampFacePicker({ catalog, value, onChange }: StampFacePickerPro
   const [activeIndex, setActiveIndex] = useState(0);
   const containerRef = useRef<HTMLDivElement>(null);
   const listRef = useRef<HTMLUListElement>(null);
+  const activeIndexRef = useRef(activeIndex);
+  const onChangeRef = useRef(onChange);
+  const catalogRef = useRef(catalog);
   const listboxId = useId();
 
   const selectedIndex = catalog.findIndex((entry) => entry.fileName === value);
   const selected = catalog[selectedIndex >= 0 ? selectedIndex : 0];
 
+  /** listbox 内 option 要素の id（aria-activedescendant 用） */
+  const getOptionId = (index: number) => `${listboxId}-option-${index}`;
+
+  useEffect(() => {
+    activeIndexRef.current = activeIndex;
+  }, [activeIndex]);
+
+  useEffect(() => {
+    onChangeRef.current = onChange;
+  }, [onChange]);
+
+  useEffect(() => {
+    catalogRef.current = catalog;
+  }, [catalog]);
+
   const openList = useCallback(() => {
-    setActiveIndex(selectedIndex >= 0 ? selectedIndex : 0);
+    const index = selectedIndex >= 0 ? selectedIndex : 0;
+    activeIndexRef.current = index;
+    setActiveIndex(index);
     setOpen(true);
   }, [selectedIndex]);
 
@@ -57,19 +77,29 @@ export function StampFacePicker({ catalog, value, onChange }: StampFacePickerPro
       }
       if (event.key === "ArrowDown") {
         event.preventDefault();
-        setActiveIndex((index) => (index + 1) % catalog.length);
+        const { length } = catalogRef.current;
+        setActiveIndex((index) => {
+          const next = (index + 1) % length;
+          activeIndexRef.current = next;
+          return next;
+        });
         return;
       }
       if (event.key === "ArrowUp") {
         event.preventDefault();
-        setActiveIndex((index) => (index - 1 + catalog.length) % catalog.length);
+        const { length } = catalogRef.current;
+        setActiveIndex((index) => {
+          const next = (index - 1 + length) % length;
+          activeIndexRef.current = next;
+          return next;
+        });
         return;
       }
       if (event.key === "Enter" || event.key === " ") {
         event.preventDefault();
-        const entry = catalog[activeIndex];
+        const entry = catalogRef.current[activeIndexRef.current];
         if (!entry) return;
-        onChange(entry.fileName);
+        onChangeRef.current(entry.fileName);
         setOpen(false);
       }
     };
@@ -78,7 +108,7 @@ export function StampFacePicker({ catalog, value, onChange }: StampFacePickerPro
     return () => {
       document.removeEventListener("keydown", handleKeyDown);
     };
-  }, [open, activeIndex, catalog, onChange]);
+  }, [open]);
 
   useEffect(() => {
     if (!open || !listRef.current) return;
@@ -107,13 +137,18 @@ export function StampFacePicker({ catalog, value, onChange }: StampFacePickerPro
 
   if (catalog.length === 0) return null;
 
+  const activeOptionId = getOptionId(activeIndex);
+
   return (
     <div ref={containerRef} className={clsx("relative shrink-0", open && "z-50")}>
       <button
         type="button"
+        role="combobox"
+        aria-autocomplete="list"
         aria-haspopup="listbox"
         aria-expanded={open}
         aria-controls={open ? listboxId : undefined}
+        aria-activedescendant={open ? activeOptionId : undefined}
         aria-label={selected ? `スタンプ: ${selected.label}` : "スタンプ画像"}
         onClick={() => {
           if (open) {
@@ -155,16 +190,20 @@ export function StampFacePicker({ catalog, value, onChange }: StampFacePickerPro
             {catalog.map((entry, index) => (
               <li
                 key={entry.fileName}
+                id={getOptionId(index)}
                 role="option"
-                aria-selected={entry.fileName === value}
                 data-index={index}
+                aria-selected={entry.fileName === value}
                 className={clsx([
                   "flex cursor-pointer items-center gap-2 bg-white px-2 py-2 text-sm text-zinc-700",
                   entry.fileName === value && "bg-blue-50",
                   index === activeIndex && entry.fileName !== value && "bg-zinc-100",
                   index === activeIndex && entry.fileName === value && "bg-blue-100",
                 ])}
-                onMouseEnter={() => setActiveIndex(index)}
+                onMouseEnter={() => {
+                  activeIndexRef.current = index;
+                  setActiveIndex(index);
+                }}
                 onClick={() => handleSelect(entry.fileName)}
               >
                 <span className="text-lg leading-none" aria-hidden="true">

--- a/features/editor/components/StampFacePicker.tsx
+++ b/features/editor/components/StampFacePicker.tsx
@@ -40,8 +40,8 @@ export function StampFacePicker({ catalog, value, onChange }: StampFacePickerPro
   };
 
   useEffect(() => {
-    activeIndexRef.current = activeIndex;
-  }, [activeIndex]);
+    activeIndexRef.current = clampActiveIndex(activeIndex, catalog.length);
+  }, [activeIndex, catalog.length]);
 
   useEffect(() => {
     onChangeRef.current = onChange;
@@ -62,7 +62,8 @@ export function StampFacePicker({ catalog, value, onChange }: StampFacePickerPro
     if (!open) return;
 
     const handlePointerDown = (event: PointerEvent) => {
-      if (containerRef.current?.contains(event.target as Node)) return;
+      const target = event.target;
+      if (target instanceof Node && containerRef.current?.contains(target)) return;
       setOpen(false);
     };
 
@@ -74,9 +75,10 @@ export function StampFacePicker({ catalog, value, onChange }: StampFacePickerPro
 
   useEffect(() => {
     if (!open || !listRef.current) return;
-    const option = listRef.current.querySelector<HTMLElement>(`[data-index="${activeIndex}"]`);
+    const index = clampActiveIndex(activeIndex, catalog.length);
+    const option = listRef.current.querySelector<HTMLElement>(`[data-index="${index}"]`);
     option?.scrollIntoView?.({ block: "nearest" });
-  }, [activeIndex, open]);
+  }, [activeIndex, open, catalog.length]);
 
   const handleSelect = useCallback(
     (fileName: string) => {
@@ -128,7 +130,9 @@ export function StampFacePicker({ catalog, value, onChange }: StampFacePickerPro
       }
       if (event.key === "Enter" || event.key === " ") {
         event.preventDefault();
-        const entry = catalogRef.current[activeIndexRef.current];
+        const index = clampActiveIndex(activeIndexRef.current, length);
+        activeIndexRef.current = index;
+        const entry = catalogRef.current[index];
         if (!entry) return;
         onChangeRef.current(entry.fileName);
         setOpen(false);
@@ -140,10 +144,6 @@ export function StampFacePicker({ catalog, value, onChange }: StampFacePickerPro
   if (catalog.length === 0) return null;
 
   const resolvedActiveIndex = clampActiveIndex(activeIndex, catalog.length);
-  if (open && activeIndex !== resolvedActiveIndex) {
-    setActiveIndex(resolvedActiveIndex);
-  }
-
   const activeOptionId = getOptionId(resolvedActiveIndex);
 
   return (

--- a/features/editor/components/StampFacePicker.tsx
+++ b/features/editor/components/StampFacePicker.tsx
@@ -108,7 +108,7 @@ export function StampFacePicker({ catalog, value, onChange }: StampFacePickerPro
   if (catalog.length === 0) return null;
 
   return (
-    <div ref={containerRef} className="relative shrink-0">
+    <div ref={containerRef} className={clsx("relative shrink-0", open && "z-50")}>
       <button
         type="button"
         aria-haspopup="listbox"

--- a/features/masking/components/GalleryItem.tsx
+++ b/features/masking/components/GalleryItem.tsx
@@ -309,7 +309,7 @@ export function GalleryItem({
               />
             </div>
 
-            <div className="relative z-0 overflow-hidden px-2 pb-2">
+            <div className="relative z-10 overflow-hidden px-2 pb-2">
               {imageNaturalWidth > 0 && imageNaturalHeight > 0 && (
                 <EditorCanvas
                   key={image.id}

--- a/features/masking/components/GalleryItem.tsx
+++ b/features/masking/components/GalleryItem.tsx
@@ -264,8 +264,8 @@ export function GalleryItem({
             : `顔: ${image.detections.length} 件 / テキスト: ${image.ocrRegions.length} 件`}
       </p>
 
-      {/* エディタUI */}
-      <div className="relative mt-3 overflow-hidden rounded-xl border border-zinc-200 bg-zinc-50">
+      {/* エディタUI（ツールバーのポップオーバーがキャンバスに隠れないよう overflow はキャンバス側のみ） */}
+      <div className="relative mt-3 rounded-xl border border-zinc-200 bg-zinc-50">
         {image.isProcessing ? (
           <div className="flex justify-center p-3">
             {/* eslint-disable-next-line @next/next/no-img-element */}
@@ -292,7 +292,7 @@ export function GalleryItem({
         ) : (
           /* PC 常時 / SP 編集中: ツールバー + Konva Canvas */
           <>
-            <div className="relative z-10 p-2">
+            <div className="relative z-20 p-2">
               <EditorToolbar
                 mode={editor.mode}
                 selectedStampType={editor.selectedStampType}
@@ -309,7 +309,7 @@ export function GalleryItem({
               />
             </div>
 
-            <div className="relative z-10 px-2 pb-2">
+            <div className="relative z-0 overflow-hidden px-2 pb-2">
               {imageNaturalWidth > 0 && imageNaturalHeight > 0 && (
                 <EditorCanvas
                   key={image.id}


### PR DESCRIPTION
## 概要

エディタツールバーのスタンプ画像選択をカスタムピッカーに置き換え、トリガーはコンパクトに、一覧では絵文字とラベルを表示する。

## 関連Issue

Closes #63

## 変更内容

- [x] 機能追加
- [ ] バグ修正
- [ ] リファクタリング
- [x] テスト追加・修正
- [ ] ドキュメント修正
- [ ] 設定・環境変更
- [ ] その他

## 主な変更箇所

### UI・コンポーネント

- `StampFacePicker`: 絵文字トリガー + ポップオーバー一覧（ラベル付き）
- `EditorToolbar`: ネイティブ `<select>` を `StampFacePicker` に差し替え

### ロジック・処理

- 外側クリック・Escape で閉じる、矢印キー・Enter/Space で選択
- combobox + `aria-activedescendant` でキーボードの active 項目を支援技術に通知

### その他

- 新規依存なし（既存の lucide-react / clsx のみ）

## 動作確認

- [x] ローカル環境での動作確認
- [x] テストの実行・通過確認
- [ ] UI動作確認
- [ ] 既存機能への影響確認
- [ ] ブラウザ動作確認（Chrome / Firefox / Safari）

## テスト

### 追加したテスト

- `StampFacePicker.test.tsx`（表示・選択・Escape・矢印+Enter・Space・外側クリック・`aria-activedescendant`）

### テスト結果

- [x] 全てのテストが通過
- [x] 新規テストを追加
- [ ] 既存テストの修正

## 破壊的変更

- [ ] 破壊的変更あり
- [x] 破壊的変更なし

## レビューポイント

- 狭いツールバーでのレイアウト（トリガー幅）
- キーボード操作（矢印・Enter・Escape）
- SP でのタップしやすさ

## 補足

#62 の暫定（絵文字のみ native select）を本コンポーネントで置き換え。

## チェックリスト

- [x] コードレビューの準備ができている
- [x] 適切なラベルを付けている
- [x] セルフレビューを実施している
- [x] `pnpm lint` と `pnpm type-check` が通ることを確認した
- [ ] 必要に応じてドキュメントを更新している
