### PR TITLE
EditorCanvas の表示ズーム・パンをマウス／タッチ操作に対応する

### DIFF
--- a/features/editor/components/EditorCanvas.tsx
+++ b/features/editor/components/EditorCanvas.tsx
@@ -17,6 +17,7 @@ import {
 import type { EditorMode, PaintStroke, StampRegion, StampType } from "../types";
 import { stagePointerToContentSpace } from "../lib/viewZoom";
 import { useEditorViewport } from "../hooks/useEditorViewport";
+import { useEditorViewportGestures } from "../hooks/useEditorViewportGestures";
 import { EditorStampRegionNode } from "./EditorStampRegionNode";
 import { EditorViewportControls } from "./EditorViewportControls";
 
@@ -137,6 +138,7 @@ export function EditorCanvas({
   className,
 }: EditorCanvasProps) {
   const containerRef = useRef<HTMLDivElement>(null);
+  const stageContainerRef = useRef<HTMLDivElement>(null);
   const transformerRef = useRef<Konva.Transformer>(null);
   const [stageWidth, setStageWidth] = useState(600);
   const [bgImage, setBgImage] = useState<HTMLImageElement | null>(null);
@@ -154,32 +156,44 @@ export function EditorCanvas({
     viewCenter,
     contentCenter,
     canPan,
-    canZoomOut,
-    canZoomIn,
-    nudgeViewCenter,
-    resetViewCenter,
-    zoomOut,
     resetViewport,
-    zoomIn,
+    zoomAt,
+    setZoomAt,
+    panByStageDelta,
   } = useEditorViewport(imageNaturalWidth, imageNaturalHeight, scaleX, scaleY);
+
+  const gestures = useEditorViewportGestures({
+    stageContainerRef,
+    stageWidth,
+    stageHeight,
+    viewZoom,
+    mode,
+    canPan,
+    zoomAt,
+    setZoomAt,
+    panByStageDelta,
+  });
 
   /**
    * キーボードショートカット
    *
    * - Escape: 選択解除
    * - Delete / Backspace: 選択中アイテムを削除
+   * - 0: 等倍・中央にリセット
    */
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
       if (e.key === "Escape") {
         onSelectItem(null);
+      } else if (e.key === "0") {
+        resetViewport();
       } else if ((e.key === "Delete" || e.key === "Backspace") && selectedId !== null) {
         onDeleteSelected();
       }
     }
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [selectedId, onSelectItem, onDeleteSelected]);
+  }, [selectedId, onSelectItem, onDeleteSelected, resetViewport]);
 
   /** コンテナの幅変化を ResizeObserver で監視 */
   useEffect(() => {
@@ -246,6 +260,9 @@ export function EditorCanvas({
    * ステージのマウスダウン/タッチスタートハンドラ
    */
   function handlePointerDown(e: KonvaEventObject<MouseEvent> | KonvaEventObject<TouchEvent>) {
+    if (gestures.tryConsumeStagePointerDown(e)) return;
+    if (gestures.isGestureCapturing) return;
+
     const stage = e.target.getStage();
     if (!stage) return;
     const pos = pointerToContentSpace(stage);
@@ -273,6 +290,7 @@ export function EditorCanvas({
    * ステージのマウス移動/タッチ移動ハンドラ
    */
   function handlePointerMove(e: KonvaEventObject<MouseEvent> | KonvaEventObject<TouchEvent>) {
+    if (gestures.tryConsumeStagePointerMove(e)) return;
     if (!isDrawing.current) return;
     // canvas / .konvajs-content は touch-action が継承されないため SP でページスクロールと競合する。
     // Konva が passive:false で登録している touchmove でも念のため抑止する。
@@ -303,6 +321,7 @@ export function EditorCanvas({
    * ステージのマウスアップ/タッチエンドハンドラ
    */
   function handlePointerUp() {
+    if (gestures.tryConsumeStagePointerUp()) return;
     if (!isDrawing.current) return;
     isDrawing.current = false;
 
@@ -562,18 +581,15 @@ export function EditorCanvas({
   );
 
   const viewportControls = (
-    <EditorViewportControls
-      canPan={canPan}
-      canZoomOut={canZoomOut}
-      canZoomIn={canZoomIn}
-      viewZoom={viewZoom}
-      onNudgeViewCenter={nudgeViewCenter}
-      onResetViewCenter={resetViewCenter}
-      onZoomOut={zoomOut}
-      onResetViewport={resetViewport}
-      onZoomIn={zoomIn}
-    />
+    <EditorViewportControls viewZoom={viewZoom} onResetViewport={resetViewport} />
   );
+
+  const stageCursor =
+    gestures.isSpacePanMode && canPan && mode === "select"
+      ? gestures.isGestureCapturing
+        ? "grabbing"
+        : "grab"
+      : MODE_CURSORS[mode];
 
   /** モーダル内: 選択モードは縦スクロールを優先、描画モードはタッチ操作をキャンバスに取る */
   const stageTouchAction =
@@ -585,6 +601,8 @@ export function EditorCanvas({
 
   const stageArea = (
     <div
+      ref={stageContainerRef}
+      {...gestures.stageContainerProps}
       className={
         pinViewportControls ? undefined : "[&_.konvajs-content]:touch-none [&_canvas]:touch-none"
       }
@@ -598,7 +616,7 @@ export function EditorCanvas({
         onTouchStart={handlePointerDown}
         onTouchMove={handlePointerMove}
         onTouchEnd={handlePointerUp}
-        style={{ cursor: MODE_CURSORS[mode], touchAction: stageTouchAction }}
+        style={{ cursor: stageCursor, touchAction: stageTouchAction }}
       >
         <Layer>
           <Group

--- a/features/editor/components/EditorCanvas.tsx
+++ b/features/editor/components/EditorCanvas.tsx
@@ -174,6 +174,7 @@ export function EditorCanvas({
     setZoomAt,
     panByStageDelta,
     onClearSelection: () => onSelectItem(null),
+    pinViewportControls,
   });
 
   /**
@@ -583,9 +584,14 @@ export function EditorCanvas({
   );
 
   const viewportControls = (
-    <EditorViewportControls viewZoom={viewZoom} onResetViewport={resetViewport} />
+    <EditorViewportControls
+      viewZoom={viewZoom}
+      onResetViewport={resetViewport}
+      pinViewportControls={pinViewportControls}
+    />
   );
 
+  /** 拡大時は空白ドラッグでパンできるため grab。Space 押下中も同カーソル */
   const stageCursor =
     canPan && mode === "select"
       ? gestures.isGestureCapturing || gestures.hasActivePanSession()

--- a/features/editor/components/EditorCanvas.tsx
+++ b/features/editor/components/EditorCanvas.tsx
@@ -172,6 +172,7 @@ export function EditorCanvas({
     zoomAt,
     setZoomAt,
     panByStageDelta,
+    onClearSelection: () => onSelectItem(null),
   });
 
   /**

--- a/features/editor/components/EditorCanvas.tsx
+++ b/features/editor/components/EditorCanvas.tsx
@@ -261,7 +261,7 @@ export function EditorCanvas({
    */
   function handlePointerDown(e: KonvaEventObject<MouseEvent> | KonvaEventObject<TouchEvent>) {
     if (gestures.tryConsumeStagePointerDown(e)) return;
-    if (gestures.isGestureCapturing) return;
+    if (gestures.hasActivePanSession() || gestures.isGestureCapturing) return;
 
     const stage = e.target.getStage();
     if (!stage) return;
@@ -585,8 +585,8 @@ export function EditorCanvas({
   );
 
   const stageCursor =
-    gestures.isSpacePanMode && canPan && mode === "select"
-      ? gestures.isGestureCapturing
+    canPan && mode === "select"
+      ? gestures.isGestureCapturing || gestures.hasActivePanSession()
         ? "grabbing"
         : "grab"
       : MODE_CURSORS[mode];

--- a/features/editor/components/EditorCanvas.tsx
+++ b/features/editor/components/EditorCanvas.tsx
@@ -190,7 +190,11 @@ export function EditorCanvas({
         onSelectItem(null);
       } else if (e.key === "0" && !isEditableKeyboardTarget(e.target)) {
         resetViewport();
-      } else if ((e.key === "Delete" || e.key === "Backspace") && selectedId !== null) {
+      } else if (
+        (e.key === "Delete" || e.key === "Backspace") &&
+        selectedId !== null &&
+        !isEditableKeyboardTarget(e.target)
+      ) {
         onDeleteSelected();
       }
     }

--- a/features/editor/components/EditorCanvas.tsx
+++ b/features/editor/components/EditorCanvas.tsx
@@ -15,6 +15,7 @@ import {
   Transformer,
 } from "react-konva";
 import type { EditorMode, PaintStroke, StampRegion, StampType } from "../types";
+import { isEditableKeyboardTarget } from "../lib/isEditableKeyboardTarget";
 import { stagePointerToContentSpace } from "../lib/viewZoom";
 import { useEditorViewport } from "../hooks/useEditorViewport";
 import { useEditorViewportGestures } from "../hooks/useEditorViewportGestures";
@@ -186,7 +187,7 @@ export function EditorCanvas({
     function handleKeyDown(e: KeyboardEvent) {
       if (e.key === "Escape") {
         onSelectItem(null);
-      } else if (e.key === "0") {
+      } else if (e.key === "0" && !isEditableKeyboardTarget(e.target)) {
         resetViewport();
       } else if ((e.key === "Delete" || e.key === "Backspace") && selectedId !== null) {
         onDeleteSelected();

--- a/features/editor/components/EditorViewportControls.tsx
+++ b/features/editor/components/EditorViewportControls.tsx
@@ -7,6 +7,8 @@ interface EditorViewportControlsProps {
   className?: string;
   viewZoom: number;
   onResetViewport: () => void;
+  /** true のときホイールはスクロール優先のため Ctrl+ホイール案内を表示 */
+  pinViewportControls?: boolean;
 }
 
 /**
@@ -16,7 +18,10 @@ export function EditorViewportControls({
   className,
   viewZoom,
   onResetViewport,
+  pinViewportControls = false,
 }: EditorViewportControlsProps) {
+  const zoomHint = pinViewportControls ? "Ctrl+ホイールで拡大" : "ホイールで拡大";
+
   return (
     <div
       className={clsx([
@@ -24,7 +29,12 @@ export function EditorViewportControls({
         className,
       ])}
     >
-      <span className="text-xs text-zinc-600">表示ズーム</span>
+      <div className="flex min-w-0 flex-1 flex-wrap items-baseline gap-x-1.5 gap-y-0.5">
+        <span className="shrink-0 text-xs text-zinc-600">表示ズーム</span>
+        <span className="text-[11px] leading-snug text-zinc-400">
+          {zoomHint} · 空白／Space+ドラッグで移動
+        </span>
+      </div>
       <div className="flex items-center gap-2">
         <span className="text-xs tabular-nums text-zinc-500">{Math.round(viewZoom * 100)}%</span>
         <button

--- a/features/editor/components/EditorViewportControls.tsx
+++ b/features/editor/components/EditorViewportControls.tsx
@@ -1,146 +1,40 @@
 "use client";
 
 import clsx from "clsx";
-import { ChevronDown, ChevronLeft, ChevronRight, ChevronUp, Minus, Plus } from "lucide-react";
-import type { ViewportDirection } from "../hooks/useEditorViewport";
 
 interface EditorViewportControlsProps {
   /** ルート要素に追加するクラス（モーダル内 sticky など） */
   className?: string;
-  canPan: boolean;
-  canZoomOut: boolean;
-  canZoomIn: boolean;
   viewZoom: number;
-  onNudgeViewCenter: (dxImageDir: ViewportDirection, dyImageDir: ViewportDirection) => void;
-  onResetViewCenter: () => void;
-  onZoomOut: () => void;
   onResetViewport: () => void;
-  onZoomIn: () => void;
 }
 
 /**
- * EditorCanvas 上部の表示ズーム / 表示移動コントロール
- *
- * 描画ロジックとは分離し、ボタン構成とレスポンシブレイアウトだけを担当する。
+ * EditorCanvas 上部の表示ズームコントロール（等倍・中央リセットのみ）
  */
 export function EditorViewportControls({
   className,
-  canPan,
-  canZoomOut,
-  canZoomIn,
   viewZoom,
-  onNudgeViewCenter,
-  onResetViewCenter,
-  onZoomOut,
   onResetViewport,
-  onZoomIn,
 }: EditorViewportControlsProps) {
   return (
     <div
       className={clsx([
-        "flex flex-col gap-1 border-b border-zinc-200 bg-zinc-50 px-2 py-1.5",
+        "flex items-center justify-between gap-2 border-b border-zinc-200 bg-zinc-50 px-2 py-1.5",
         className,
       ])}
     >
       <span className="text-xs text-zinc-600">表示ズーム</span>
-      <div className="flex w-full flex-wrap items-start gap-2 md:items-center">
-        {canPan && (
-          <div className="flex flex-col gap-1 border-r border-zinc-300 pr-1.5 md:flex-row md:items-center md:gap-2">
-            <div className="flex items-center justify-between gap-2 md:justify-start">
-              <span className="text-xs text-zinc-600">移動</span>
-              <button
-                type="button"
-                className="rounded border border-zinc-300 bg-white px-2 py-0.5 text-xs text-zinc-800 hover:bg-zinc-100"
-                aria-label="表示位置を中央に戻す"
-                onClick={onResetViewCenter}
-              >
-                中央
-              </button>
-            </div>
-            <div className="flex flex-wrap items-center gap-1 md:flex-nowrap">
-              <button
-                type="button"
-                className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded border border-zinc-300 bg-white text-zinc-800 hover:bg-zinc-100"
-                aria-label="表示を左へ移動"
-                onClick={() => onNudgeViewCenter(-1, 0)}
-              >
-                <ChevronLeft className="h-4 w-4" aria-hidden />
-              </button>
-              <button
-                type="button"
-                className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded border border-zinc-300 bg-white text-zinc-800 hover:bg-zinc-100"
-                aria-label="表示を上へ移動"
-                onClick={() => onNudgeViewCenter(0, -1)}
-              >
-                <ChevronUp className="h-4 w-4" aria-hidden />
-              </button>
-              <button
-                type="button"
-                className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded border border-zinc-300 bg-white text-zinc-800 hover:bg-zinc-100"
-                aria-label="表示を下へ移動"
-                onClick={() => onNudgeViewCenter(0, 1)}
-              >
-                <ChevronDown className="h-4 w-4" aria-hidden />
-              </button>
-              <button
-                type="button"
-                className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded border border-zinc-300 bg-white text-zinc-800 hover:bg-zinc-100"
-                aria-label="表示を右へ移動"
-                onClick={() => onNudgeViewCenter(1, 0)}
-              >
-                <ChevronRight className="h-4 w-4" aria-hidden />
-              </button>
-            </div>
-          </div>
-        )}
-        <div className="ml-auto flex shrink-0 flex-col items-end gap-1">
-          <div className="flex items-center justify-between gap-2 md:justify-start">
-            <span className="text-xs text-zinc-600">拡大縮小</span>
-            <span className="text-xs tabular-nums text-zinc-500">
-              {Math.round(viewZoom * 100)}%
-            </span>
-          </div>
-          <div className="flex items-center gap-1.5">
-            <button
-              type="button"
-              className={clsx([
-                "inline-flex h-7 w-7 shrink-0 items-center justify-center rounded border border-zinc-300 text-zinc-800",
-                canZoomOut
-                  ? "bg-white hover:bg-zinc-100"
-                  : "cursor-not-allowed bg-zinc-100 text-zinc-400",
-              ])}
-              aria-label="ズームアウト"
-              aria-disabled={!canZoomOut}
-              disabled={!canZoomOut}
-              onClick={onZoomOut}
-            >
-              <Minus className="h-4 w-4" aria-hidden />
-            </button>
-            <button
-              type="button"
-              className="inline-flex h-7 items-center justify-center rounded border border-zinc-300 bg-white px-2 text-xs text-zinc-800 hover:bg-zinc-100"
-              aria-label={`表示ズームを等倍に戻す。現在 ${Math.round(viewZoom * 100)}%`}
-              onClick={onResetViewport}
-            >
-              等倍
-            </button>
-            <button
-              type="button"
-              className={clsx([
-                "inline-flex h-7 w-7 shrink-0 items-center justify-center rounded border border-zinc-300 text-zinc-800",
-                canZoomIn
-                  ? "bg-white hover:bg-zinc-100"
-                  : "cursor-not-allowed bg-zinc-100 text-zinc-400",
-              ])}
-              aria-label="ズームイン"
-              aria-disabled={!canZoomIn}
-              disabled={!canZoomIn}
-              onClick={onZoomIn}
-            >
-              <Plus className="h-4 w-4" aria-hidden />
-            </button>
-          </div>
-        </div>
+      <div className="flex items-center gap-2">
+        <span className="text-xs tabular-nums text-zinc-500">{Math.round(viewZoom * 100)}%</span>
+        <button
+          type="button"
+          className="inline-flex h-7 items-center justify-center rounded border border-zinc-300 bg-white px-2.5 text-xs text-zinc-800 hover:bg-zinc-100"
+          aria-label={`表示を等倍・中央に戻す。現在 ${Math.round(viewZoom * 100)}%`}
+          onClick={onResetViewport}
+        >
+          等倍・中央
+        </button>
       </div>
     </div>
   );

--- a/features/editor/components/EditorViewportControls.tsx
+++ b/features/editor/components/EditorViewportControls.tsx
@@ -20,7 +20,7 @@ export function EditorViewportControls({
   onResetViewport,
   pinViewportControls = false,
 }: EditorViewportControlsProps) {
-  const zoomHint = pinViewportControls ? "Ctrl+ホイールで拡大" : "ホイールで拡大";
+  const zoomHint = pinViewportControls ? "Ctrl/Cmd+ホイールで拡大" : "ホイールで拡大";
 
   return (
     <div

--- a/features/editor/components/EditorViewportControls.tsx
+++ b/features/editor/components/EditorViewportControls.tsx
@@ -20,7 +20,7 @@ export function EditorViewportControls({
   onResetViewport,
   pinViewportControls = false,
 }: EditorViewportControlsProps) {
-  const zoomHint = pinViewportControls ? "Ctrl/Cmd+ホイールで拡大" : "ホイールで拡大";
+  const zoomHint = pinViewportControls ? "Ctrl/Cmd+ホイールで拡大/縮小" : "ホイールで拡大/縮小";
 
   return (
     <div
@@ -32,7 +32,7 @@ export function EditorViewportControls({
       <div className="flex min-w-0 flex-1 flex-wrap items-baseline gap-x-1.5 gap-y-0.5">
         <span className="shrink-0 text-xs text-zinc-600">表示ズーム</span>
         <span className="text-[11px] leading-snug text-zinc-400">
-          {zoomHint} · 空白／Space+ドラッグで移動
+          {zoomHint} · 拡大時: 空白／Space+ドラッグで移動
         </span>
       </div>
       <div className="flex items-center gap-2">

--- a/features/editor/hooks/useEditorViewport.test.ts
+++ b/features/editor/hooks/useEditorViewport.test.ts
@@ -62,4 +62,15 @@ describe("useEditorViewport", () => {
     expect(result.current.canZoomOut).toBe(false);
     expect(result.current.canZoomIn).toBe(true);
   });
+
+  it("zoomAt でポインタ下を保ったまま倍率が変わる", () => {
+    const { result } = renderHook(() => useEditorViewport(200, 100, 1, 1));
+
+    act(() => {
+      result.current.zoomAt({ x: 100, y: 50 }, 200, 100, VIEW_ZOOM.step);
+    });
+
+    expect(result.current.viewZoom).toBeCloseTo(1.1);
+    expect(result.current.viewCenter).toEqual({ x: 100, y: 50 });
+  });
 });

--- a/features/editor/hooks/useEditorViewport.ts
+++ b/features/editor/hooks/useEditorViewport.ts
@@ -5,7 +5,9 @@ import {
   VIEW_CENTER_NUDGE_PX,
   VIEW_ZOOM,
   clampViewCenter,
+  computeViewCenterAfterZoomAt,
   getDefaultViewCenter,
+  panViewCenterByStageDelta,
   roundViewZoomStep,
   type ViewCenter,
 } from "../lib/viewZoom";
@@ -27,6 +29,22 @@ export interface UseEditorViewportReturn {
   zoomOut: () => void;
   resetViewport: () => void;
   zoomIn: () => void;
+  /** ステージ上の焦点を保ったまま表示倍率を増減する（ホイール・ピンチ用） */
+  zoomAt: (
+    stagePos: { x: number; y: number },
+    stageWidth: number,
+    stageHeight: number,
+    zoomDelta: number
+  ) => void;
+  /** ステージ上の焦点を保ったまま表示倍率を絶対値で設定する（ピンチ用） */
+  setZoomAt: (
+    stagePos: { x: number; y: number },
+    stageWidth: number,
+    stageHeight: number,
+    absoluteZoom: number
+  ) => void;
+  /** ステージ px のドラッグ量で表示中心を移動する */
+  panByStageDelta: (stageDelta: { x: number; y: number }) => void;
 }
 
 /**
@@ -134,6 +152,106 @@ export function useEditorViewport(
     stepZoom(1);
   }, [stepZoom]);
 
+  /**
+   * ポインタ下の画像点を固定したまま表示倍率を変更する
+   *
+   * @param stagePos - ズームの焦点（ステージ座標）
+   * @param stageWidth - ステージ幅
+   * @param stageHeight - ステージ高さ
+   * @param zoomDelta - 倍率の増減量
+   */
+  const zoomAt = useCallback(
+    (
+      stagePos: { x: number; y: number },
+      stageWidth: number,
+      stageHeight: number,
+      zoomDelta: number
+    ) => {
+      if (zoomDelta === 0) return;
+      setViewZoom((prevZoom) => {
+        const nextZoom = roundViewZoomStep(prevZoom + zoomDelta);
+        if (nextZoom === prevZoom) return prevZoom;
+        setViewCenter((center) =>
+          computeViewCenterAfterZoomAt(
+            center,
+            stagePos,
+            stageWidth,
+            stageHeight,
+            scaleX,
+            scaleY,
+            prevZoom,
+            nextZoom,
+            imageNaturalWidth,
+            imageNaturalHeight
+          )
+        );
+        return nextZoom;
+      });
+    },
+    [imageNaturalWidth, imageNaturalHeight, scaleX, scaleY]
+  );
+
+  /**
+   * ポインタ下の画像点を固定したまま表示倍率を絶対値で設定する
+   *
+   * @param stagePos - ズームの焦点（ステージ座標）
+   * @param stageWidth - ステージ幅
+   * @param stageHeight - ステージ高さ
+   * @param absoluteZoom - 目標倍率
+   */
+  const setZoomAt = useCallback(
+    (
+      stagePos: { x: number; y: number },
+      stageWidth: number,
+      stageHeight: number,
+      absoluteZoom: number
+    ) => {
+      setViewZoom((prevZoom) => {
+        const nextZoom = roundViewZoomStep(absoluteZoom);
+        if (nextZoom === prevZoom) return prevZoom;
+        setViewCenter((center) =>
+          computeViewCenterAfterZoomAt(
+            center,
+            stagePos,
+            stageWidth,
+            stageHeight,
+            scaleX,
+            scaleY,
+            prevZoom,
+            nextZoom,
+            imageNaturalWidth,
+            imageNaturalHeight
+          )
+        );
+        return nextZoom;
+      });
+    },
+    [imageNaturalWidth, imageNaturalHeight, scaleX, scaleY]
+  );
+
+  /**
+   * ステージ上のドラッグ量で表示中心を移動する（viewZoom > 1 のときのみ）
+   *
+   * @param stageDelta - ステージ px での移動量
+   */
+  const panByStageDelta = useCallback(
+    (stageDelta: { x: number; y: number }) => {
+      if (viewZoom <= 1) return;
+      setViewCenter((center) =>
+        panViewCenterByStageDelta(
+          center,
+          stageDelta,
+          scaleX,
+          scaleY,
+          viewZoom,
+          imageNaturalWidth,
+          imageNaturalHeight
+        )
+      );
+    },
+    [imageNaturalWidth, imageNaturalHeight, scaleX, scaleY, viewZoom]
+  );
+
   return {
     viewZoom,
     viewCenter,
@@ -147,5 +265,8 @@ export function useEditorViewport(
     zoomOut,
     resetViewport,
     zoomIn,
+    zoomAt,
+    setZoomAt,
+    panByStageDelta,
   };
 }

--- a/features/editor/hooks/useEditorViewportGestures.test.ts
+++ b/features/editor/hooks/useEditorViewportGestures.test.ts
@@ -132,6 +132,17 @@ describe("useEditorViewportGestures", () => {
     expect(hook.result.current.isSpacePanMode).toBe(false);
   });
 
+  it("button フォーカス中は Space パンを開始しない", () => {
+    const { hook } = mountGestures();
+    const button = document.createElement("button");
+    document.body.appendChild(button);
+    button.focus();
+
+    fireEvent.keyDown(button, { code: "Space", key: " " });
+
+    expect(hook.result.current.isSpacePanMode).toBe(false);
+  });
+
   it("空白ドラッグで panByStageDelta が呼ばれる", async () => {
     const { hook, panByStageDelta } = mountGestures();
     const stage = { getStage: () => stage, getType: () => "Stage" };

--- a/features/editor/hooks/useEditorViewportGestures.test.ts
+++ b/features/editor/hooks/useEditorViewportGestures.test.ts
@@ -143,6 +143,22 @@ describe("useEditorViewportGestures", () => {
     expect(hook.result.current.isSpacePanMode).toBe(false);
   });
 
+  it("canPan が false のとき Space パンを開始しない", () => {
+    const { hook } = mountGestures({ canPan: false, viewZoom: 1 });
+
+    window.dispatchEvent(new KeyboardEvent("keydown", { code: "Space", bubbles: true }));
+
+    expect(hook.result.current.isSpacePanMode).toBe(false);
+  });
+
+  it("選択モード以外では Space パンを開始しない", () => {
+    const { hook } = mountGestures({ mode: "paint" });
+
+    window.dispatchEvent(new KeyboardEvent("keydown", { code: "Space", bubbles: true }));
+
+    expect(hook.result.current.isSpacePanMode).toBe(false);
+  });
+
   it("空白ドラッグで panByStageDelta が呼ばれる", async () => {
     const { hook, panByStageDelta } = mountGestures();
     const stage = { getStage: () => stage, getType: () => "Stage" };

--- a/features/editor/hooks/useEditorViewportGestures.test.ts
+++ b/features/editor/hooks/useEditorViewportGestures.test.ts
@@ -131,4 +131,45 @@ describe("useEditorViewportGestures", () => {
 
     expect(hook.result.current.isSpacePanMode).toBe(false);
   });
+
+  it("空白ドラッグで panByStageDelta が呼ばれる", async () => {
+    const { hook, panByStageDelta } = mountGestures();
+    const stage = { getStage: () => stage, getType: () => "Stage" };
+    const emptyEvent = {
+      evt: { button: 0, clientX: 40, clientY: 40, preventDefault: vi.fn() },
+      target: stage,
+    } as unknown as Parameters<typeof hook.result.current.tryConsumeStagePointerDown>[0];
+
+    expect(hook.result.current.tryConsumeStagePointerDown(emptyEvent)).toBe(true);
+
+    const moveEvent = {
+      evt: { buttons: 1, clientX: 60, clientY: 55, preventDefault: vi.fn() },
+    } as unknown as Parameters<typeof hook.result.current.tryConsumeStagePointerMove>[0];
+
+    expect(hook.result.current.tryConsumeStagePointerMove(moveEvent)).toBe(true);
+
+    await waitFor(() => {
+      expect(panByStageDelta).toHaveBeenCalledWith({ x: 20, y: 15 });
+    });
+  });
+
+  it("pinViewportControls 時は修飾キーなし wheel で zoomAt しない", async () => {
+    const { container, zoomAt } = mountGestures({ pinViewportControls: true });
+
+    fireEvent.wheel(container, { deltaY: -120, clientX: 200, clientY: 150 });
+
+    await waitFor(() => {
+      expect(zoomAt).not.toHaveBeenCalled();
+    });
+  });
+
+  it("pinViewportControls 時は Ctrl+wheel で zoomAt する", async () => {
+    const { container, zoomAt } = mountGestures({ pinViewportControls: true });
+
+    fireEvent.wheel(container, { deltaY: -120, clientX: 200, clientY: 150, ctrlKey: true });
+
+    await waitFor(() => {
+      expect(zoomAt).toHaveBeenCalled();
+    });
+  });
 });

--- a/features/editor/hooks/useEditorViewportGestures.test.ts
+++ b/features/editor/hooks/useEditorViewportGestures.test.ts
@@ -189,6 +189,18 @@ describe("useEditorViewportGestures", () => {
     });
   });
 
+  it("stageWidth が 0 のときは wheel で zoomAt しない", async () => {
+    const { hook, container, zoomAt } = mountGestures({ stageWidth: 0 });
+
+    fireEvent.wheel(container, { deltaY: -120, clientX: 200, clientY: 150 });
+
+    await waitFor(() => {
+      expect(zoomAt).not.toHaveBeenCalled();
+    });
+
+    hook.unmount();
+  });
+
   it("Space+ドラッグ開始時は選択を解除しない", async () => {
     const { hook, onClearSelection } = mountGestures();
 

--- a/features/editor/hooks/useEditorViewportGestures.test.ts
+++ b/features/editor/hooks/useEditorViewportGestures.test.ts
@@ -1,0 +1,134 @@
+import { fireEvent, renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach, afterEach, type Mock } from "vitest";
+import type { MouseEvent as ReactMouseEvent, RefObject } from "react";
+import {
+  useEditorViewportGestures,
+  type UseEditorViewportGesturesParams,
+} from "./useEditorViewportGestures";
+
+type GesturesParams = UseEditorViewportGesturesParams & {
+  zoomAt: Mock<UseEditorViewportGesturesParams["zoomAt"]>;
+  setZoomAt: Mock<UseEditorViewportGesturesParams["setZoomAt"]>;
+  panByStageDelta: Mock<UseEditorViewportGesturesParams["panByStageDelta"]>;
+  onClearSelection: Mock<UseEditorViewportGesturesParams["onClearSelection"]>;
+};
+
+function mountGestures(overrides: Partial<GesturesParams> = {}) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  vi.spyOn(container, "getBoundingClientRect").mockReturnValue({
+    left: 0,
+    top: 0,
+    width: 400,
+    height: 300,
+    right: 400,
+    bottom: 300,
+    x: 0,
+    y: 0,
+    toJSON: () => ({}),
+  } as DOMRect);
+
+  const stageContainerRef: RefObject<HTMLDivElement | null> = { current: container };
+  const zoomAt = vi.fn<UseEditorViewportGesturesParams["zoomAt"]>();
+  const setZoomAt = vi.fn<UseEditorViewportGesturesParams["setZoomAt"]>();
+  const panByStageDelta = vi.fn<UseEditorViewportGesturesParams["panByStageDelta"]>();
+  const onClearSelection = vi.fn<UseEditorViewportGesturesParams["onClearSelection"]>();
+
+  const props: GesturesParams = {
+    stageContainerRef,
+    stageWidth: 400,
+    stageHeight: 300,
+    viewZoom: 2,
+    mode: "select",
+    canPan: true,
+    zoomAt,
+    setZoomAt,
+    panByStageDelta,
+    onClearSelection,
+    ...overrides,
+  };
+
+  const hook = renderHook((p: GesturesParams) => useEditorViewportGestures(p), {
+    initialProps: props,
+  });
+
+  return { hook, container, zoomAt, setZoomAt, panByStageDelta, onClearSelection };
+}
+
+describe("useEditorViewportGestures", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    document.body.replaceChildren();
+  });
+
+  it("wheel で zoomAt が呼ばれる", async () => {
+    const { container, zoomAt } = mountGestures();
+
+    fireEvent.wheel(container, { deltaY: -120, clientX: 200, clientY: 150 });
+
+    await waitFor(() => {
+      expect(zoomAt).toHaveBeenCalledWith(
+        expect.objectContaining({ x: 200, y: 150 }),
+        400,
+        300,
+        expect.any(Number)
+      );
+    });
+  });
+
+  it("2 本指タッチ開始で isGestureCapturing が true になる", async () => {
+    const { hook, container } = mountGestures();
+
+    fireEvent.touchStart(container, {
+      touches: [
+        { clientX: 100, clientY: 100 },
+        { clientX: 200, clientY: 200 },
+      ],
+    });
+
+    await waitFor(() => {
+      expect(hook.result.current.isGestureCapturing).toBe(true);
+    });
+  });
+
+  it("Space+ドラッグで panByStageDelta が呼ばれる", async () => {
+    const { hook, panByStageDelta } = mountGestures();
+
+    window.dispatchEvent(new KeyboardEvent("keydown", { code: "Space", bubbles: true }));
+
+    await waitFor(() => {
+      expect(hook.result.current.isSpacePanMode).toBe(true);
+    });
+
+    hook.result.current.stageContainerProps.onMouseDownCapture({
+      button: 0,
+      clientX: 50,
+      clientY: 50,
+      preventDefault: vi.fn(),
+      stopPropagation: vi.fn(),
+    } as unknown as ReactMouseEvent<HTMLDivElement>);
+
+    window.dispatchEvent(new MouseEvent("mousemove", { clientX: 70, clientY: 60, bubbles: true }));
+
+    await waitFor(() => {
+      expect(panByStageDelta).toHaveBeenCalledWith({ x: 20, y: 10 });
+    });
+
+    window.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
+    window.dispatchEvent(new KeyboardEvent("keyup", { code: "Space", bubbles: true }));
+  });
+
+  it("INPUT フォーカス中は Space パンを開始しない", () => {
+    const { hook } = mountGestures();
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    input.focus();
+
+    fireEvent.keyDown(input, { code: "Space", key: " " });
+
+    expect(hook.result.current.isSpacePanMode).toBe(false);
+  });
+});

--- a/features/editor/hooks/useEditorViewportGestures.test.ts
+++ b/features/editor/hooks/useEditorViewportGestures.test.ts
@@ -172,4 +172,36 @@ describe("useEditorViewportGestures", () => {
       expect(zoomAt).toHaveBeenCalled();
     });
   });
+
+  it("Ctrl+wheel でも deltaY が 0 なら zoomAt しない", async () => {
+    const { container, zoomAt } = mountGestures({ pinViewportControls: true });
+
+    fireEvent.wheel(container, {
+      deltaY: 0,
+      deltaX: 50,
+      clientX: 200,
+      clientY: 150,
+      ctrlKey: true,
+    });
+
+    await waitFor(() => {
+      expect(zoomAt).not.toHaveBeenCalled();
+    });
+  });
+
+  it("Space+ドラッグ開始時は選択を解除しない", async () => {
+    const { hook, onClearSelection } = mountGestures();
+
+    window.dispatchEvent(new KeyboardEvent("keydown", { code: "Space", bubbles: true }));
+
+    hook.result.current.stageContainerProps.onMouseDownCapture({
+      button: 0,
+      clientX: 50,
+      clientY: 50,
+      preventDefault: vi.fn(),
+      stopPropagation: vi.fn(),
+    } as unknown as ReactMouseEvent<HTMLDivElement>);
+
+    expect(onClearSelection).not.toHaveBeenCalled();
+  });
 });

--- a/features/editor/hooks/useEditorViewportGestures.ts
+++ b/features/editor/hooks/useEditorViewportGestures.ts
@@ -115,6 +115,16 @@ export function useEditorViewportGestures({
     viewZoomRef.current = viewZoom;
   }, [viewZoom]);
 
+  const canPanRef = useRef(canPan);
+  useEffect(() => {
+    canPanRef.current = canPan;
+  }, [canPan]);
+
+  const modeRef = useRef(mode);
+  useEffect(() => {
+    modeRef.current = mode;
+  }, [mode]);
+
   const spacePressedRef = useRef(false);
   const panSessionRef = useRef<{
     lastClientX: number;
@@ -162,6 +172,7 @@ export function useEditorViewportGestures({
   useEffect(() => {
     const onKeyDown = (e: KeyboardEvent) => {
       if (e.code !== "Space" || e.repeat || isEditableKeyboardTarget(e.target)) return;
+      if (!canPanRef.current || modeRef.current !== "select") return;
       e.preventDefault();
       spacePressedRef.current = true;
       setIsSpacePanMode(true);
@@ -237,7 +248,7 @@ export function useEditorViewportGestures({
       const center = touchCenter(t0, t1);
       const stagePos = clientToStagePos(center.x, center.y);
       if (!stagePos) return;
-      e.preventDefault();
+      if (e.cancelable) e.preventDefault();
       pinchSessionRef.current = {
         initialDistance: touchDistance(t0, t1),
         initialZoom: viewZoomRef.current,
@@ -253,7 +264,7 @@ export function useEditorViewportGestures({
         const t0 = e.touches[0];
         const t1 = e.touches[1];
         if (!t0 || !t1) return;
-        e.preventDefault();
+        if (e.cancelable) e.preventDefault();
         const dist = touchDistance(t0, t1);
         if (pinch.initialDistance <= 0) return;
         const center = touchCenter(t0, t1);

--- a/features/editor/hooks/useEditorViewportGestures.ts
+++ b/features/editor/hooks/useEditorViewportGestures.ts
@@ -59,6 +59,11 @@ export interface UseEditorViewportGesturesParams {
   panByStageDelta: (stageDelta: { x: number; y: number }) => void;
   /** 空白上でパンを開始するときに選択を外す */
   onClearSelection: () => void;
+  /**
+   * true のときホイールは Ctrl/Cmd+ホイールのみズームし、通常ホイールは親スクロールに任せる
+   * （モーダル内 `overflow-auto` 向け）
+   */
+  pinViewportControls?: boolean;
 }
 
 interface UseEditorViewportGesturesReturn {
@@ -83,7 +88,11 @@ interface UseEditorViewportGesturesReturn {
 }
 
 /**
- * EditorCanvas のホイールズーム・Space+パン・ピンチ・SP 1 本指パンを扱う
+ * EditorCanvas のホイールズーム・パン・ピンチを扱う。
+ *
+ * パン（viewZoom > 1・選択モード）:
+ * - PC: 空白ドラッグ、または Space+ドラッグ（オブジェクト上でも画面移動）
+ * - SP: 空白上の 1 本指ドラッグ
  */
 export function useEditorViewportGestures({
   stageContainerRef,
@@ -96,6 +105,7 @@ export function useEditorViewportGestures({
   setZoomAt,
   panByStageDelta,
   onClearSelection,
+  pinViewportControls = false,
 }: UseEditorViewportGesturesParams): UseEditorViewportGesturesReturn {
   const [isGestureCapturing, setIsGestureCapturing] = useState(false);
   const [isSpacePanMode, setIsSpacePanMode] = useState(false);
@@ -206,6 +216,9 @@ export function useEditorViewportGestures({
     if (!el) return;
 
     const onWheel = (e: WheelEvent) => {
+      if (pinViewportControls && !e.ctrlKey && !e.metaKey) {
+        return;
+      }
       e.preventDefault();
       const zoomDelta = wheelEventToZoomDelta(e.deltaY, e.deltaMode);
       if (zoomDelta === 0) return;
@@ -248,20 +261,6 @@ export function useEditorViewportGestures({
         setZoomAt(stagePos, stageWidth, stageHeight, pinch.initialZoom * ratio);
         return;
       }
-
-      const touchPan = dragPanSessionRef.current;
-      if (touchPan && e.touches.length === 1) {
-        const t = e.touches[0];
-        if (!t) return;
-        if (e.cancelable) e.preventDefault();
-        const dx = t.clientX - touchPan.lastClientX;
-        const dy = t.clientY - touchPan.lastClientY;
-        touchPan.lastClientX = t.clientX;
-        touchPan.lastClientY = t.clientY;
-        if (dx !== 0 || dy !== 0) {
-          panByStageDelta({ x: dx, y: dy });
-        }
-      }
     };
 
     const onTouchEnd = (e: TouchEvent) => {
@@ -296,6 +295,7 @@ export function useEditorViewportGestures({
     panByStageDelta,
     endPanSession,
     endPinchSession,
+    pinViewportControls,
   ]);
 
   const stageContainerProps = {
@@ -355,6 +355,7 @@ export function useEditorViewportGestures({
         return true;
       }
 
+      // PC: 空白ドラッグでもパン（拡大時）。オブジェクト上は Space+ドラッグに限定。
       if (!isEmptyStageHit(e)) return false;
       onClearSelection();
       startDragPan(mouseEvt.clientX, mouseEvt.clientY);

--- a/features/editor/hooks/useEditorViewportGestures.ts
+++ b/features/editor/hooks/useEditorViewportGestures.ts
@@ -1,0 +1,368 @@
+"use client";
+
+import type { KonvaEventObject } from "konva/lib/Node";
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type MouseEvent as ReactMouseEvent,
+  type RefObject,
+} from "react";
+import type { EditorMode } from "../types";
+import { wheelDeltaToZoomDelta } from "../lib/viewZoom";
+
+/** 2 点間の距離（px） */
+function touchDistance(t0: Touch, t1: Touch): number {
+  const dx = t1.clientX - t0.clientX;
+  const dy = t1.clientY - t0.clientY;
+  return Math.hypot(dx, dy);
+}
+
+/** 2 点の中点（クライアント座標） */
+function touchCenter(t0: Touch, t1: Touch): { x: number; y: number } {
+  return {
+    x: (t0.clientX + t1.clientX) / 2,
+    y: (t0.clientY + t1.clientY) / 2,
+  };
+}
+
+interface UseEditorViewportGesturesParams {
+  /** ホイール・タッチを受け取るステージラッパー */
+  stageContainerRef: RefObject<HTMLDivElement | null>;
+  stageWidth: number;
+  stageHeight: number;
+  viewZoom: number;
+  mode: EditorMode;
+  canPan: boolean;
+  zoomAt: (
+    stagePos: { x: number; y: number },
+    stageWidth: number,
+    stageHeight: number,
+    zoomDelta: number
+  ) => void;
+  setZoomAt: (
+    stagePos: { x: number; y: number },
+    stageWidth: number,
+    stageHeight: number,
+    absoluteZoom: number
+  ) => void;
+  panByStageDelta: (stageDelta: { x: number; y: number }) => void;
+}
+
+interface UseEditorViewportGesturesReturn {
+  /** ピンチ／Space+パン中は Konva のポインタハンドラを抑止する */
+  isGestureCapturing: boolean;
+  /** Space 押下中（パン可能カーソル表示用） */
+  isSpacePanMode: boolean;
+  /** ステージラッパーに付与するキャプチャ用 props */
+  stageContainerProps: {
+    onMouseDownCapture: (e: ReactMouseEvent<HTMLDivElement>) => void;
+  };
+  /** Konva の pointerDown より先にパンを開始できる場合 true */
+  tryConsumeStagePointerDown: (
+    e: KonvaEventObject<MouseEvent> | KonvaEventObject<TouchEvent>
+  ) => boolean;
+  tryConsumeStagePointerMove: (
+    e: KonvaEventObject<MouseEvent> | KonvaEventObject<TouchEvent>
+  ) => boolean;
+  tryConsumeStagePointerUp: () => boolean;
+}
+
+/**
+ * EditorCanvas のホイールズーム・Space+パン・ピンチ・SP 1 本指パンを扱う
+ */
+export function useEditorViewportGestures({
+  stageContainerRef,
+  stageWidth,
+  stageHeight,
+  viewZoom,
+  mode,
+  canPan,
+  zoomAt,
+  setZoomAt,
+  panByStageDelta,
+}: UseEditorViewportGesturesParams): UseEditorViewportGesturesReturn {
+  const [isGestureCapturing, setIsGestureCapturing] = useState(false);
+  const [isSpacePanMode, setIsSpacePanMode] = useState(false);
+
+  const viewZoomRef = useRef(viewZoom);
+  useEffect(() => {
+    viewZoomRef.current = viewZoom;
+  }, [viewZoom]);
+
+  const spacePressedRef = useRef(false);
+  const panSessionRef = useRef<{
+    lastClientX: number;
+    lastClientY: number;
+  } | null>(null);
+  const pinchSessionRef = useRef<{
+    initialDistance: number;
+    initialZoom: number;
+    focalStagePos: { x: number; y: number };
+  } | null>(null);
+  const touchPanSessionRef = useRef<{
+    lastClientX: number;
+    lastClientY: number;
+  } | null>(null);
+
+  const clientToStagePos = useCallback(
+    (clientX: number, clientY: number): { x: number; y: number } | null => {
+      const el = stageContainerRef.current;
+      if (!el) return null;
+      const rect = el.getBoundingClientRect();
+      return {
+        x: clientX - rect.left,
+        y: clientY - rect.top,
+      };
+    },
+    [stageContainerRef]
+  );
+
+  const endPanSession = useCallback(() => {
+    panSessionRef.current = null;
+    touchPanSessionRef.current = null;
+    setIsGestureCapturing(false);
+  }, []);
+
+  const endPinchSession = useCallback(() => {
+    pinchSessionRef.current = null;
+    setIsGestureCapturing(false);
+  }, []);
+
+  /** Space キーでパンモード切替 */
+  useEffect(() => {
+    const isEditableTarget = (target: EventTarget | null): boolean => {
+      if (!(target instanceof HTMLElement)) return false;
+      const tag = target.tagName;
+      return tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT" || target.isContentEditable;
+    };
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.code !== "Space" || e.repeat || isEditableTarget(e.target)) return;
+      e.preventDefault();
+      spacePressedRef.current = true;
+      setIsSpacePanMode(true);
+    };
+
+    const onKeyUp = (e: KeyboardEvent) => {
+      if (e.code !== "Space") return;
+      spacePressedRef.current = false;
+      setIsSpacePanMode(false);
+      endPanSession();
+    };
+
+    window.addEventListener("keydown", onKeyDown);
+    window.addEventListener("keyup", onKeyUp);
+    return () => {
+      window.removeEventListener("keydown", onKeyDown);
+      window.removeEventListener("keyup", onKeyUp);
+    };
+  }, [endPanSession]);
+
+  /** Space + 左ドラッグ（PC） */
+  useEffect(() => {
+    const onMouseMove = (e: globalThis.MouseEvent) => {
+      const session = panSessionRef.current;
+      if (!session) return;
+      const dx = e.clientX - session.lastClientX;
+      const dy = e.clientY - session.lastClientY;
+      session.lastClientX = e.clientX;
+      session.lastClientY = e.clientY;
+      if (dx !== 0 || dy !== 0) {
+        panByStageDelta({ x: dx, y: dy });
+      }
+    };
+
+    const onMouseUp = () => {
+      if (panSessionRef.current) {
+        endPanSession();
+      }
+    };
+
+    window.addEventListener("mousemove", onMouseMove);
+    window.addEventListener("mouseup", onMouseUp);
+    return () => {
+      window.removeEventListener("mousemove", onMouseMove);
+      window.removeEventListener("mouseup", onMouseUp);
+    };
+  }, [panByStageDelta, endPanSession]);
+
+  /** ホイールズーム・2 本指ピンチ */
+  useEffect(() => {
+    const el = stageContainerRef.current;
+    if (!el) return;
+
+    const onWheel = (e: WheelEvent) => {
+      e.preventDefault();
+      const stagePos = clientToStagePos(e.clientX, e.clientY);
+      if (!stagePos || stageWidth <= 0 || stageHeight <= 0) return;
+      const zoomDelta = wheelDeltaToZoomDelta(e.deltaY);
+      zoomAt(stagePos, stageWidth, stageHeight, zoomDelta);
+    };
+
+    const onTouchStart = (e: TouchEvent) => {
+      if (e.touches.length < 2) return;
+      const t0 = e.touches[0];
+      const t1 = e.touches[1];
+      if (!t0 || !t1) return;
+      const center = touchCenter(t0, t1);
+      const stagePos = clientToStagePos(center.x, center.y);
+      if (!stagePos) return;
+      e.preventDefault();
+      pinchSessionRef.current = {
+        initialDistance: touchDistance(t0, t1),
+        initialZoom: viewZoomRef.current,
+        focalStagePos: stagePos,
+      };
+      touchPanSessionRef.current = null;
+      setIsGestureCapturing(true);
+    };
+
+    const onTouchMove = (e: TouchEvent) => {
+      const pinch = pinchSessionRef.current;
+      if (pinch && e.touches.length >= 2) {
+        const t0 = e.touches[0];
+        const t1 = e.touches[1];
+        if (!t0 || !t1) return;
+        e.preventDefault();
+        const dist = touchDistance(t0, t1);
+        if (pinch.initialDistance <= 0) return;
+        const center = touchCenter(t0, t1);
+        const stagePos = clientToStagePos(center.x, center.y) ?? pinch.focalStagePos;
+        const ratio = dist / pinch.initialDistance;
+        setZoomAt(stagePos, stageWidth, stageHeight, pinch.initialZoom * ratio);
+        return;
+      }
+
+      const touchPan = touchPanSessionRef.current;
+      if (touchPan && e.touches.length === 1) {
+        const t = e.touches[0];
+        if (!t) return;
+        if (e.cancelable) e.preventDefault();
+        const dx = t.clientX - touchPan.lastClientX;
+        const dy = t.clientY - touchPan.lastClientY;
+        touchPan.lastClientX = t.clientX;
+        touchPan.lastClientY = t.clientY;
+        if (dx !== 0 || dy !== 0) {
+          panByStageDelta({ x: dx, y: dy });
+        }
+      }
+    };
+
+    const onTouchEnd = (e: TouchEvent) => {
+      if (e.touches.length < 2) {
+        endPinchSession();
+      }
+      if (e.touches.length === 0) {
+        endPanSession();
+      }
+    };
+
+    el.addEventListener("wheel", onWheel, { passive: false });
+    el.addEventListener("touchstart", onTouchStart, { passive: false });
+    el.addEventListener("touchmove", onTouchMove, { passive: false });
+    el.addEventListener("touchend", onTouchEnd);
+    el.addEventListener("touchcancel", onTouchEnd);
+
+    return () => {
+      el.removeEventListener("wheel", onWheel);
+      el.removeEventListener("touchstart", onTouchStart);
+      el.removeEventListener("touchmove", onTouchMove);
+      el.removeEventListener("touchend", onTouchEnd);
+      el.removeEventListener("touchcancel", onTouchEnd);
+    };
+  }, [
+    stageContainerRef,
+    stageWidth,
+    stageHeight,
+    clientToStagePos,
+    zoomAt,
+    setZoomAt,
+    panByStageDelta,
+    endPanSession,
+    endPinchSession,
+  ]);
+
+  const stageContainerProps = {
+    onMouseDownCapture: (e: ReactMouseEvent<HTMLDivElement>) => {
+      if (
+        !spacePressedRef.current ||
+        !canPan ||
+        mode !== "select" ||
+        e.button !== 0 ||
+        stageWidth <= 0
+      ) {
+        return;
+      }
+      e.preventDefault();
+      e.stopPropagation();
+      panSessionRef.current = {
+        lastClientX: e.clientX,
+        lastClientY: e.clientY,
+      };
+      setIsGestureCapturing(true);
+    },
+  };
+
+  const tryConsumeStagePointerDown = useCallback(
+    (e: KonvaEventObject<globalThis.MouseEvent> | KonvaEventObject<TouchEvent>): boolean => {
+      if (pinchSessionRef.current || panSessionRef.current) return true;
+
+      if ("touches" in e.evt) {
+        if (e.evt.touches.length >= 2) return true;
+        if (mode !== "select" || !canPan) return false;
+        const stage = e.target.getStage();
+        if (!stage || e.target !== stage) return false;
+        const touch = e.evt.touches[0];
+        if (!touch) return false;
+        touchPanSessionRef.current = {
+          lastClientX: touch.clientX,
+          lastClientY: touch.clientY,
+        };
+        setIsGestureCapturing(true);
+        if (e.evt.cancelable) e.evt.preventDefault();
+        return true;
+      }
+
+      return false;
+    },
+    [mode, canPan]
+  );
+
+  const tryConsumeStagePointerMove = useCallback(
+    (e: KonvaEventObject<globalThis.MouseEvent> | KonvaEventObject<TouchEvent>): boolean => {
+      const touchPan = touchPanSessionRef.current;
+      if (!touchPan || !("touches" in e.evt)) return false;
+      const touch = e.evt.touches[0];
+      if (!touch) return false;
+      if (e.evt.cancelable) e.evt.preventDefault();
+      const dx = touch.clientX - touchPan.lastClientX;
+      const dy = touch.clientY - touchPan.lastClientY;
+      touchPan.lastClientX = touch.clientX;
+      touchPan.lastClientY = touch.clientY;
+      if (dx !== 0 || dy !== 0) {
+        panByStageDelta({ x: dx, y: dy });
+      }
+      return true;
+    },
+    [panByStageDelta]
+  );
+
+  const tryConsumeStagePointerUp = useCallback((): boolean => {
+    if (touchPanSessionRef.current) {
+      endPanSession();
+      return true;
+    }
+    return false;
+  }, [endPanSession]);
+
+  return {
+    isGestureCapturing,
+    isSpacePanMode,
+    stageContainerProps,
+    tryConsumeStagePointerDown,
+    tryConsumeStagePointerMove,
+    tryConsumeStagePointerUp,
+  };
+}

--- a/features/editor/hooks/useEditorViewportGestures.ts
+++ b/features/editor/hooks/useEditorViewportGestures.ts
@@ -10,7 +10,7 @@ import {
   type RefObject,
 } from "react";
 import type { EditorMode } from "../types";
-import { wheelDeltaToZoomDelta } from "../lib/viewZoom";
+import { wheelEventToZoomDelta } from "../lib/viewZoom";
 
 /** 2 点間の距離（px） */
 function touchDistance(t0: Touch, t1: Touch): number {
@@ -107,7 +107,6 @@ export function useEditorViewportGestures({
     lastClientX: number;
     lastClientY: number;
   } | null>(null);
-
   const hasActivePanSession = useCallback(
     () => panSessionRef.current !== null || dragPanSessionRef.current !== null,
     []
@@ -202,9 +201,11 @@ export function useEditorViewportGestures({
 
     const onWheel = (e: WheelEvent) => {
       e.preventDefault();
+      const zoomDelta = wheelEventToZoomDelta(e.deltaY, e.deltaMode);
+      if (zoomDelta === 0) return;
+
       const stagePos = clientToStagePos(e.clientX, e.clientY);
       if (!stagePos || stageWidth <= 0 || stageHeight <= 0) return;
-      const zoomDelta = wheelDeltaToZoomDelta(e.deltaY);
       zoomAt(stagePos, stageWidth, stageHeight, zoomDelta);
     };
 

--- a/features/editor/hooks/useEditorViewportGestures.ts
+++ b/features/editor/hooks/useEditorViewportGestures.ts
@@ -222,9 +222,10 @@ export function useEditorViewportGestures({
       const zoomDelta = wheelEventToZoomDelta(e.deltaY, e.deltaMode);
       if (zoomDelta === 0) return;
 
-      e.preventDefault();
       const stagePos = clientToStagePos(e.clientX, e.clientY);
       if (!stagePos || stageWidth <= 0 || stageHeight <= 0) return;
+
+      e.preventDefault();
       zoomAt(stagePos, stageWidth, stageHeight, zoomDelta);
     };
 
@@ -292,7 +293,6 @@ export function useEditorViewportGestures({
     clientToStagePos,
     zoomAt,
     setZoomAt,
-    panByStageDelta,
     endPanSession,
     endPinchSession,
     pinViewportControls,

--- a/features/editor/hooks/useEditorViewportGestures.ts
+++ b/features/editor/hooks/useEditorViewportGestures.ts
@@ -27,6 +27,14 @@ function touchCenter(t0: Touch, t1: Touch): { x: number; y: number } {
   };
 }
 
+/** Konva イベントが Stage 空白（背景）へのヒットか */
+function isEmptyStageHit(
+  e: KonvaEventObject<globalThis.MouseEvent> | KonvaEventObject<TouchEvent>
+): boolean {
+  const stage = e.target.getStage();
+  return stage !== null && (e.target === stage || e.target.getType() === "Stage");
+}
+
 interface UseEditorViewportGesturesParams {
   /** ホイール・タッチを受け取るステージラッパー */
   stageContainerRef: RefObject<HTMLDivElement | null>;
@@ -48,6 +56,8 @@ interface UseEditorViewportGesturesParams {
     absoluteZoom: number
   ) => void;
   panByStageDelta: (stageDelta: { x: number; y: number }) => void;
+  /** 空白上でパンを開始するときに選択を外す */
+  onClearSelection: () => void;
 }
 
 interface UseEditorViewportGesturesReturn {
@@ -84,6 +94,7 @@ export function useEditorViewportGestures({
   zoomAt,
   setZoomAt,
   panByStageDelta,
+  onClearSelection,
 }: UseEditorViewportGesturesParams): UseEditorViewportGesturesReturn {
   const [isGestureCapturing, setIsGestureCapturing] = useState(false);
   const [isSpacePanMode, setIsSpacePanMode] = useState(false);
@@ -305,6 +316,7 @@ export function useEditorViewportGestures({
       }
       e.preventDefault();
       e.stopPropagation();
+      onClearSelection();
       panSessionRef.current = {
         lastClientX: e.clientX,
         lastClientY: e.clientY,
@@ -330,10 +342,10 @@ export function useEditorViewportGestures({
       if ("touches" in e.evt) {
         if (e.evt.touches.length >= 2) return true;
         if (mode !== "select" || !canPan) return false;
-        const stage = e.target.getStage();
-        if (!stage || e.target !== stage) return false;
+        if (!isEmptyStageHit(e)) return false;
         const touch = e.evt.touches[0];
         if (!touch) return false;
+        onClearSelection();
         startDragPan(touch.clientX, touch.clientY);
         if (e.evt.cancelable) e.evt.preventDefault();
         return true;
@@ -348,13 +360,13 @@ export function useEditorViewportGestures({
         return true;
       }
 
-      const stage = e.target.getStage();
-      if (!stage || e.target !== stage) return false;
+      if (!isEmptyStageHit(e)) return false;
+      onClearSelection();
       startDragPan(mouseEvt.clientX, mouseEvt.clientY);
       mouseEvt.preventDefault();
       return true;
     },
-    [mode, canPan, startDragPan]
+    [mode, canPan, startDragPan, onClearSelection]
   );
 
   const tryConsumeStagePointerMove = useCallback(

--- a/features/editor/hooks/useEditorViewportGestures.ts
+++ b/features/editor/hooks/useEditorViewportGestures.ts
@@ -10,6 +10,7 @@ import {
   type RefObject,
 } from "react";
 import type { EditorMode } from "../types";
+import { isEditableKeyboardTarget } from "../lib/isEditableKeyboardTarget";
 import { wheelEventToZoomDelta } from "../lib/viewZoom";
 
 /** 2 点間の距離（px） */
@@ -35,7 +36,7 @@ function isEmptyStageHit(
   return stage !== null && (e.target === stage || e.target.getType() === "Stage");
 }
 
-interface UseEditorViewportGesturesParams {
+export interface UseEditorViewportGesturesParams {
   /** ホイール・タッチを受け取るステージラッパー */
   stageContainerRef: RefObject<HTMLDivElement | null>;
   stageWidth: number;
@@ -149,14 +150,8 @@ export function useEditorViewportGestures({
 
   /** Space キーでパンモード切替 */
   useEffect(() => {
-    const isEditableTarget = (target: EventTarget | null): boolean => {
-      if (!(target instanceof HTMLElement)) return false;
-      const tag = target.tagName;
-      return tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT" || target.isContentEditable;
-    };
-
     const onKeyDown = (e: KeyboardEvent) => {
-      if (e.code !== "Space" || e.repeat || isEditableTarget(e.target)) return;
+      if (e.code !== "Space" || e.repeat || isEditableKeyboardTarget(e.target)) return;
       e.preventDefault();
       spacePressedRef.current = true;
       setIsSpacePanMode(true);

--- a/features/editor/hooks/useEditorViewportGestures.ts
+++ b/features/editor/hooks/useEditorViewportGestures.ts
@@ -219,10 +219,10 @@ export function useEditorViewportGestures({
       if (pinViewportControls && !e.ctrlKey && !e.metaKey) {
         return;
       }
-      e.preventDefault();
       const zoomDelta = wheelEventToZoomDelta(e.deltaY, e.deltaMode);
       if (zoomDelta === 0) return;
 
+      e.preventDefault();
       const stagePos = clientToStagePos(e.clientX, e.clientY);
       if (!stagePos || stageWidth <= 0 || stageHeight <= 0) return;
       zoomAt(stagePos, stageWidth, stageHeight, zoomDelta);
@@ -311,7 +311,6 @@ export function useEditorViewportGestures({
       }
       e.preventDefault();
       e.stopPropagation();
-      onClearSelection();
       panSessionRef.current = {
         lastClientX: e.clientX,
         lastClientY: e.clientY,

--- a/features/editor/hooks/useEditorViewportGestures.ts
+++ b/features/editor/hooks/useEditorViewportGestures.ts
@@ -51,8 +51,10 @@ interface UseEditorViewportGesturesParams {
 }
 
 interface UseEditorViewportGesturesReturn {
-  /** ピンチ／Space+パン中は Konva のポインタハンドラを抑止する */
+  /** ピンチ／パン中は Konva のポインタハンドラを抑止する */
   isGestureCapturing: boolean;
+  /** パンセッションが進行中か（state 更新前の同期判定用） */
+  hasActivePanSession: () => boolean;
   /** Space 押下中（パン可能カーソル表示用） */
   isSpacePanMode: boolean;
   /** ステージラッパーに付与するキャプチャ用 props */
@@ -101,10 +103,15 @@ export function useEditorViewportGestures({
     initialZoom: number;
     focalStagePos: { x: number; y: number };
   } | null>(null);
-  const touchPanSessionRef = useRef<{
+  const dragPanSessionRef = useRef<{
     lastClientX: number;
     lastClientY: number;
   } | null>(null);
+
+  const hasActivePanSession = useCallback(
+    () => panSessionRef.current !== null || dragPanSessionRef.current !== null,
+    []
+  );
 
   const clientToStagePos = useCallback(
     (clientX: number, clientY: number): { x: number; y: number } | null => {
@@ -121,7 +128,7 @@ export function useEditorViewportGestures({
 
   const endPanSession = useCallback(() => {
     panSessionRef.current = null;
-    touchPanSessionRef.current = null;
+    dragPanSessionRef.current = null;
     setIsGestureCapturing(false);
   }, []);
 
@@ -175,7 +182,7 @@ export function useEditorViewportGestures({
     };
 
     const onMouseUp = () => {
-      if (panSessionRef.current) {
+      if (panSessionRef.current || dragPanSessionRef.current) {
         endPanSession();
       }
     };
@@ -215,7 +222,7 @@ export function useEditorViewportGestures({
         initialZoom: viewZoomRef.current,
         focalStagePos: stagePos,
       };
-      touchPanSessionRef.current = null;
+      dragPanSessionRef.current = null;
       setIsGestureCapturing(true);
     };
 
@@ -235,7 +242,7 @@ export function useEditorViewportGestures({
         return;
       }
 
-      const touchPan = touchPanSessionRef.current;
+      const touchPan = dragPanSessionRef.current;
       if (touchPan && e.touches.length === 1) {
         const t = e.touches[0];
         if (!t) return;
@@ -305,9 +312,19 @@ export function useEditorViewportGestures({
     },
   };
 
+  const startDragPan = useCallback((clientX: number, clientY: number) => {
+    dragPanSessionRef.current = {
+      lastClientX: clientX,
+      lastClientY: clientY,
+    };
+    setIsGestureCapturing(true);
+  }, []);
+
   const tryConsumeStagePointerDown = useCallback(
     (e: KonvaEventObject<globalThis.MouseEvent> | KonvaEventObject<TouchEvent>): boolean => {
-      if (pinchSessionRef.current || panSessionRef.current) return true;
+      if (pinchSessionRef.current || panSessionRef.current || dragPanSessionRef.current) {
+        return true;
+      }
 
       if ("touches" in e.evt) {
         if (e.evt.touches.length >= 2) return true;
@@ -316,31 +333,55 @@ export function useEditorViewportGestures({
         if (!stage || e.target !== stage) return false;
         const touch = e.evt.touches[0];
         if (!touch) return false;
-        touchPanSessionRef.current = {
-          lastClientX: touch.clientX,
-          lastClientY: touch.clientY,
-        };
-        setIsGestureCapturing(true);
+        startDragPan(touch.clientX, touch.clientY);
         if (e.evt.cancelable) e.evt.preventDefault();
         return true;
       }
 
-      return false;
+      const mouseEvt = e.evt;
+      if (mouseEvt.button !== 0 || mode !== "select" || !canPan) return false;
+
+      if (spacePressedRef.current) {
+        startDragPan(mouseEvt.clientX, mouseEvt.clientY);
+        mouseEvt.preventDefault();
+        return true;
+      }
+
+      const stage = e.target.getStage();
+      if (!stage || e.target !== stage) return false;
+      startDragPan(mouseEvt.clientX, mouseEvt.clientY);
+      mouseEvt.preventDefault();
+      return true;
     },
-    [mode, canPan]
+    [mode, canPan, startDragPan]
   );
 
   const tryConsumeStagePointerMove = useCallback(
     (e: KonvaEventObject<globalThis.MouseEvent> | KonvaEventObject<TouchEvent>): boolean => {
-      const touchPan = touchPanSessionRef.current;
-      if (!touchPan || !("touches" in e.evt)) return false;
-      const touch = e.evt.touches[0];
-      if (!touch) return false;
-      if (e.evt.cancelable) e.evt.preventDefault();
-      const dx = touch.clientX - touchPan.lastClientX;
-      const dy = touch.clientY - touchPan.lastClientY;
-      touchPan.lastClientX = touch.clientX;
-      touchPan.lastClientY = touch.clientY;
+      const dragPan = dragPanSessionRef.current;
+      if (!dragPan) return false;
+
+      if ("touches" in e.evt) {
+        const touch = e.evt.touches[0];
+        if (!touch) return false;
+        if (e.evt.cancelable) e.evt.preventDefault();
+        const dx = touch.clientX - dragPan.lastClientX;
+        const dy = touch.clientY - dragPan.lastClientY;
+        dragPan.lastClientX = touch.clientX;
+        dragPan.lastClientY = touch.clientY;
+        if (dx !== 0 || dy !== 0) {
+          panByStageDelta({ x: dx, y: dy });
+        }
+        return true;
+      }
+
+      const mouseEvt = e.evt;
+      if (mouseEvt.buttons !== 1) return false;
+      mouseEvt.preventDefault();
+      const dx = mouseEvt.clientX - dragPan.lastClientX;
+      const dy = mouseEvt.clientY - dragPan.lastClientY;
+      dragPan.lastClientX = mouseEvt.clientX;
+      dragPan.lastClientY = mouseEvt.clientY;
       if (dx !== 0 || dy !== 0) {
         panByStageDelta({ x: dx, y: dy });
       }
@@ -350,7 +391,7 @@ export function useEditorViewportGestures({
   );
 
   const tryConsumeStagePointerUp = useCallback((): boolean => {
-    if (touchPanSessionRef.current) {
+    if (dragPanSessionRef.current) {
       endPanSession();
       return true;
     }
@@ -359,6 +400,7 @@ export function useEditorViewportGestures({
 
   return {
     isGestureCapturing,
+    hasActivePanSession,
     isSpacePanMode,
     stageContainerProps,
     tryConsumeStagePointerDown,

--- a/features/editor/lib/isEditableKeyboardTarget.test.ts
+++ b/features/editor/lib/isEditableKeyboardTarget.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { isEditableKeyboardTarget } from "./isEditableKeyboardTarget";
+
+describe("isEditableKeyboardTarget", () => {
+  it("INPUT にフォーカス中は true", () => {
+    const input = document.createElement("input");
+    expect(isEditableKeyboardTarget(input)).toBe(true);
+  });
+
+  it("button にフォーカス中は true", () => {
+    const button = document.createElement("button");
+    expect(isEditableKeyboardTarget(button)).toBe(true);
+  });
+
+  it("button 内の子要素も true", () => {
+    const button = document.createElement("button");
+    const span = document.createElement("span");
+    button.appendChild(span);
+    expect(isEditableKeyboardTarget(span)).toBe(true);
+  });
+
+  it("div のみは false", () => {
+    expect(isEditableKeyboardTarget(document.createElement("div"))).toBe(false);
+  });
+});

--- a/features/editor/lib/isEditableKeyboardTarget.ts
+++ b/features/editor/lib/isEditableKeyboardTarget.ts
@@ -1,10 +1,15 @@
 /**
- * キーボードショートカットを無効化すべきフォーカス先か（入力系 UI）
+ * エディタのグローバルショートカットを無効化すべきフォーカス先か
+ *
+ * 入力系 UI のほか、Space で押下される button / リンク等も対象とする。
  *
  * @param target - keydown 等の event.target
  */
 export function isEditableKeyboardTarget(target: EventTarget | null): boolean {
   if (!(target instanceof HTMLElement)) return false;
   const tag = target.tagName;
-  return tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT" || target.isContentEditable;
+  if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT" || target.isContentEditable) {
+    return true;
+  }
+  return target.closest('button, a[href], [role="button"], [role="link"], summary') !== null;
 }

--- a/features/editor/lib/isEditableKeyboardTarget.ts
+++ b/features/editor/lib/isEditableKeyboardTarget.ts
@@ -1,0 +1,10 @@
+/**
+ * キーボードショートカットを無効化すべきフォーカス先か（入力系 UI）
+ *
+ * @param target - keydown 等の event.target
+ */
+export function isEditableKeyboardTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  const tag = target.tagName;
+  return tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT" || target.isContentEditable;
+}

--- a/features/editor/lib/isEditableKeyboardTarget.ts
+++ b/features/editor/lib/isEditableKeyboardTarget.ts
@@ -11,5 +11,5 @@ export function isEditableKeyboardTarget(target: EventTarget | null): boolean {
   if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT" || target.isContentEditable) {
     return true;
   }
-  return target.closest('button, a[href], [role="button"], [role="link"], summary') !== null;
+  return target.closest("button, a[href], [role='button'], [role='link'], summary") !== null;
 }

--- a/features/editor/lib/viewZoom.test.ts
+++ b/features/editor/lib/viewZoom.test.ts
@@ -10,8 +10,7 @@ import {
   stagePointerToContentSpace,
   normalizeWheelDeltaY,
   wheelEventToZoomDelta,
-  WHEEL_ZOOM_DELTA_CAP,
-  WHEEL_PIXELS_PER_ZOOM_STEP,
+  MOUSE_WHEEL_ZOOM_FACTOR,
 } from "./viewZoom";
 
 describe("clampViewZoom", () => {
@@ -129,20 +128,18 @@ describe("panViewCenterByStageDelta", () => {
 });
 
 describe("wheelEventToZoomDelta", () => {
-  it("下スクロールで縮小・上スクロールで拡大", () => {
-    expect(wheelEventToZoomDelta(45, 0)).toBeCloseTo(-0.05);
-    expect(wheelEventToZoomDelta(-45, 0)).toBeCloseTo(0.05);
+  it("トラックパッド（小さなピクセル delta）は 1 イベント 1 刻み", () => {
+    expect(wheelEventToZoomDelta(8, 0)).toBe(-VIEW_ZOOM.step);
+    expect(wheelEventToZoomDelta(-8, 0)).toBe(VIEW_ZOOM.step);
   });
 
-  it("大きな delta は 1 イベントあたりの上限でクランプする", () => {
-    expect(wheelEventToZoomDelta(500, 0)).toBe(-WHEEL_ZOOM_DELTA_CAP);
-    expect(wheelEventToZoomDelta(-500, 0)).toBe(WHEEL_ZOOM_DELTA_CAP);
+  it("マウスホイール（LINE）はやや弱い 1 刻み", () => {
+    expect(wheelEventToZoomDelta(3, 1)).toBe(-VIEW_ZOOM.step * MOUSE_WHEEL_ZOOM_FACTOR);
+    expect(wheelEventToZoomDelta(-3, 1)).toBe(VIEW_ZOOM.step * MOUSE_WHEEL_ZOOM_FACTOR);
   });
 
-  it("トラックパッドの細かい delta は比例して小さく変化する", () => {
-    const small = wheelEventToZoomDelta(6, 0);
-    expect(small).toBeCloseTo(-6 / WHEEL_PIXELS_PER_ZOOM_STEP / 10);
-    expect(Math.abs(small)).toBeLessThan(WHEEL_ZOOM_DELTA_CAP);
+  it("ピクセルでも大きな一手はマウス扱い", () => {
+    expect(wheelEventToZoomDelta(120, 0)).toBe(-VIEW_ZOOM.step * MOUSE_WHEEL_ZOOM_FACTOR);
   });
 });
 

--- a/features/editor/lib/viewZoom.test.ts
+++ b/features/editor/lib/viewZoom.test.ts
@@ -3,9 +3,12 @@ import {
   VIEW_ZOOM,
   clampViewCenter,
   clampViewZoom,
+  computeViewCenterAfterZoomAt,
   getDefaultViewCenter,
+  panViewCenterByStageDelta,
   roundViewZoomStep,
   stagePointerToContentSpace,
+  wheelDeltaToZoomDelta,
 } from "./viewZoom";
 
 describe("clampViewZoom", () => {
@@ -75,5 +78,57 @@ describe("stagePointerToContentSpace", () => {
     const out = stagePointerToContentSpace({ x: 0, y: 0 }, w, h, z, { x: 150, y: 130 });
     expect(out.x).toBeCloseTo(100);
     expect(out.y).toBeCloseTo(80);
+  });
+});
+
+describe("computeViewCenterAfterZoomAt", () => {
+  it("ズーム後もステージ中心の下の画像点が同じコンテンツ座標に対応する", () => {
+    const w = 200;
+    const h = 100;
+    const scale = 1;
+    const center = { x: 100, y: 50 };
+    const stageCenter = { x: w / 2, y: h / 2 };
+    const before = stagePointerToContentSpace(stageCenter, w, h, 1, {
+      x: center.x * scale,
+      y: center.y * scale,
+    });
+    const afterCenter = computeViewCenterAfterZoomAt(
+      center,
+      stageCenter,
+      w,
+      h,
+      scale,
+      scale,
+      1,
+      2,
+      w,
+      h
+    );
+    const after = stagePointerToContentSpace(stageCenter, w, h, 2, {
+      x: afterCenter.x * scale,
+      y: afterCenter.y * scale,
+    });
+    expect(after.x).toBeCloseTo(before.x);
+    expect(after.y).toBeCloseTo(before.y);
+  });
+});
+
+describe("panViewCenterByStageDelta", () => {
+  it("ステージ右ドラッグで表示中心が左へ移動する", () => {
+    const w = 400;
+    const h = 200;
+    const z = 2;
+    const start = { x: 200, y: 100 };
+    const next = panViewCenterByStageDelta(start, { x: 24, y: 0 }, 1, 1, z, w, h);
+    expect(next.x).toBeCloseTo(start.x - 24 / z);
+    expect(next.y).toBe(start.y);
+  });
+});
+
+describe("wheelDeltaToZoomDelta", () => {
+  it("下スクロールで縮小・上スクロールで拡大", () => {
+    expect(wheelDeltaToZoomDelta(120)).toBe(-VIEW_ZOOM.step);
+    expect(wheelDeltaToZoomDelta(-120)).toBe(VIEW_ZOOM.step);
+    expect(wheelDeltaToZoomDelta(0)).toBe(0);
   });
 });

--- a/features/editor/lib/viewZoom.test.ts
+++ b/features/editor/lib/viewZoom.test.ts
@@ -8,7 +8,10 @@ import {
   panViewCenterByStageDelta,
   roundViewZoomStep,
   stagePointerToContentSpace,
-  wheelDeltaToZoomDelta,
+  normalizeWheelDeltaY,
+  wheelEventToZoomDelta,
+  WHEEL_ZOOM_DELTA_CAP,
+  WHEEL_PIXELS_PER_ZOOM_STEP,
 } from "./viewZoom";
 
 describe("clampViewZoom", () => {
@@ -125,10 +128,26 @@ describe("panViewCenterByStageDelta", () => {
   });
 });
 
-describe("wheelDeltaToZoomDelta", () => {
+describe("wheelEventToZoomDelta", () => {
   it("下スクロールで縮小・上スクロールで拡大", () => {
-    expect(wheelDeltaToZoomDelta(120)).toBe(-VIEW_ZOOM.step);
-    expect(wheelDeltaToZoomDelta(-120)).toBe(VIEW_ZOOM.step);
-    expect(wheelDeltaToZoomDelta(0)).toBe(0);
+    expect(wheelEventToZoomDelta(45, 0)).toBeCloseTo(-0.05);
+    expect(wheelEventToZoomDelta(-45, 0)).toBeCloseTo(0.05);
+  });
+
+  it("大きな delta は 1 イベントあたりの上限でクランプする", () => {
+    expect(wheelEventToZoomDelta(500, 0)).toBe(-WHEEL_ZOOM_DELTA_CAP);
+    expect(wheelEventToZoomDelta(-500, 0)).toBe(WHEEL_ZOOM_DELTA_CAP);
+  });
+
+  it("トラックパッドの細かい delta は比例して小さく変化する", () => {
+    const small = wheelEventToZoomDelta(6, 0);
+    expect(small).toBeCloseTo(-6 / WHEEL_PIXELS_PER_ZOOM_STEP / 10);
+    expect(Math.abs(small)).toBeLessThan(WHEEL_ZOOM_DELTA_CAP);
+  });
+});
+
+describe("normalizeWheelDeltaY", () => {
+  it("LINE モードは 16 倍してピクセル相当にする", () => {
+    expect(normalizeWheelDeltaY(3, 1)).toBe(48);
   });
 });

--- a/features/editor/lib/viewZoom.ts
+++ b/features/editor/lib/viewZoom.ts
@@ -193,14 +193,11 @@ export function panViewCenterByStageDelta(
   );
 }
 
-/** ピクセル換算でこの量のスクロールで VIEW_ZOOM.step 相当の倍率変化 */
-export const WHEEL_PIXELS_PER_ZOOM_STEP = 90;
+/** マウスホイール 1 ノッチあたりの倍率（VIEW_ZOOM.step よりやや弱め） */
+export const MOUSE_WHEEL_ZOOM_FACTOR = 0.8;
 
-/** 1 回の wheel で変えられる倍率の上限（トラックパッド連打・大きなノッチの飛びすぎ防止） */
-export const WHEEL_ZOOM_DELTA_CAP = 0.14;
-
-/** これ未満の変化は無視（トラックパッドの微小ノイズ） */
-export const WHEEL_ZOOM_MIN_DELTA = 0.001;
+/** ピクセルモードでもこの量以上ならマウスホイール相当とみなす */
+export const MOUSE_WHEEL_PIXEL_THRESHOLD = 40;
 
 /**
  * WheelEvent.deltaY をピクセル相当量に正規化する
@@ -221,17 +218,20 @@ export function normalizeWheelDeltaY(deltaY: number, deltaMode: number): number 
 /**
  * ホイール 1 イベント分の表示倍率変化量（下スクロールで縮小）
  *
- * delta の大きさに比例させつつ 1 イベントあたりの上限で抑え、トラックパッドは滑らかに・マウスは速すぎない中間にする。
+ * トラックパッドは最初どおり 1 イベント 1 刻み（0.1）。マウスホイールだけやや弱める。
  *
  * @param deltaY - WheelEvent.deltaY
  * @param deltaMode - WheelEvent.deltaMode
  */
 export function wheelEventToZoomDelta(deltaY: number, deltaMode: number): number {
-  const px = normalizeWheelDeltaY(deltaY, deltaMode);
-  if (px === 0) return 0;
+  if (deltaY === 0) return 0;
 
-  const raw = (-px / WHEEL_PIXELS_PER_ZOOM_STEP) * VIEW_ZOOM.step;
-  if (Math.abs(raw) < WHEEL_ZOOM_MIN_DELTA) return 0;
+  const step = -Math.sign(deltaY) * VIEW_ZOOM.step;
+  const px = Math.abs(normalizeWheelDeltaY(deltaY, deltaMode));
+  const isMouseLike = deltaMode === 1 || px >= MOUSE_WHEEL_PIXEL_THRESHOLD;
 
-  return Math.max(-WHEEL_ZOOM_DELTA_CAP, Math.min(WHEEL_ZOOM_DELTA_CAP, raw));
+  if (isMouseLike) {
+    return step * MOUSE_WHEEL_ZOOM_FACTOR;
+  }
+  return step;
 }

--- a/features/editor/lib/viewZoom.ts
+++ b/features/editor/lib/viewZoom.ts
@@ -193,12 +193,45 @@ export function panViewCenterByStageDelta(
   );
 }
 
+/** ピクセル換算でこの量のスクロールで VIEW_ZOOM.step 相当の倍率変化 */
+export const WHEEL_PIXELS_PER_ZOOM_STEP = 90;
+
+/** 1 回の wheel で変えられる倍率の上限（トラックパッド連打・大きなノッチの飛びすぎ防止） */
+export const WHEEL_ZOOM_DELTA_CAP = 0.14;
+
+/** これ未満の変化は無視（トラックパッドの微小ノイズ） */
+export const WHEEL_ZOOM_MIN_DELTA = 0.001;
+
 /**
- * ホイールの deltaY から表示倍率の増減量を求める（下スクロールで縮小）
+ * WheelEvent.deltaY をピクセル相当量に正規化する
  *
  * @param deltaY - WheelEvent.deltaY
+ * @param deltaMode - WheelEvent.deltaMode
  */
-export function wheelDeltaToZoomDelta(deltaY: number): number {
-  if (deltaY === 0) return 0;
-  return -Math.sign(deltaY) * VIEW_ZOOM.step;
+export function normalizeWheelDeltaY(deltaY: number, deltaMode: number): number {
+  if (deltaMode === 1) {
+    return deltaY * 16;
+  }
+  if (deltaMode === 2) {
+    return deltaY * 400;
+  }
+  return deltaY;
+}
+
+/**
+ * ホイール 1 イベント分の表示倍率変化量（下スクロールで縮小）
+ *
+ * delta の大きさに比例させつつ 1 イベントあたりの上限で抑え、トラックパッドは滑らかに・マウスは速すぎない中間にする。
+ *
+ * @param deltaY - WheelEvent.deltaY
+ * @param deltaMode - WheelEvent.deltaMode
+ */
+export function wheelEventToZoomDelta(deltaY: number, deltaMode: number): number {
+  const px = normalizeWheelDeltaY(deltaY, deltaMode);
+  if (px === 0) return 0;
+
+  const raw = (-px / WHEEL_PIXELS_PER_ZOOM_STEP) * VIEW_ZOOM.step;
+  if (Math.abs(raw) < WHEEL_ZOOM_MIN_DELTA) return 0;
+
+  return Math.max(-WHEEL_ZOOM_DELTA_CAP, Math.min(WHEEL_ZOOM_DELTA_CAP, raw));
 }

--- a/features/editor/lib/viewZoom.ts
+++ b/features/editor/lib/viewZoom.ts
@@ -118,3 +118,87 @@ export function stagePointerToContentSpace(
     y: contentCenter.y + (stagePos.y - stageCenterY) / viewZoom,
   };
 }
+
+/**
+ * ホイール／ピンチで倍率を変えたあとも、ポインタ下の画像点が同じステージ位置に留まるよう表示中心を更新する
+ *
+ * @param viewCenter - 現在の表示中心（画像自然座標）
+ * @param stagePos - ズームの焦点（ステージ座標）
+ * @param stageWidth - ステージ幅
+ * @param stageHeight - ステージ高さ
+ * @param scaleX - 画像→ステージ X スケール
+ * @param scaleY - 画像→ステージ Y スケール
+ * @param oldZoom - 変更前の表示倍率
+ * @param newZoom - 変更後の表示倍率
+ * @param imageNaturalWidth - 元画像の幅
+ * @param imageNaturalHeight - 元画像の高さ
+ */
+export function computeViewCenterAfterZoomAt(
+  viewCenter: ViewCenter,
+  stagePos: { x: number; y: number },
+  stageWidth: number,
+  stageHeight: number,
+  scaleX: number,
+  scaleY: number,
+  oldZoom: number,
+  newZoom: number,
+  imageNaturalWidth: number,
+  imageNaturalHeight: number
+): ViewCenter {
+  const stageCenterX = stageWidth / 2;
+  const stageCenterY = stageHeight / 2;
+  const imageX = viewCenter.x + (stagePos.x - stageCenterX) / (oldZoom * scaleX);
+  const imageY = viewCenter.y + (stagePos.y - stageCenterY) / (oldZoom * scaleY);
+  return clampViewCenter(
+    {
+      x: imageX - (stagePos.x - stageCenterX) / (newZoom * scaleX),
+      y: imageY - (stagePos.y - stageCenterY) / (newZoom * scaleY),
+    },
+    imageNaturalWidth,
+    imageNaturalHeight,
+    newZoom
+  );
+}
+
+/**
+ * ステージ上のドラッグ量から表示中心を平行移動する（viewZoom > 1 のときのみ有効）
+ *
+ * @param viewCenter - 現在の表示中心
+ * @param stageDelta - ステージ px での移動量（指の移動方向）
+ * @param scaleX - 画像→ステージ X スケール
+ * @param scaleY - 画像→ステージ Y スケール
+ * @param viewZoom - 表示倍率
+ * @param imageNaturalWidth - 元画像の幅
+ * @param imageNaturalHeight - 元画像の高さ
+ */
+export function panViewCenterByStageDelta(
+  viewCenter: ViewCenter,
+  stageDelta: { x: number; y: number },
+  scaleX: number,
+  scaleY: number,
+  viewZoom: number,
+  imageNaturalWidth: number,
+  imageNaturalHeight: number
+): ViewCenter {
+  const deltaX = scaleX > 0 ? stageDelta.x / (scaleX * viewZoom) : 0;
+  const deltaY = scaleY > 0 ? stageDelta.y / (scaleY * viewZoom) : 0;
+  return clampViewCenter(
+    {
+      x: viewCenter.x - deltaX,
+      y: viewCenter.y - deltaY,
+    },
+    imageNaturalWidth,
+    imageNaturalHeight,
+    viewZoom
+  );
+}
+
+/**
+ * ホイールの deltaY から表示倍率の増減量を求める（下スクロールで縮小）
+ *
+ * @param deltaY - WheelEvent.deltaY
+ */
+export function wheelDeltaToZoomDelta(deltaY: number): number {
+  if (deltaY === 0) return 0;
+  return -Math.sign(deltaY) * VIEW_ZOOM.step;
+}


### PR DESCRIPTION
## 概要

`EditorCanvas` の表示ズーム・表示移動をマウス／タッチ操作に対応し、既存の細かいボタン操作を「等倍・中央」1ボタンに整理する。論理座標・エクスポートは変更しない。

## 関連Issue

Closes #66

## 変更内容

- [x] 機能追加
- [x] バグ修正
- [ ] リファクタリング
- [x] テスト追加・修正
- [ ] ドキュメント修正
- [ ] 設定・環境変更
- [ ] その他

## 主な変更箇所

### UI・コンポーネント

- `EditorViewportControls`: `+` / `−` / 十字移動 / 「中央」単体を削除し、「等倍・中央」1ボタンと倍率表示のみに簡素化。操作ヒント（薄字）を追加
- `EditorCanvas`: ジェスチャ統合、拡大時の grab カーソル、`0` キーで等倍リセット

### ロジック・処理

- `viewZoom.ts`: ポインタ中心ズーム、ステージドラッグによるパン、ホイール増減量
- `useEditorViewport`: `zoomAt` / `setZoomAt` / `panByStageDelta` API
- `useEditorViewportGestures`（新規）: ホイールズーム、2本指ピンチ、PC/SP パン
  - **PC パン（拡大時・選択モード）**: 空白ドラッグ、または Space+ドラッグ（オブジェクト上でも画面移動）
  - **モーダル内（`pinViewportControls`）**: 通常ホイールは縦スクロール、**Ctrl/Cmd+ホイール**でズーム
  - **SP**: 選択モード・空白上の 1 本指パン（Konva 経由に一本化）

### その他

- `isEditableKeyboardTarget`: 入力フォーカス中の `0` / Space ショートカット無効化

## 操作早見表（PC・拡大時）

| 操作 | 効果 |
|------|------|
| ホイール（モーダル外レイアウト） | ズーム |
| Ctrl/Cmd+ホイール（モーダル内） | ズーム |
| ホイール（モーダル内） | モーダルスクロール |
| 空白ドラッグ | パン |
| Space+ドラッグ | パン（スタンプ上でも画面移動） |

## 動作確認

- [x] ローカル環境での動作確認
- [x] テストの実行・通過確認
- [x] UI動作確認
- [ ] 既存機能への影響確認
- [ ] ブラウザ動作確認（Chrome / Firefox / Safari）

## スクリーンショット・動画

UI のボタン削減・操作ヒント追加のみのため省略。実機でのホイール・ピンチ・パンはレビュー時に確認推奨。

## テスト

### 追加したテスト

- `viewZoom.test.ts`: ポインタ中心ズーム・パン・ホイール増減
- `useEditorViewport.test.ts`: `zoomAt`
- `useEditorViewportGestures.test.ts`: ホイール、ピンチ、Space+ドラッグ、空白ドラッグ、モーダル時 Ctrl+ホイール、入力フォーカス時 Space 無効

### テスト結果

- [x] 全てのテストが通過
- [x] 新規テストを追加
- [ ] 既存テストの修正

```
pnpm exec vitest run features/editor/hooks/useEditorViewportGestures.test.ts features/editor/lib/viewZoom.test.ts features/editor/hooks/useEditorViewport.test.ts
pnpm lint
pnpm type-check
```

## 破壊的変更

- [ ] 破壊的変更あり
- [x] 破壊的変更なし

### 破壊的変更の詳細

該当なし

## レビューポイント

- モーダル内で Ctrl/Cmd+ホイール案内と実挙動が一致しているか
- PC 空白ドラッグパンを残した意図（Issue #66 コメント参照）が妥当か
- 2本指ピンチ中の Konva 1 本指抑止
- SP 1 本指パンの Konva 一本化後の体感

## 補足

- 依存 Issue #65（モーダル化）はマージ済み前提
- Copilot レビュー4件（ホイール・空白パン・カーソル・SP 二重経路）に対応済み
- Issue #66 に PC パン仕様（空白 + Space）をコメント追記済み

## チェックリスト

- [x] コードレビューの準備ができている
- [x] 適切なラベルを付けている
- [x] セルフレビューを実施している
- [x] `pnpm lint` と `pnpm type-check` が通ることを確認した
- [x] 必要に応じてドキュメントを更新している（操作ヒント UI）
