### PR TITLE
ドロップゾーンのモデル読み込み時レイアウトシフトを解消

### DIFF
--- a/components/ImageUpload/ImageUpload.test.tsx
+++ b/components/ImageUpload/ImageUpload.test.tsx
@@ -31,6 +31,17 @@ describe("ImageUpload", () => {
     expect(screen.getAllByText(/JPEG \/ PNG \/ WebP \/ GIF/)).toHaveLength(2);
   });
 
+  it("loadingMessage 表示中もドロップゾーンのガイド文言で高さを確保する", () => {
+    render(<ImageUpload onUpload={vi.fn()} loadingMessage="顔検出モデルをロード中…" />);
+    const dropZone = screen.getByRole("button", {
+      name: "画像をアップロード。クリックまたはドラッグ＆ドロップ",
+    });
+    expect(dropZone).toHaveTextContent("顔検出モデルをロード中…");
+    const guideHeading = screen.getByText("画像をドラッグ＆ドロップ");
+    expect(dropZone).toContainElement(guideHeading);
+    expect(guideHeading.closest("[aria-hidden]")).toHaveAttribute("aria-hidden", "true");
+  });
+
   it("disabled時は操作不可になる", () => {
     render(<ImageUpload onUpload={vi.fn()} disabled />);
     const mobileButton = screen.getByRole("button", {

--- a/components/ImageUpload/index.tsx
+++ b/components/ImageUpload/index.tsx
@@ -450,8 +450,8 @@ export function ImageUpload({
         aria-disabled={disabled}
         aria-busy={Boolean(loadingMessage)}
         className={clsx([
-          "hidden w-full md:flex",
-          "cursor-pointer flex-col items-center justify-center gap-3",
+          "relative hidden w-full md:flex",
+          "cursor-pointer flex-col items-center justify-center",
           "rounded-xl border-2 border-dashed px-6 py-12 text-center",
           "transition-colors duration-200",
           isDragOver
@@ -465,22 +465,27 @@ export function ImageUpload({
         onClick={() => !disabled && inputRef.current?.click()}
         onKeyDown={handleDesktopKeyDown}
       >
-        {loadingMessage ? (
-          <div className="flex flex-col items-center gap-2">
+        <div
+          className={clsx(["flex flex-col items-center gap-3", loadingMessage && "opacity-0"])}
+          aria-hidden={Boolean(loadingMessage)}
+        >
+          <ImageIcon className="h-10 w-10 text-zinc-500" aria-hidden="true" />
+          <div className="flex flex-col gap-1">
+            <p className="font-medium text-zinc-700">画像をドラッグ＆ドロップ</p>
+            <p className="text-sm text-zinc-500">
+              または クリックして{multiple ? "ファイルを複数選択" : "ファイルを選択"}
+            </p>
+            <p className="text-xs text-zinc-400">JPEG / PNG / WebP / GIF（最大 20MB）</p>
+          </div>
+        </div>
+        {loadingMessage && (
+          <div
+            className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center gap-2"
+            aria-live="polite"
+          >
             <LoaderCircle className="h-10 w-10 animate-spin text-blue-600" aria-hidden="true" />
             <p className="text-sm font-medium text-blue-700">{loadingMessage}</p>
           </div>
-        ) : (
-          <>
-            <ImageIcon className="h-10 w-10 text-zinc-500" aria-hidden="true" />
-            <div className="flex flex-col gap-1">
-              <p className="font-medium text-zinc-700">画像をドラッグ＆ドロップ</p>
-              <p className="text-sm text-zinc-500">
-                または クリックして{multiple ? "ファイルを複数選択" : "ファイルを選択"}
-              </p>
-              <p className="text-xs text-zinc-400">JPEG / PNG / WebP / GIF（最大 20MB）</p>
-            </div>
-          </>
         )}
       </div>
 


### PR DESCRIPTION
## 概要

顔検出モデル読み込み中と読み込み完了後で、デスクトップ用ドロップゾーンの高さが変わるレイアウトシフトを解消する。

## 関連Issue

Closes #70

## 変更内容

- [ ] 機能追加
- [x] バグ修正
- [ ] リファクタリング
- [x] テスト追加・修正
- [ ] ドキュメント修正
- [ ] 設定・環境変更
- [ ] その他

## 主な変更箇所

### UI・コンポーネント

- `components/ImageUpload/index.tsx`
  - デスクトップ用ドロップゾーンで、通常時のガイド文言ブロックを常に DOM に残し、ローディング中は `opacity-0` で非表示
  - ローディング表示は `absolute inset-0` で中央重ね（高さはガイド文言ブロックで固定）
  - オーバーレイに `pointer-events-none` を付与し、クリック操作は親要素に委譲

### ロジック・処理

- 変更なし

### その他

- 変更なし

## 動作確認

- [x] ローカル環境での動作確認（コードレビュー観点での構造確認）
- [x] テストの実行・通過確認（`pnpm test:run components/ImageUpload/ImageUpload.test.tsx`）
- [ ] UI動作確認（レビュアー・マージ前にブラウザでモデル読み込み前後の高さを確認推奨）
- [x] 既存機能への影響確認（ImageUpload の既存テスト 21 件すべて通過）
- [ ] ブラウザ動作確認（Chrome / Firefox / Safari）

## スクリーンショット・動画

UI の見た目変更は最小（レイアウト安定化のみ）のため省略。

## テスト

### 追加したテスト

- `loadingMessage` 表示中もドロップゾーン内にガイド文言が `aria-hidden` で残り、高さ確保の構造を維持すること

### テスト結果

- [x] 全てのテストが通過（ImageUpload 21 件）
- [x] 新規テストを追加
- [ ] 既存テストの修正

## 破壊的変更

- [ ] 破壊的変更あり
- [x] 破壊的変更なし

### 破壊的変更の詳細

該当なし

## レビューポイント

- ローディング中の `opacity-0` ガイド文言がスクリーンリーダー向けに `aria-hidden` になっていること
- `absolute` オーバーレイで高さが二重計上されないこと（以前の grid 重ねでは積み上がっていた）

## 補足

- モバイル用ボタン（`md:hidden`）は従来どおり表示切り替えのまま（1 行テキストのためシフト影響は小さい）

## チェックリスト

- [x] コードレビューの準備ができている
- [x] 適切なラベルを付けている
- [x] セルフレビューを実施している
- [x] `pnpm lint` と `pnpm type-check` が通ることを確認した（`tsc --noEmit` 実行済み）
- [ ] 必要に応じてドキュメントを更新している
