### PR TITLE
github-ops にレビュー精査と過去コメント矛盾確認を追記

### DIFF
--- a/.cursor/skills/github-ops/SKILL.md
+++ b/.cursor/skills/github-ops/SKILL.md
@@ -170,6 +170,7 @@ gh api --paginate "repos/${REPO}/pulls/<PR番号>/reviews?per_page=100" \
 - PRのissueコメント（会話欄コメント）と PR Review本文コメント（`pulls/<PR番号>/reviews`）は review comment のような親子スレッド構造が無いため、コメント単体でマーカー有無を判定する
 - PR Review本文コメントは、本文が空のレビュー（例: APPROVED）を判定対象外とし、本文あり + `COMMENTED` / `CHANGES_REQUESTED` のみを判定対象とする
 - `gh pr view --comments` は補助的に使ってよいが、最終判定は `gh api --paginate` で取得した全件を用い、PR review comment はスレッド単位、issueコメントとReview本文コメントはコメント単体で行う
+- 全件取得したら未対応の判定だけでなく、対応済みスレッド・過去の issue/Review コメントも参照し、同じ箇所・論点で指摘や方針が矛盾していないか確認する（例: 以前 `ignored` / `resolved` した内容と逆の再指摘、スレッド内のやり取れ違い）。矛盾がある場合は精査報告に含める
 
 ### 運用ルール
 
@@ -186,6 +187,9 @@ gh api --paginate "repos/${REPO}/pulls/<PR番号>/reviews?per_page=100" \
 
 - PR本文の修正・対応不要・対応しない理由がある場合など、コミットを伴わない対応はコミットIDの付与は不要で、対応内容の説明のみ返信する
 - これにより次回確認時は、スレッド末尾がマーカー付きのスレッドをスキップし、未対応のみ確認する
+- Copilot / Bugbot 等の自動レビューは、未対応スレッドごとに `path` / `line` のコード・PR diff・`AGENTS.md`（Frontend なら `frontend.mdc`）を照合し、要対応か誤指摘かを判断してから対応する（コメント本文だけで決めない）
+- 「レビュー確認」「精査」— 未対応一覧と要対応/誤指摘の判断・理由をチャットに報告するまで。コミット・返信はユーザーが「対応して」等と明示したときのみ
+- 要対応と判断したものは修正後 `resolved`、誤指摘は根拠を書いて `ignored`（いずれも上記運用ルールの返信・マーカーに従う）
 
 GitHubのWeb UIではなくCLIで確認する。
 

--- a/.cursor/skills/github-ops/SKILL.md
+++ b/.cursor/skills/github-ops/SKILL.md
@@ -170,7 +170,7 @@ gh api --paginate "repos/${REPO}/pulls/<PR番号>/reviews?per_page=100" \
 - PRのissueコメント（会話欄コメント）と PR Review本文コメント（`pulls/<PR番号>/reviews`）は review comment のような親子スレッド構造が無いため、コメント単体でマーカー有無を判定する
 - PR Review本文コメントは、本文が空のレビュー（例: APPROVED）を判定対象外とし、本文あり + `COMMENTED` / `CHANGES_REQUESTED` のみを判定対象とする
 - `gh pr view --comments` は補助的に使ってよいが、最終判定は `gh api --paginate` で取得した全件を用い、PR review comment はスレッド単位、issueコメントとReview本文コメントはコメント単体で行う
-- 全件取得したら未対応の判定だけでなく、対応済みスレッド・過去の issue/Review コメントも参照し、同じ箇所・論点で指摘や方針が矛盾していないか確認する（例: 以前 `ignored` / `resolved` した内容と逆の再指摘、スレッド内のやり取れ違い）。矛盾がある場合は精査報告に含める
+- 全件取得したら未対応の判定だけでなく、対応済みスレッド・過去の issue/Review コメントも参照し、同じ箇所・論点で指摘や方針が矛盾していないか確認する（例: 以前 `ignored` / `resolved` した内容と逆の再指摘、スレッド内のやり取りの行き違い）。矛盾がある場合は精査報告に含める
 
 ### 運用ルール
 

--- a/.github/skills/github-ops/SKILL.md
+++ b/.github/skills/github-ops/SKILL.md
@@ -169,7 +169,7 @@ gh api --paginate "repos/${REPO}/pulls/<PR番号>/reviews?per_page=100" \
 - PRのissueコメント（会話欄コメント）と PR Review本文コメント（`pulls/<PR番号>/reviews`）は review comment のような親子スレッド構造が無いため、コメント単体でマーカー有無を判定する
 - PR Review本文コメントは、本文が空のレビュー（例: APPROVED）を判定対象外とし、本文あり + `COMMENTED` / `CHANGES_REQUESTED` のみを判定対象とする
 - `gh pr view --comments` は補助的に使ってよいが、最終判定は `gh api --paginate` で取得した全件を用い、PR review comment はスレッド単位、issueコメントとReview本文コメントはコメント単体で行う
-- 全件取得したら未対応の判定だけでなく、対応済みスレッド・過去の issue/Review コメントも参照し、同じ箇所・論点で指摘や方針が矛盾していないか確認する（例: 以前 `ignored` / `resolved` した内容と逆の再指摘、スレッド内のやり取れ違い）。矛盾がある場合は精査報告に含める
+- 全件取得したら未対応の判定だけでなく、対応済みスレッド・過去の issue/Review コメントも参照し、同じ箇所・論点で指摘や方針が矛盾していないか確認する（例: 以前 `ignored` / `resolved` した内容と逆の再指摘、スレッド内のやり取りの行き違い）。矛盾がある場合は精査報告に含める
 
 ### 運用ルール
 

--- a/.github/skills/github-ops/SKILL.md
+++ b/.github/skills/github-ops/SKILL.md
@@ -169,6 +169,7 @@ gh api --paginate "repos/${REPO}/pulls/<PR番号>/reviews?per_page=100" \
 - PRのissueコメント（会話欄コメント）と PR Review本文コメント（`pulls/<PR番号>/reviews`）は review comment のような親子スレッド構造が無いため、コメント単体でマーカー有無を判定する
 - PR Review本文コメントは、本文が空のレビュー（例: APPROVED）を判定対象外とし、本文あり + `COMMENTED` / `CHANGES_REQUESTED` のみを判定対象とする
 - `gh pr view --comments` は補助的に使ってよいが、最終判定は `gh api --paginate` で取得した全件を用い、PR review comment はスレッド単位、issueコメントとReview本文コメントはコメント単体で行う
+- 全件取得したら未対応の判定だけでなく、対応済みスレッド・過去の issue/Review コメントも参照し、同じ箇所・論点で指摘や方針が矛盾していないか確認する（例: 以前 `ignored` / `resolved` した内容と逆の再指摘、スレッド内のやり取れ違い）。矛盾がある場合は精査報告に含める
 
 ### 運用ルール
 
@@ -185,6 +186,9 @@ gh api --paginate "repos/${REPO}/pulls/<PR番号>/reviews?per_page=100" \
 
 - PR本文の修正・対応不要・対応しない理由がある場合など、コミットを伴わない対応はコミットIDの付与は不要で、対応内容の説明のみ返信する
 - これにより次回確認時は、スレッド末尾がマーカー付きのスレッドをスキップし、未対応のみ確認する
+- Copilot / Bugbot 等の自動レビューは、未対応スレッドごとに `path` / `line` のコード・PR diff・`AGENTS.md`（Frontend なら `frontend.mdc`）を照合し、要対応か誤指摘かを判断してから対応する（コメント本文だけで決めない）
+- 「レビュー確認」「精査」— 未対応一覧と要対応/誤指摘の判断・理由をチャットに報告するまで。コミット・返信はユーザーが「対応して」等と明示したときのみ
+- 要対応と判断したものは修正後 `resolved`、誤指摘は根拠を書いて `ignored`（いずれも上記運用ルールの返信・マーカーに従う）
 
 GitHubのWeb UIではなくCLIで確認する。
 

--- a/.github/skills/github-ops/SKILL.md
+++ b/.github/skills/github-ops/SKILL.md
@@ -186,7 +186,7 @@ gh api --paginate "repos/${REPO}/pulls/<PR番号>/reviews?per_page=100" \
 
 - PR本文の修正・対応不要・対応しない理由がある場合など、コミットを伴わない対応はコミットIDの付与は不要で、対応内容の説明のみ返信する
 - これにより次回確認時は、スレッド末尾がマーカー付きのスレッドをスキップし、未対応のみ確認する
-- Copilot / Bugbot 等の自動レビューは、未対応スレッドごとに `path` / `line` のコード・PR diff・`AGENTS.md`（Frontend なら `frontend.mdc`）を照合し、要対応か誤指摘かを判断してから対応する（コメント本文だけで決めない）
+- Copilot / Bugbot 等の自動レビューは、未対応スレッドごとに `path` / `line` のコード・PR diff・`.github/copilot-instructions.md`（Frontend なら `instructions/frontend.instructions.md`）を照合し、要対応か誤指摘かを判断してから対応する（コメント本文だけで決めない）
 - 「レビュー確認」「精査」— 未対応一覧と要対応/誤指摘の判断・理由をチャットに報告するまで。コミット・返信はユーザーが「対応して」等と明示したときのみ
 - 要対応と判断したものは修正後 `resolved`、誤指摘は根拠を書いて `ignored`（いずれも上記運用ルールの返信・マーカーに従う）
 


### PR DESCRIPTION
## 概要

github-ops スキルに、Copilot / Bugbot 等の自動レビューを精査する手順と、全件取得時に過去コメントとの矛盾を確認するルールを追記する。

## 関連Issue

なし（ドキュメント改善のため Issue 未作成）

## 変更内容

- [ ] 機能追加
- [ ] バグ修正
- [ ] リファクタリング
- [ ] テスト追加・修正
- [x] ドキュメント修正
- [ ] 設定・環境変更
- [ ] その他

## 主な変更箇所

### UI・コンポーネント

該当なし

### ロジック・処理

該当なし

### その他

- `.github/skills/github-ops/SKILL.md` — PRレビューコメント確認の判定・運用ルールを拡充
- `.cursor/skills/github-ops/SKILL.md` — 上記と同期

追記内容:

1. 未対応スレッドはコード・PR diff・プロジェクトルールを照合して要対応/誤指摘を判断してから対応する
2. 「レビュー確認」「精査」は報告まで、コミット・返信はユーザー明示時のみ
3. 全件取得時は対応済み・過去コメントも参照し、指摘の矛盾を精査報告に含める

## 動作確認

- [x] ローカル環境での動作確認（Markdown の内容確認）
- [ ] テストの実行・通過確認（該当なし）
- [ ] UI動作確認（該当なし）
- [x] 既存機能への影響確認（スキル文書のみ、実行コード変更なし）
- [ ] ブラウザ動作確認（Chrome / Firefox / Safari）

## スクリーンショット・動画

該当なし

## テスト

### 追加したテスト

該当なし

### テスト結果

- [x] 全てのテストが通過（実行対象のコード変更なし）
- [ ] 新規テストを追加
- [ ] 既存テストの修正

## 破壊的変更

- [ ] 破壊的変更あり
- [x] 破壊的変更なし

### 破壊的変更の詳細

該当なし

## レビューポイント

- `.github` と `.cursor` の両 SKILL が同内容か
- 運用ルールの追記が既存のマーカー運用と矛盾していないか

## 補足

エージェント向けワークフロー定義のため、アプリ本体の挙動は変わらない。

## チェックリスト

- [x] コードレビューの準備ができている
- [x] 適切なラベルを付けている
- [x] セルフレビューを実施している
- [x] `pnpm lint` と `pnpm type-check` が通ることを確認した（Markdown のみの変更）
- [x] 必要に応じてドキュメントを更新している
