### PR TITLE
編集モーダル SP 向け UX 改善（操作ヒント・初回読み込み・スタンプピッカー）

### DIFF
--- a/features/editor/components/EditorCanvas.tsx
+++ b/features/editor/components/EditorCanvas.tsx
@@ -3,7 +3,7 @@
 import clsx from "clsx";
 import Konva from "konva";
 import type { KonvaEventObject } from "konva/lib/Node";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import {
   Circle,
   Group,
@@ -203,6 +203,15 @@ export function EditorCanvas({
   }, [selectedId, onSelectItem, onDeleteSelected, resetViewport]);
 
   /** コンテナの幅変化を ResizeObserver で監視 */
+  useLayoutEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+    const w = container.clientWidth;
+    if (w > 0) {
+      setStageWidth(w);
+    }
+  }, [imageNaturalHeight, imageNaturalWidth]);
+
   useEffect(() => {
     const container = containerRef.current;
     if (!container) return;

--- a/features/editor/components/EditorCanvas.tsx
+++ b/features/editor/components/EditorCanvas.tsx
@@ -202,7 +202,7 @@ export function EditorCanvas({
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, [selectedId, onSelectItem, onDeleteSelected, resetViewport]);
 
-  /** コンテナの幅変化を ResizeObserver で監視 */
+  /** 初回ペイント前にコンテナ幅を同期し、レイアウトシフトを抑える */
   useLayoutEffect(() => {
     const container = containerRef.current;
     if (!container) return;
@@ -212,6 +212,7 @@ export function EditorCanvas({
     }
   }, [imageNaturalHeight, imageNaturalWidth]);
 
+  /** コンテナの幅変化を ResizeObserver で継続的に監視する */
   useEffect(() => {
     const container = containerRef.current;
     if (!container) return;

--- a/features/editor/components/EditorToolbar.tsx
+++ b/features/editor/components/EditorToolbar.tsx
@@ -4,6 +4,7 @@ import clsx from "clsx";
 import { MousePointer2, Pen, Plus } from "lucide-react";
 import type React from "react";
 import type { LucideProps } from "lucide-react";
+import { useNarrowViewport } from "@/lib/useNarrowViewport";
 import type { StampCatalogEntry } from "../constants";
 import type { EditorMode, StampType } from "../types";
 import { StampFacePicker } from "./StampFacePicker";
@@ -43,11 +44,129 @@ function Divider() {
   return <div aria-hidden className="h-5 w-px shrink-0 bg-zinc-300" />;
 }
 
+interface ModeButtonGroupProps {
+  mode: EditorMode;
+  onChangeMode: (mode: EditorMode) => void;
+}
+
+/** モード切替ピルグループ */
+function ModeButtonGroup({ mode, onChangeMode }: ModeButtonGroupProps) {
+  return (
+    <div className="flex shrink-0 overflow-hidden rounded-md border border-zinc-300 shadow-sm">
+      {MODE_BUTTONS.map(({ mode: m, label, Icon }, i) => (
+        <button
+          key={m}
+          type="button"
+          title={label}
+          aria-label={label}
+          aria-pressed={mode === m}
+          onClick={() => onChangeMode(m)}
+          className={clsx([
+            "flex items-center px-2.5 py-1.5 transition-colors",
+            i > 0 && "border-l border-zinc-300",
+            mode === m ? "bg-blue-600 text-white" : "bg-white text-zinc-700 hover:bg-zinc-50",
+          ])}
+        >
+          <Icon size={14} aria-hidden="true" />
+        </button>
+      ))}
+    </div>
+  );
+}
+
+interface DeleteSelectedButtonProps {
+  disabled: boolean;
+  onClick: () => void;
+  className?: string;
+}
+
+/** 選択中アイテムの削除ボタン */
+function DeleteSelectedButton({ disabled, onClick, className }: DeleteSelectedButtonProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      className={clsx([
+        "shrink-0 rounded-md px-3 py-1 text-sm font-medium transition-colors",
+        "bg-red-600 text-white hover:bg-red-700",
+        disabled && "cursor-not-allowed opacity-50",
+        className,
+      ])}
+    >
+      削除
+    </button>
+  );
+}
+
+interface StampControlsProps {
+  selectedStampType: StampType;
+  stampCatalog: readonly StampCatalogEntry[];
+  selectedStampFileName: string;
+  onStampTypeChange: (type: StampType) => void;
+  onStampFileNameChange: (name: string) => void;
+  /** SP 2 段目など狭い行向けのスタンプ種別 select クラス */
+  stampTypeClassName?: string;
+}
+
+/** スタンプ種別・顔スタンプ選択 */
+function StampControls({
+  selectedStampType,
+  stampCatalog,
+  selectedStampFileName,
+  onStampTypeChange,
+  onStampFileNameChange,
+  stampTypeClassName,
+}: StampControlsProps) {
+  return (
+    <>
+      <StampTypeSelector
+        value={selectedStampType}
+        onChange={onStampTypeChange}
+        className={stampTypeClassName}
+      />
+      {selectedStampType === "stamp-face" && (
+        <StampFacePicker
+          catalog={stampCatalog}
+          value={selectedStampFileName}
+          onChange={onStampFileNameChange}
+        />
+      )}
+    </>
+  );
+}
+
+interface BrushControlsProps {
+  brushSize: number;
+  onBrushSizeChange: (size: number) => void;
+}
+
+/** ペイントブラシサイズ */
+function BrushControls({ brushSize, onBrushSizeChange }: BrushControlsProps) {
+  return (
+    <div className="flex min-w-0 flex-1 items-center gap-2">
+      <label className="shrink-0 text-sm text-zinc-600" htmlFor="brush-size-slider">
+        ブラシ: {brushSize}
+      </label>
+      <input
+        id="brush-size-slider"
+        type="range"
+        min={5}
+        max={50}
+        value={brushSize}
+        onChange={(e) => onBrushSizeChange(Number(e.target.value))}
+        className="min-w-0 flex-1"
+      />
+    </div>
+  );
+}
+
 /**
  * エディタ操作ツールバーコンポーネント
  *
  * モード切替の右にマスキング種別（矩形追加時 / スタンプ領域選択時）、
  * ペイントブラシ・削除は各モードに応じて表示する。
+ * SP では 2 段レイアウトにしてモーダル内の高さ変動を抑える。
  */
 export function EditorToolbar({
   mode,
@@ -63,82 +182,80 @@ export function EditorToolbar({
   onBrushSizeChange,
   onDeleteSelected,
 }: EditorToolbarProps) {
+  const isNarrowViewport = useNarrowViewport();
   const showStampControls = mode === "rect" || isStampSelected;
+
+  if (isNarrowViewport) {
+    const reserveStampRow = mode === "select" || mode === "rect";
+
+    return (
+      <div className="rounded-lg border border-zinc-200 bg-zinc-50 px-2 py-1.5">
+        <div className="flex flex-col gap-1.5">
+          <div className="flex items-center justify-between gap-2">
+            <ModeButtonGroup mode={mode} onChangeMode={onChangeMode} />
+            {mode === "select" && (
+              <DeleteSelectedButton disabled={selectedId === null} onClick={onDeleteSelected} />
+            )}
+          </div>
+
+          {reserveStampRow && (
+            <div
+              className={clsx([
+                "flex min-h-9 min-w-0 items-center gap-2",
+                !showStampControls && "pointer-events-none invisible",
+              ])}
+              aria-hidden={!showStampControls}
+            >
+              <StampControls
+                selectedStampType={selectedStampType}
+                stampCatalog={stampCatalog}
+                selectedStampFileName={selectedStampFileName}
+                onStampTypeChange={onStampTypeChange}
+                onStampFileNameChange={onStampFileNameChange}
+                stampTypeClassName="min-w-0 flex-1 shrink"
+              />
+            </div>
+          )}
+
+          {mode === "paint" && (
+            <BrushControls brushSize={brushSize} onBrushSizeChange={onBrushSizeChange} />
+          )}
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="rounded-lg border border-zinc-200 bg-zinc-50 px-2 py-1.5">
       <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
-        {/* モード切替: ピルグループ（アイコンのみ・title でツールチップ） */}
-        <div className="flex overflow-hidden rounded-md border border-zinc-300 shadow-sm">
-          {MODE_BUTTONS.map(({ mode: m, label, Icon }, i) => (
-            <button
-              key={m}
-              type="button"
-              title={label}
-              aria-label={label}
-              aria-pressed={mode === m}
-              onClick={() => onChangeMode(m)}
-              className={clsx([
-                "flex items-center px-2.5 py-1.5 transition-colors",
-                i > 0 && "border-l border-zinc-300",
-                mode === m ? "bg-blue-600 text-white" : "bg-white text-zinc-700 hover:bg-zinc-50",
-              ])}
-            >
-              <Icon size={14} aria-hidden="true" />
-            </button>
-          ))}
-        </div>
+        <ModeButtonGroup mode={mode} onChangeMode={onChangeMode} />
 
-        {/* マスキング種別（矩形追加時 / スタンプ領域選択時） */}
         {showStampControls && (
           <>
             <Divider />
-            <StampTypeSelector value={selectedStampType} onChange={onStampTypeChange} />
-            {selectedStampType === "stamp-face" && (
-              <StampFacePicker
-                catalog={stampCatalog}
-                value={selectedStampFileName}
-                onChange={onStampFileNameChange}
-              />
-            )}
+            <StampControls
+              selectedStampType={selectedStampType}
+              stampCatalog={stampCatalog}
+              selectedStampFileName={selectedStampFileName}
+              onStampTypeChange={onStampTypeChange}
+              onStampFileNameChange={onStampFileNameChange}
+            />
           </>
         )}
 
-        {/* ペイントブラシサイズスライダー */}
         {mode === "paint" && (
           <>
             <Divider />
-            <div className="flex items-center gap-2">
-              <label className="text-sm text-zinc-600" htmlFor="brush-size-slider">
-                ブラシ: {brushSize}
-              </label>
-              <input
-                id="brush-size-slider"
-                type="range"
-                min={5}
-                max={50}
-                value={brushSize}
-                onChange={(e) => onBrushSizeChange(Number(e.target.value))}
-                className="w-24"
-              />
-            </div>
+            <BrushControls brushSize={brushSize} onBrushSizeChange={onBrushSizeChange} />
           </>
         )}
 
-        {/* 削除ボタン */}
         {mode === "select" && (
-          <button
-            type="button"
-            onClick={onDeleteSelected}
+          <DeleteSelectedButton
             disabled={selectedId === null}
-            className={clsx([
-              "ml-auto rounded-md px-3 py-1 text-sm font-medium transition-colors",
-              "bg-red-600 text-white hover:bg-red-700",
-              selectedId === null && "cursor-not-allowed opacity-50",
-            ])}
-          >
-            削除
-          </button>
+            onClick={onDeleteSelected}
+            className="ml-auto"
+          />
         )}
       </div>
     </div>

--- a/features/editor/components/EditorViewportControls.tsx
+++ b/features/editor/components/EditorViewportControls.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import clsx from "clsx";
+import { useNarrowViewport } from "@/lib/useNarrowViewport";
+import { getEditorViewportHintText } from "../lib/editorViewportHintText";
 
 interface EditorViewportControlsProps {
   /** ルート要素に追加するクラス（モーダル内 sticky など） */
@@ -20,7 +22,8 @@ export function EditorViewportControls({
   onResetViewport,
   pinViewportControls = false,
 }: EditorViewportControlsProps) {
-  const zoomHint = pinViewportControls ? "Ctrl/Cmd+ホイールで拡大/縮小" : "ホイールで拡大/縮小";
+  const isNarrowViewport = useNarrowViewport();
+  const hintText = getEditorViewportHintText({ pinViewportControls, isNarrowViewport });
 
   return (
     <div
@@ -31,9 +34,7 @@ export function EditorViewportControls({
     >
       <div className="flex min-w-0 flex-1 flex-wrap items-baseline gap-x-1.5 gap-y-0.5">
         <span className="shrink-0 text-xs text-zinc-600">表示ズーム</span>
-        <span className="text-[11px] leading-snug text-zinc-400">
-          {zoomHint} · 拡大時: 空白／Space+ドラッグで移動
-        </span>
+        <span className="text-[11px] leading-snug text-zinc-400">{hintText}</span>
       </div>
       <div className="flex items-center gap-2">
         <span className="text-xs tabular-nums text-zinc-500">{Math.round(viewZoom * 100)}%</span>

--- a/features/editor/components/StampFacePicker.test.tsx
+++ b/features/editor/components/StampFacePicker.test.tsx
@@ -143,13 +143,15 @@ describe("StampFacePicker", () => {
     }));
     vi.stubGlobal("matchMedia", matchMedia);
 
-    render(<StampFacePicker catalog={CATALOG} value="a.png" onChange={vi.fn()} />);
-    await userEvent.click(getTrigger("笑顔"));
+    try {
+      render(<StampFacePicker catalog={CATALOG} value="a.png" onChange={vi.fn()} />);
+      await userEvent.click(getTrigger("笑顔"));
 
-    const listbox = screen.getByRole("listbox", { name: "スタンプ画像" });
-    expect(listbox.parentElement).toHaveClass("right-0");
-    expect(listbox.parentElement).not.toHaveClass("left-0");
-
-    vi.unstubAllGlobals();
+      const listbox = screen.getByRole("listbox", { name: "スタンプ画像" });
+      expect(listbox.parentElement).toHaveClass("right-0");
+      expect(listbox.parentElement).not.toHaveClass("left-0");
+    } finally {
+      vi.unstubAllGlobals();
+    }
   });
 });

--- a/features/editor/components/StampFacePicker.test.tsx
+++ b/features/editor/components/StampFacePicker.test.tsx
@@ -129,4 +129,27 @@ describe("StampFacePicker", () => {
     expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
     expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
   });
+
+  it("SP では一覧をトリガー右端に揃えて左方向に展開する", async () => {
+    const matchMedia = vi.fn().mockImplementation((query: string) => ({
+      matches: query.includes("max-width"),
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
+    vi.stubGlobal("matchMedia", matchMedia);
+
+    render(<StampFacePicker catalog={CATALOG} value="a.png" onChange={vi.fn()} />);
+    await userEvent.click(getTrigger("笑顔"));
+
+    const listbox = screen.getByRole("listbox", { name: "スタンプ画像" });
+    expect(listbox.parentElement).toHaveClass("right-0");
+    expect(listbox.parentElement).not.toHaveClass("left-0");
+
+    vi.unstubAllGlobals();
+  });
 });

--- a/features/editor/components/StampFacePicker.tsx
+++ b/features/editor/components/StampFacePicker.tsx
@@ -4,6 +4,7 @@ import clsx from "clsx";
 import { ChevronDown } from "lucide-react";
 import type React from "react";
 import { useCallback, useEffect, useId, useRef, useState } from "react";
+import { useNarrowViewport } from "@/lib/useNarrowViewport";
 import type { StampCatalogEntry } from "../constants";
 
 interface StampFacePickerProps {
@@ -18,6 +19,7 @@ interface StampFacePickerProps {
  * トリガーは絵文字のみのコンパクト表示。一覧では絵文字とラベルを表示する。
  */
 export function StampFacePicker({ catalog, value, onChange }: StampFacePickerProps) {
+  const isNarrowViewport = useNarrowViewport();
   const [open, setOpen] = useState(false);
   const [activeIndex, setActiveIndex] = useState(0);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -179,7 +181,8 @@ export function StampFacePicker({ catalog, value, onChange }: StampFacePickerPro
       {open && (
         <div
           className={clsx([
-            "absolute top-full left-0 z-50 mt-1 w-56 overflow-hidden rounded-md border border-zinc-200 bg-white shadow-lg",
+            "absolute top-full z-50 mt-1 w-56 max-w-[min(14rem,calc(100vw-2rem))] overflow-hidden rounded-md border border-zinc-200 bg-white shadow-lg",
+            isNarrowViewport ? "right-0" : "left-0",
             /* Safari: スクロール層の背景が透けるのを防ぐ */
             "[transform:translateZ(0)]",
           ])}

--- a/features/editor/components/StampTypeSelector.tsx
+++ b/features/editor/components/StampTypeSelector.tsx
@@ -1,10 +1,12 @@
 "use client";
 
+import clsx from "clsx";
 import type { StampType } from "../types";
 
 interface StampTypeSelectorProps {
   value: StampType;
   onChange: (type: StampType) => void;
+  className?: string;
 }
 
 /** スタンプ種別の選択肢定義 */
@@ -20,12 +22,15 @@ const STAMP_OPTIONS: { type: StampType; label: string }[] = [
  *
  * 矩形モードでスタンプを追加する際に種別を選択する。
  */
-export function StampTypeSelector({ value, onChange }: StampTypeSelectorProps) {
+export function StampTypeSelector({ value, onChange, className }: StampTypeSelectorProps) {
   return (
     <select
       value={value}
       onChange={(e) => onChange(e.target.value as StampType)}
-      className="max-w-[8.5rem] shrink-0 rounded-md border border-zinc-300 bg-white px-2 py-1.5 text-sm text-zinc-700 shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+      className={clsx([
+        "rounded-md border border-zinc-300 bg-white px-2 py-1.5 text-sm text-zinc-700 shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500",
+        className ?? "max-w-[8.5rem] shrink-0",
+      ])}
     >
       {STAMP_OPTIONS.map(({ type, label }) => (
         <option key={type} value={type}>

--- a/features/editor/lib/editorViewportHintText.test.ts
+++ b/features/editor/lib/editorViewportHintText.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { getEditorViewportHintText } from "./editorViewportHintText";
+
+describe("getEditorViewportHintText", () => {
+  it("PC・通常レイアウトではホイールと Space パンを案内する", () => {
+    expect(getEditorViewportHintText({ pinViewportControls: false, isNarrowViewport: false })).toBe(
+      "ホイールで拡大/縮小 · 拡大時: 空白／Space+ドラッグで移動"
+    );
+  });
+
+  it("PC・モーダルでは Ctrl/Cmd+ホイールを案内する", () => {
+    expect(getEditorViewportHintText({ pinViewportControls: true, isNarrowViewport: false })).toBe(
+      "Ctrl/Cmd+ホイールで拡大/縮小 · 拡大時: 空白／Space+ドラッグで移動"
+    );
+  });
+
+  it("SP では 2 本指ピンチと空白ドラッグを案内する", () => {
+    expect(getEditorViewportHintText({ pinViewportControls: true, isNarrowViewport: true })).toBe(
+      "2本指ピンチで拡大/縮小 · 拡大時: 空白をドラッグで移動"
+    );
+  });
+});

--- a/features/editor/lib/editorViewportHintText.ts
+++ b/features/editor/lib/editorViewportHintText.ts
@@ -1,0 +1,21 @@
+export interface EditorViewportHintTextOptions {
+  /** モーダル内など、通常ホイールをスクロールに任せるレイアウト */
+  pinViewportControls: boolean;
+  /** Tailwind `md` 未満（767px 以下） */
+  isNarrowViewport: boolean;
+}
+
+/**
+ * 表示ズームコントロール横の操作ヒント文言を返す
+ */
+export function getEditorViewportHintText({
+  pinViewportControls,
+  isNarrowViewport,
+}: EditorViewportHintTextOptions): string {
+  if (isNarrowViewport) {
+    return "2本指ピンチで拡大/縮小 · 拡大時: 空白をドラッグで移動";
+  }
+
+  const zoomHint = pinViewportControls ? "Ctrl/Cmd+ホイールで拡大/縮小" : "ホイールで拡大/縮小";
+  return `${zoomHint} · 拡大時: 空白／Space+ドラッグで移動`;
+}

--- a/features/masking/components/EditorCanvasPlaceholder.tsx
+++ b/features/masking/components/EditorCanvasPlaceholder.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import clsx from "clsx";
+
+interface EditorCanvasPlaceholderProps {
+  /** ルート要素に追加するクラス */
+  className?: string;
+}
+
+/**
+ * 編集モーダル内キャンバスの読み込み中プレースホルダー
+ *
+ * 初回の dynamic import や画像メタデータ取得中にレイアウトシフトを抑える。
+ */
+export function EditorCanvasPlaceholder({ className }: EditorCanvasPlaceholderProps) {
+  return (
+    <div
+      className={clsx([
+        "flex min-h-0 flex-1 flex-col overflow-hidden rounded-xl border border-zinc-200 bg-zinc-50",
+        className,
+      ])}
+      aria-busy="true"
+      aria-label="編集キャンバスを読み込み中"
+    >
+      <div className="flex items-center justify-between gap-2 border-b border-zinc-200 bg-zinc-50 px-2 py-1.5">
+        <div className="h-3 w-24 animate-pulse rounded bg-zinc-200" />
+        <div className="h-7 w-20 animate-pulse rounded bg-zinc-200" />
+      </div>
+      <div className="min-h-[min(52dvh,28rem)] flex-1 animate-pulse bg-zinc-100" />
+    </div>
+  );
+}

--- a/features/masking/components/EditorModal.tsx
+++ b/features/masking/components/EditorModal.tsx
@@ -5,11 +5,15 @@ import { EditorToolbar } from "@/features/editor/components/EditorToolbar";
 import { STAMP_CATALOG } from "@/features/editor/constants";
 import { useEditorModal } from "../hooks/useEditorModal";
 import type { MaskingImageItem } from "../types";
+import { EditorCanvasPlaceholder } from "./EditorCanvasPlaceholder";
 
 /** Konva は window を module ロード時に参照するため SSR を無効化して動的インポートする */
 const EditorCanvas = dynamic(
   () => import("@/features/editor/components/EditorCanvas").then((mod) => mod.EditorCanvas),
-  { ssr: false }
+  {
+    ssr: false,
+    loading: () => <EditorCanvasPlaceholder className="min-h-0 flex-1" />,
+  }
 );
 
 interface EditorModalProps {
@@ -105,7 +109,7 @@ export function EditorModal({ image, stampImages, onClose, onRendered }: EditorM
           </div>
 
           <div className="flex min-h-0 flex-1 flex-col overflow-hidden p-1.5 sm:p-2">
-            {imageNaturalWidth > 0 && imageNaturalHeight > 0 && (
+            {imageNaturalWidth > 0 && imageNaturalHeight > 0 ? (
               <EditorCanvas
                 key={image.id}
                 pinViewportControls
@@ -128,6 +132,8 @@ export function EditorModal({ image, stampImages, onClose, onRendered }: EditorM
                 selectedStampFileName={editor.selectedStampFileName}
                 onDeleteSelected={editor.removeSelectedItem}
               />
+            ) : (
+              <EditorCanvasPlaceholder className="min-h-0 flex-1" />
             )}
           </div>
         </div>

--- a/features/masking/components/MaskingGallery.tsx
+++ b/features/masking/components/MaskingGallery.tsx
@@ -195,7 +195,14 @@ export function MaskingGallery() {
                 setImages((prev) =>
                   prev.map((image) =>
                     image.id === item.id
-                      ? { ...image, detections, ocrRegions, isProcessing: false }
+                      ? {
+                          ...image,
+                          detections,
+                          ocrRegions,
+                          naturalWidth: imageElement.naturalWidth,
+                          naturalHeight: imageElement.naturalHeight,
+                          isProcessing: false,
+                        }
                       : image
                   )
                 );
@@ -321,7 +328,14 @@ export function MaskingGallery() {
           setImages((prev) =>
             prev.map((image) =>
               image.id === imageId
-                ? { ...image, detections, ocrRegions, isProcessing: false }
+                ? {
+                    ...image,
+                    detections,
+                    ocrRegions,
+                    naturalWidth: imageElement.naturalWidth,
+                    naturalHeight: imageElement.naturalHeight,
+                    isProcessing: false,
+                  }
                 : image
             )
           );
@@ -515,6 +529,7 @@ export function MaskingGallery() {
 
       {editingImage && (
         <EditorModal
+          key={editingImage.id}
           image={editingImage}
           stampImages={stampImages}
           onClose={() => setEditingImageId(null)}

--- a/features/masking/hooks/useEditorModal.ts
+++ b/features/masking/hooks/useEditorModal.ts
@@ -57,8 +57,10 @@ export function useEditorModal({
   const dialogRef = useRef<HTMLDivElement>(null);
   const doneButtonRef = useRef<HTMLButtonElement>(null);
   const [imageElement, setImageElement] = useState<HTMLImageElement | null>(null);
-  const [imageNaturalWidth, setImageNaturalWidth] = useState(0);
-  const [imageNaturalHeight, setImageNaturalHeight] = useState(0);
+  const [loadedNaturalWidth, setLoadedNaturalWidth] = useState(0);
+  const [loadedNaturalHeight, setLoadedNaturalHeight] = useState(0);
+  const imageNaturalWidth = image.naturalWidth ?? loadedNaturalWidth;
+  const imageNaturalHeight = image.naturalHeight ?? loadedNaturalHeight;
   const onRenderedRef = useRef(onRendered);
   const baselineSnapshotRef = useRef<EditorStateSnapshot | null>(null);
   const closeInFlightRef = useRef(false);
@@ -245,13 +247,19 @@ export function useEditorModal({
     if (!image.imageUrl) return;
     let cancelled = false;
     const img = new Image();
-    img.onload = () => {
+    const onLoad = () => {
       if (cancelled) return;
       setImageElement(img);
-      setImageNaturalWidth(img.naturalWidth);
-      setImageNaturalHeight(img.naturalHeight);
+      if (img.naturalWidth > 0 && img.naturalHeight > 0) {
+        setLoadedNaturalWidth(img.naturalWidth);
+        setLoadedNaturalHeight(img.naturalHeight);
+      }
     };
+    img.onload = onLoad;
     img.src = image.imageUrl;
+    if (img.complete) {
+      onLoad();
+    }
     return () => {
       cancelled = true;
     };

--- a/features/masking/hooks/useEditorModal.ts
+++ b/features/masking/hooks/useEditorModal.ts
@@ -247,7 +247,7 @@ export function useEditorModal({
     if (!image.imageUrl) return;
     let cancelled = false;
     const img = new Image();
-    const onLoad = () => {
+    const applyLoaded = () => {
       if (cancelled) return;
       setImageElement(img);
       if (img.naturalWidth > 0 && img.naturalHeight > 0) {
@@ -255,10 +255,11 @@ export function useEditorModal({
         setLoadedNaturalHeight(img.naturalHeight);
       }
     };
-    img.onload = onLoad;
     img.src = image.imageUrl;
     if (img.complete) {
-      onLoad();
+      applyLoaded();
+    } else {
+      img.onload = applyLoaded;
     }
     return () => {
       cancelled = true;

--- a/features/masking/types.ts
+++ b/features/masking/types.ts
@@ -87,6 +87,10 @@ export interface MaskingImageItem {
   maskedBlobUrl: string | null;
   /** 顔検出・OCR 処理中フラグ */
   isProcessing: boolean;
+  /** 原画像のピクセル幅（検出時に設定。モーダル初期レイアウト用） */
+  naturalWidth?: number;
+  /** 原画像のピクセル高さ（検出時に設定。モーダル初期レイアウト用） */
+  naturalHeight?: number;
   /**
    * 顔検出・OCR が失敗したフラグ。
    * true の場合は FaceDetectionCanvas をマウントせず、ダウンロードも無効にする。


### PR DESCRIPTION
## 概要

編集モーダル利用時の SP 向け UX を改善する。操作ヒントの端末別切り替え、初回起動時のレイアウトシフト抑制、スタンプピッカー一覧のはみ出し修正を含む。

## 関連Issue

Closes #73

## 変更内容

- [x] 機能追加
- [x] バグ修正
- [x] リファクタリング
- [x] テスト追加・修正
- [ ] ドキュメント修正
- [ ] 設定・環境変更
- [ ] その他

## 主な変更箇所

### UI・コンポーネント

- `EditorViewportControls`: SP では「2本指ピンチ」「空白ドラッグ」ヒントに切り替え
- `EditorToolbar`: SP 向け 2 段レイアウト（スタンプ行の高さ変動を抑制）
- `StampFacePicker`: SP では一覧をトリガー右端揃えで左方向に展開
- `EditorModal` / `EditorCanvasPlaceholder`: 読み込み中プレースホルダー、Konva dynamic import 中の表示

### ロジック・処理

- `editorViewportHintText`: 端末別ヒント文言の純関数
- `MaskingImageItem`: `naturalWidth` / `naturalHeight` を検出時に保存
- `useEditorModal`: 寸法の即時利用、キャッシュ済み画像の同期読み込み
- `EditorCanvas`: `useLayoutEffect` で初回ステージ幅をコンテナに合わせる

### その他

- `MaskingGallery`: `EditorModal` に `key={image.id}`、検出完了時に画像寸法を state へ反映

## 動作確認

- [x] ローカル環境での動作確認
- [x] テストの実行・通過確認
- [ ] UI動作確認（実機 SP 推奨）
- [x] 既存機能への影響確認
- [ ] ブラウザ動作確認（Chrome / Firefox / Safari）

## スクリーンショット・動画

なし（実機確認はレビュー時・マージ前に推奨）

## テスト

### 追加したテスト

- `editorViewportHintText.test.ts`（PC/SP/モーダル別ヒント）
- `StampFacePicker.test.tsx`（SP 時 `right-0` 展開）

### テスト結果

- [x] 全てのテストが通過（対象ファイル）
- [x] 新規テストを追加
- [ ] 既存テストの修正

## 破壊的変更

- [ ] 破壊的変更あり
- [x] 破壊的変更なし

### 破壊的変更の詳細

該当なし

## レビューポイント

- SP 操作ヒントの文言（モーダル内もピンチ表記で問題ないか）
- マージ前にアップロード済み画像は `naturalWidth` 未保存のため、初回のみプレースホルダーが出る可能性
- `StampFacePicker` の `right-0` がモーダル右端ピッカー以外の配置でも意図どおりか

## 補足

#72 マージ後のフォローアップ。

## チェックリスト

- [x] コードレビューの準備ができている
- [x] 適切なラベルを付けている
- [x] セルフレビューを実施している
- [x] `pnpm lint` と `pnpm type-check` が通ることを確認した
- [ ] 必要に応じてドキュメントを更新している
