### PR TITLE
MaskingGallery の責務分割と命名改善

### DIFF
--- a/features/masking/components/MaskingGallery.tsx
+++ b/features/masking/components/MaskingGallery.tsx
@@ -1,34 +1,18 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback } from "react";
 import clsx from "clsx";
-import { zip } from "fflate";
 import { toast } from "sonner";
 import { ImageUpload } from "@/components/ImageUpload";
-import { ACCEPTED_IMAGE_TYPES, MAX_IMAGE_FILE_SIZE } from "@/components/ImageUpload/constants";
 import { useFaceDetection } from "@/features/face-detection";
 import { useOcr } from "@/features/ocr";
-import { loadStampImagesCached } from "@/features/editor/lib/loadStampImages";
-import { useConfirmStore } from "@/lib/confirmStore";
-import { clearAllImageEditorSnapshots, clearImageEditorSnapshot } from "../lib/imageEditorCache";
-import { type MaskingImageItem, createDownloadFileName } from "../types";
+import { useClipboardImagePaste } from "../hooks/useClipboardImagePaste";
+import { useGalleryDetection } from "../hooks/useGalleryDetection";
+import { useGalleryImages } from "../hooks/useGalleryImages";
+import { useStampImages } from "../hooks/useStampImages";
+import { downloadMaskedImagesAsZip } from "../lib/downloadMaskedImagesAsZip";
 import { EditorModal } from "./EditorModal";
 import { GalleryItem } from "./GalleryItem";
-
-/**
- * 画像URLから HTMLImageElement を生成する
- *
- * @param src - 画像の Data URL または Blob URL
- * @returns 読み込み済みのHTMLImageElement
- */
-const loadImageElement = (src: string): Promise<HTMLImageElement> => {
-  return new Promise((resolve, reject) => {
-    const img = new Image();
-    img.onload = () => resolve(img);
-    img.onerror = () => reject(new Error("画像の読み込みに失敗しました"));
-    img.src = src;
-  });
-};
 
 /**
  * メインマスキングギャラリーコンポーネント
@@ -36,426 +20,44 @@ const loadImageElement = (src: string): Promise<HTMLImageElement> => {
  * 画像アップロード、顔検出、Canvas表示を統合する。
  */
 export function MaskingGallery() {
-  const [images, setImages] = useState<MaskingImageItem[]>([]);
-  const [editingImageId, setEditingImageId] = useState<string | null>(null);
-  const [stampImages, setStampImages] = useState<Map<string, HTMLImageElement>>(new Map());
-  const [activeImageId, setActiveImageId] = useState<string | null>(null);
-  const imagesRef = useRef(images);
-  const isMountedRef = useRef(true);
-  useEffect(() => {
-    imagesRef.current = images;
-  }, [images]);
+  const stampImages = useStampImages();
+  const {
+    images,
+    setImages,
+    isMountedRef,
+    activeImageId,
+    setActiveImageId,
+    setEditingImageId,
+    editingImage,
+    handleOpenEdit,
+    handleRendered,
+    handleClearAll,
+  } = useGalleryImages();
 
-  useEffect(() => {
-    let cancelled = false;
-    void loadStampImagesCached()
-      .then((map) => {
-        if (!cancelled) setStampImages(map);
-      })
-      .catch((err: unknown) => {
-        if (!cancelled) console.error("スタンプ画像の読み込みに失敗しました", err);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
-  const handleOpenEdit = useCallback((imageId: string) => {
-    const target = imagesRef.current.find((image) => image.id === imageId);
-    if (!target || target.isProcessing || target.processingError) return;
-    setEditingImageId(imageId);
-    setActiveImageId(imageId);
-  }, []);
   const { isModelLoading, isModelError, isDetecting, detectFaces } = useFaceDetection();
   const { isRecognizing, recognizeText } = useOcr();
 
-  /** コンポーネント破棄時に imageUrl の Blob URL をすべて解放し isMountedRef を false にする */
-  useEffect(() => {
-    isMountedRef.current = true;
-    return () => {
-      isMountedRef.current = false;
-      imagesRef.current.forEach((image) => {
-        URL.revokeObjectURL(image.imageUrl);
-        if (image.maskedBlobUrl?.startsWith("blob:")) {
-          URL.revokeObjectURL(image.maskedBlobUrl);
-        }
-      });
-      clearAllImageEditorSnapshots();
-    };
-  }, []);
+  const { handleUpload, handleRedetect } = useGalleryDetection({
+    images,
+    setImages,
+    setActiveImageId,
+    setEditingImageId,
+    isMountedRef,
+    isModelLoading,
+    isModelError,
+    detectFaces,
+    recognizeText,
+  });
 
-  /**
-   * ファイルアップロード時の処理
-   *
-   * 全画像を即座に state に追加して表示したあと、各画像を並行して処理し
-   * 完了したものから個別に state を更新する。
-   *
-   * @param files - アップロードされた画像ファイル一覧
-   */
-  const handleUpload = useCallback(
-    async (files: File[]) => {
-      if (files.length === 0 || isModelLoading || isModelError) return;
+  useClipboardImagePaste({ onUpload: handleUpload, isModelLoading, isModelError });
 
-      const uploadedAt = Date.now();
-
-      /**
-       * Step 1: 全ファイルを ArrayBuffer 経由でメモリ上の Blob に変換し、
-       * 変換完了したものから順に state に追加して即時表示する。
-       *
-       * - File から直接 createObjectURL した URL はモバイルで ERR_UPLOAD_FILE_CHANGED が発生するため
-       *   ArrayBuffer 経由で生成する。
-       * - allSettled で個別失敗を吸収しつつ、変換完了した画像から setImages して即時プレビューを表示する。
-       * - arrayBuffer() は全件同時に走るため、大容量ファイルを多数アップロードする場合は
-       *   Step 2 と同様の CONCURRENCY 制限の追加を検討すること。
-       */
-      const initialItems: MaskingImageItem[] = [];
-      const blobResults = await Promise.allSettled(
-        files.map(async (file, index) => {
-          const buffer = await file.arrayBuffer();
-          /** アンマウント後は URL を生成せずに即解放して return */
-          if (!isMountedRef.current) return Promise.reject(new Error("unmounted"));
-          const memoryBlob = new Blob([buffer], { type: file.type });
-          const imageUrl = URL.createObjectURL(memoryBlob);
-          /** アンマウントが arrayBuffer 完了後に発生した場合も即解放 */
-          if (!isMountedRef.current) {
-            URL.revokeObjectURL(imageUrl);
-            return Promise.reject(new Error("unmounted"));
-          }
-          const item: MaskingImageItem = {
-            id: `${file.name}-${file.lastModified}-${file.size}-${uploadedAt}-${index}`,
-            name: file.name,
-            size: file.size,
-            imageUrl,
-            detections: [],
-            ocrRegions: [],
-            maskedBlobUrl: null,
-            isProcessing: true,
-            processingError: false,
-          };
-          return item;
-        })
-      );
-
-      /**
-       * アップロード順を維持したまま一括 state 追加する。
-       * allSettled の結果は files の順序を保持するため、成功分をそのまま追加すれば
-       * arrayBuffer 完了順のランダム表示を防げる。
-       */
-      const succeededItems = blobResults.flatMap((r) =>
-        r.status === "fulfilled" ? [r.value] : []
-      );
-      if (!isMountedRef.current) return;
-      if (succeededItems.length > 0) {
-        setImages((prev) => {
-          const next = [...prev, ...succeededItems];
-          imagesRef.current = next;
-          return next;
-        });
-        setActiveImageId((prev) => prev ?? succeededItems[0].id);
-      }
-
-      if (!isMountedRef.current) return;
-      blobResults.forEach((result, idx) => {
-        if (result.status === "rejected") {
-          toast.error(`${files[idx].name} の読み込みに失敗しました`);
-        }
-      });
-      const blobFailedCount = blobResults.filter((r) => r.status === "rejected").length;
-      if (!isMountedRef.current) return;
-      if (blobFailedCount > 0) {
-        toast.error(`${blobFailedCount} 件の画像の読み込みに失敗しました`);
-      }
-
-      initialItems.push(...succeededItems);
-
-      /**
-       * Step 2: 並行数を制限しながら各画像を処理し、完了したものから個別に state を更新する。
-       *
-       * 全画像を同時処理するとモバイルで CPU/メモリが競合して逆に遅くなるため、
-       * 同時実行数を CONCURRENCY に抑える。
-       */
-      const CONCURRENCY = 2;
-      let step2SucceededCount = 0;
-      let step2FailedCount = 0;
-      for (let i = 0; i < initialItems.length; i += CONCURRENCY) {
-        if (!isMountedRef.current) break;
-        const chunk = initialItems.slice(i, i + CONCURRENCY);
-        await Promise.allSettled(
-          chunk.map(async (item) => {
-            try {
-              const imageElement = await loadImageElement(item.imageUrl);
-
-              /** 顔検出とOCRを並行して実行 */
-              const [detections, ocrRegions] = await Promise.all([
-                detectFaces(imageElement),
-                recognizeText(imageElement),
-              ]);
-
-              if (isMountedRef.current) {
-                setImages((prev) =>
-                  prev.map((image) =>
-                    image.id === item.id
-                      ? {
-                          ...image,
-                          detections,
-                          ocrRegions,
-                          naturalWidth: imageElement.naturalWidth,
-                          naturalHeight: imageElement.naturalHeight,
-                          isProcessing: false,
-                        }
-                      : image
-                  )
-                );
-                toast.success(`${item.name} の検出が完了しました`);
-                step2SucceededCount++;
-              }
-            } catch (err) {
-              if (isMountedRef.current) {
-                setImages((prev) =>
-                  prev.map((image) =>
-                    image.id === item.id
-                      ? { ...image, isProcessing: false, processingError: true }
-                      : image
-                  )
-                );
-                toast.error(`${item.name} の検出に失敗しました`);
-                step2FailedCount++;
-              }
-              throw err;
-            }
-          })
-        );
-      }
-      if (!isMountedRef.current) return;
-      if (step2SucceededCount > 0) {
-        toast.success(`${step2SucceededCount} 件の検出が完了しました`);
-      }
-      if (step2FailedCount > 0) {
-        toast.error(`${step2FailedCount} 件の検出に失敗しました`);
-      }
-    },
-    [detectFaces, recognizeText, isModelLoading, isModelError]
-  );
-
-  /**
-   * ページ全体の paste イベントをリッスンし、クリップボードの画像を handleUpload へ渡す
-   *
-   * - モデル未ロード・エラー時は何もしない
-   * - クリップボードに画像がない場合も何もしない
-   * - ImageUpload と同じ基準（JPEG/PNG/WebP/GIF・20MB以下）でバリデーションを行う
-   * - 貼り付け成功時にトースト通知を表示する
-   */
-  useEffect(() => {
-    const handlePaste = (e: ClipboardEvent) => {
-      if (isModelLoading || isModelError) return;
-      const items = e.clipboardData?.items;
-      if (!items) return;
-
-      const validFiles: File[] = [];
-      let validationError: string | null = null;
-
-      for (const item of Array.from(items)) {
-        if (!item.type.startsWith("image/")) continue;
-        const file = item.getAsFile();
-        if (!file) continue;
-
-        if (!ACCEPTED_IMAGE_TYPES.includes(file.type)) {
-          validationError = "JPEG / PNG / WebP / GIF 形式の画像を選択してください";
-          continue;
-        }
-        if (file.size > MAX_IMAGE_FILE_SIZE) {
-          validationError = "ファイルサイズは20MB以下にしてください";
-          continue;
-        }
-        validFiles.push(file);
-      }
-
-      /** ImageUpload と同じ挙動: 有効ファイルがあればアップロードのみ、なければエラー表示 */
-      if (validFiles.length > 0) {
-        toast.info("画像を貼り付けました");
-        void handleUpload(validFiles);
-        return;
-      }
-
-      if (validationError) {
-        toast.error(validationError);
-      }
-    };
-
-    window.addEventListener("paste", handlePaste);
-    return () => {
-      window.removeEventListener("paste", handlePaste);
-    };
-  }, [handleUpload, isModelLoading, isModelError]);
-
-  /**
-   * 個別画像を再検出する
-   *
-   * @param imageId - 再検出対象画像ID
-   */
-  const handleRedetect = useCallback(
-    async (imageId: string) => {
-      const target = images.find((image) => image.id === imageId);
-      if (!target || isModelLoading || isModelError || target.isProcessing) return;
-
-      clearImageEditorSnapshot(imageId);
-      setEditingImageId((current) => (current === imageId ? null : current));
-
-      setImages((prev) =>
-        prev.map((image) =>
-          image.id === imageId
-            ? {
-                ...image,
-                detections: [],
-                ocrRegions: [],
-                maskedBlobUrl: null,
-                isProcessing: true,
-                processingError: false,
-              }
-            : image
-        )
-      );
-      try {
-        const imageElement = await loadImageElement(target.imageUrl);
-
-        /** 顔検出とOCRを並行して実行 */
-        const [detections, ocrRegions] = await Promise.all([
-          detectFaces(imageElement),
-          recognizeText(imageElement),
-        ]);
-
-        if (isMountedRef.current) {
-          setImages((prev) =>
-            prev.map((image) =>
-              image.id === imageId
-                ? {
-                    ...image,
-                    detections,
-                    ocrRegions,
-                    naturalWidth: imageElement.naturalWidth,
-                    naturalHeight: imageElement.naturalHeight,
-                    isProcessing: false,
-                  }
-                : image
-            )
-          );
-          toast.success(`${target.name} の再検出が完了しました`);
-        }
-      } catch (err) {
-        if (isMountedRef.current) {
-          setImages((prev) =>
-            prev.map((image) =>
-              image.id === imageId
-                ? { ...image, isProcessing: false, processingError: true }
-                : image
-            )
-          );
-          const detail = err instanceof Error ? err.message : "不明なエラー";
-          toast.error(`${target.name} の再検出に失敗しました: ${detail}`);
-        }
-      }
-    },
-    [images, detectFaces, recognizeText, isModelLoading, isModelError]
-  );
-
-  /**
-   * Canvas描画後の Blob URL を保持する
-   *
-   * @param imageId - 対象画像ID
-   * @param blobUrl - 描画済み Blob URL
-   */
-  const handleRendered = useCallback((imageId: string, blobUrl: string) => {
-    setImages((prev) =>
-      prev.map((image) => {
-        if (image.id !== imageId || image.maskedBlobUrl === blobUrl || image.processingError) {
-          return image;
-        }
-
-        return {
-          ...image,
-          maskedBlobUrl: blobUrl,
-        };
-      })
-    );
-  }, []);
-
-  /** 全画像をクリアする（確認ダイアログ表示後、OK の場合のみ Blob URL を解放して state をリセット） */
-  const handleClearAll = useCallback(async () => {
-    try {
-      const ok = await useConfirmStore.getState().open("すべての画像と編集内容をクリアしますか？");
-      if (!ok) return;
-      if (!isMountedRef.current) return;
-      imagesRef.current.forEach((image) => {
-        URL.revokeObjectURL(image.imageUrl);
-        if (image.maskedBlobUrl?.startsWith("blob:")) {
-          URL.revokeObjectURL(image.maskedBlobUrl);
-        }
-      });
-      clearAllImageEditorSnapshots();
-      setImages([]);
-      setActiveImageId(null);
-      setEditingImageId(null);
-    } catch (err) {
-      const message = err instanceof Error ? err.message : "クリアに失敗しました";
-      toast.error(message);
-    }
-  }, []);
-
-  /** 描画済み画像をすべてZIPにまとめてダウンロードする */
   const handleDownloadAll = useCallback(() => {
-    const downloadableImages = images.filter(
-      (image) => image.maskedBlobUrl !== null && !image.isProcessing
-    );
-    if (downloadableImages.length === 0) return;
-
-    const fetchAll = downloadableImages.map(async (image) => {
-      const res = await fetch(image.maskedBlobUrl as string);
-      if (!res.ok) {
-        throw new Error(`Failed to fetch masked image: ${image.name}`);
+    downloadMaskedImagesAsZip(images, () => {
+      if (isMountedRef.current) {
+        toast.error("ZIPの生成に失敗しました");
       }
-      const buffer = await res.arrayBuffer();
-      return { name: createDownloadFileName(image.name), data: new Uint8Array(buffer) };
     });
-
-    void Promise.allSettled(fetchAll).then((results) => {
-      const entries = results.flatMap((result) =>
-        result.status === "fulfilled" ? [result.value] : []
-      );
-
-      if (entries.length === 0) return;
-
-      /** 同名ファイルが複数ある場合に連番サフィックスを付与 */
-      const nameCounts = new Map<string, number>();
-      const fileMap: Record<string, Uint8Array> = {};
-
-      for (const entry of entries) {
-        const count = nameCounts.get(entry.name) ?? 0;
-        nameCounts.set(entry.name, count + 1);
-        const uniqueName =
-          count === 0 ? entry.name : entry.name.replace(/-masked\.png$/, `-masked-${count}.png`);
-        fileMap[uniqueName] = entry.data;
-      }
-
-      zip(fileMap, (err, data) => {
-        if (err) {
-          console.error("ZIPの生成に失敗しました", err);
-          if (isMountedRef.current) {
-            toast.error("ZIPの生成に失敗しました");
-          }
-          return;
-        }
-        const blob = new Blob([data as Uint8Array<ArrayBuffer>], { type: "application/zip" });
-        const url = URL.createObjectURL(blob);
-        const anchor = document.createElement("a");
-        anchor.href = url;
-        anchor.download = "masked-images.zip";
-        anchor.click();
-        window.setTimeout(() => {
-          URL.revokeObjectURL(url);
-        }, 0);
-      });
-    });
-  }, [images]);
+  }, [images, isMountedRef]);
 
   const hasProcessingImage = images.some((image) => image.isProcessing);
   const isProcessing = isDetecting || isRecognizing || hasProcessingImage;
@@ -463,9 +65,6 @@ export function MaskingGallery() {
   const downloadableImagesCount = images.filter(
     (image) => image.maskedBlobUrl && !image.isProcessing
   ).length;
-  const editingImage = editingImageId
-    ? images.find((image) => image.id === editingImageId)
-    : undefined;
 
   return (
     <div className="flex flex-col gap-6">

--- a/features/masking/hooks/useClipboardImagePaste.ts
+++ b/features/masking/hooks/useClipboardImagePaste.ts
@@ -2,7 +2,11 @@
 
 import { useEffect } from "react";
 import { toast } from "sonner";
-import { ACCEPTED_IMAGE_TYPES, MAX_IMAGE_FILE_SIZE } from "@/components/ImageUpload/constants";
+import {
+  ACCEPTED_IMAGE_TYPES,
+  ACCEPTED_IMAGE_TYPES_ERROR,
+  MAX_IMAGE_FILE_SIZE,
+} from "@/components/ImageUpload/constants";
 
 /** useClipboardImagePaste のオプション */
 export interface UseClipboardImagePasteOptions {
@@ -39,7 +43,7 @@ export function useClipboardImagePaste(options: UseClipboardImagePasteOptions): 
         if (!file) continue;
 
         if (!ACCEPTED_IMAGE_TYPES.includes(file.type)) {
-          validationError = "JPEG / PNG / WebP / GIF 形式の画像を選択してください";
+          validationError = ACCEPTED_IMAGE_TYPES_ERROR;
           continue;
         }
         if (file.size > MAX_IMAGE_FILE_SIZE) {

--- a/features/masking/hooks/useClipboardImagePaste.ts
+++ b/features/masking/hooks/useClipboardImagePaste.ts
@@ -1,0 +1,69 @@
+"use client";
+
+import { useEffect } from "react";
+import { toast } from "sonner";
+import { ACCEPTED_IMAGE_TYPES, MAX_IMAGE_FILE_SIZE } from "@/components/ImageUpload/constants";
+
+/** useClipboardImagePaste のオプション */
+export interface UseClipboardImagePasteOptions {
+  onUpload: (files: File[]) => void;
+  isModelLoading: boolean;
+  isModelError: boolean;
+}
+
+/**
+ * ページ全体の paste イベントをリッスンし、クリップボードの画像を onUpload へ渡す
+ *
+ * - モデル未ロード・エラー時は何もしない
+ * - クリップボードに画像がない場合も何もしない
+ * - ImageUpload と同じ基準（JPEG/PNG/WebP/GIF・20MB以下）でバリデーションを行う
+ * - 貼り付け成功時にトースト通知を表示する
+ *
+ * @param options - アップロードコールバックとモデル状態
+ */
+export function useClipboardImagePaste(options: UseClipboardImagePasteOptions): void {
+  const { onUpload, isModelLoading, isModelError } = options;
+
+  useEffect(() => {
+    const handlePaste = (e: ClipboardEvent) => {
+      if (isModelLoading || isModelError) return;
+      const items = e.clipboardData?.items;
+      if (!items) return;
+
+      const validFiles: File[] = [];
+      let validationError: string | null = null;
+
+      for (const item of Array.from(items)) {
+        if (!item.type.startsWith("image/")) continue;
+        const file = item.getAsFile();
+        if (!file) continue;
+
+        if (!ACCEPTED_IMAGE_TYPES.includes(file.type)) {
+          validationError = "JPEG / PNG / WebP / GIF 形式の画像を選択してください";
+          continue;
+        }
+        if (file.size > MAX_IMAGE_FILE_SIZE) {
+          validationError = "ファイルサイズは20MB以下にしてください";
+          continue;
+        }
+        validFiles.push(file);
+      }
+
+      /** ImageUpload と同じ挙動: 有効ファイルがあればアップロードのみ、なければエラー表示 */
+      if (validFiles.length > 0) {
+        toast.info("画像を貼り付けました");
+        void onUpload(validFiles);
+        return;
+      }
+
+      if (validationError) {
+        toast.error(validationError);
+      }
+    };
+
+    window.addEventListener("paste", handlePaste);
+    return () => {
+      window.removeEventListener("paste", handlePaste);
+    };
+  }, [onUpload, isModelLoading, isModelError]);
+}

--- a/features/masking/hooks/useGalleryDetection.ts
+++ b/features/masking/hooks/useGalleryDetection.ts
@@ -1,0 +1,182 @@
+"use client";
+
+import { useCallback, type Dispatch, type RefObject, type SetStateAction } from "react";
+import { toast } from "sonner";
+import { applyDetectionFailure, applyDetectionSuccess } from "../lib/applyDetectionResult";
+import { detectImageContent } from "../lib/detectImageContent";
+import { prepareGalleryItemsFromFiles } from "../lib/prepareGalleryItemsFromFiles";
+import { runDetectionForGalleryItems } from "../lib/runDetectionForGalleryItems";
+import { clearImageEditorSnapshot } from "../lib/imageEditorCache";
+import type { MaskingImageItem } from "../types";
+
+/** useGalleryDetection の依存 */
+export interface UseGalleryDetectionOptions {
+  images: MaskingImageItem[];
+  setImages: Dispatch<SetStateAction<MaskingImageItem[]>>;
+  setActiveImageId: Dispatch<SetStateAction<string | null>>;
+  setEditingImageId: Dispatch<SetStateAction<string | null>>;
+  isMountedRef: RefObject<boolean>;
+  isModelLoading: boolean;
+  isModelError: boolean;
+  detectFaces: (imageElement: HTMLImageElement) => Promise<MaskingImageItem["detections"]>;
+  recognizeText: (imageElement: HTMLImageElement) => Promise<MaskingImageItem["ocrRegions"]>;
+}
+
+/** useGalleryDetection の戻り値 */
+export interface UseGalleryDetectionReturn {
+  handleUpload: (files: File[]) => Promise<void>;
+  handleRedetect: (imageId: string) => Promise<void>;
+}
+
+/**
+ * 画像アップロードと再検出のパイプラインを提供する
+ *
+ * Blob 変換フェーズと検出フェーズを orchestrate し、完了ごとに state を更新する。
+ *
+ * @param options - ギャラリー state と検出関数
+ * @returns handleUpload / handleRedetect
+ */
+export function useGalleryDetection(
+  options: UseGalleryDetectionOptions
+): UseGalleryDetectionReturn {
+  const {
+    images,
+    setImages,
+    setActiveImageId,
+    setEditingImageId,
+    isMountedRef,
+    isModelLoading,
+    isModelError,
+    detectFaces,
+    recognizeText,
+  } = options;
+
+  const isMounted = useCallback(() => isMountedRef.current === true, [isMountedRef]);
+
+  const handleUpload = useCallback(
+    async (files: File[]) => {
+      if (files.length === 0 || isModelLoading || isModelError) return;
+
+      const uploadedAt = Date.now();
+      const { succeededItems, blobResults } = await prepareGalleryItemsFromFiles(
+        files,
+        uploadedAt,
+        isMounted
+      );
+
+      if (!isMounted()) return;
+      if (succeededItems.length > 0) {
+        setImages((prev) => [...prev, ...succeededItems]);
+        setActiveImageId((prev) => prev ?? succeededItems[0].id);
+      }
+
+      if (!isMounted()) return;
+      blobResults.forEach((result, idx) => {
+        if (result.status === "rejected") {
+          toast.error(`${files[idx].name} の読み込みに失敗しました`);
+        }
+      });
+      const blobFailedCount = blobResults.filter((result) => result.status === "rejected").length;
+      if (!isMounted()) return;
+      if (blobFailedCount > 0) {
+        toast.error(`${blobFailedCount} 件の画像の読み込みに失敗しました`);
+      }
+
+      const { detectionSucceededCount, detectionFailedCount } = await runDetectionForGalleryItems({
+        items: succeededItems,
+        isMounted,
+        detectFaces,
+        recognizeText,
+        onItemSuccess: (item, result) => {
+          setImages((prev) =>
+            prev.map((image) =>
+              image.id === item.id ? applyDetectionSuccess(image, result) : image
+            )
+          );
+          toast.success(`${item.name} の検出が完了しました`);
+        },
+        onItemFailure: (item) => {
+          setImages((prev) =>
+            prev.map((image) => (image.id === item.id ? applyDetectionFailure(image) : image))
+          );
+          toast.error(`${item.name} の検出に失敗しました`);
+        },
+      });
+
+      if (!isMounted()) return;
+      if (detectionSucceededCount > 0) {
+        toast.success(`${detectionSucceededCount} 件の検出が完了しました`);
+      }
+      if (detectionFailedCount > 0) {
+        toast.error(`${detectionFailedCount} 件の検出に失敗しました`);
+      }
+    },
+    [
+      detectFaces,
+      recognizeText,
+      isModelLoading,
+      isModelError,
+      isMounted,
+      setImages,
+      setActiveImageId,
+    ]
+  );
+
+  const handleRedetect = useCallback(
+    async (imageId: string) => {
+      const target = images.find((image) => image.id === imageId);
+      if (!target || isModelLoading || isModelError || target.isProcessing) return;
+
+      clearImageEditorSnapshot(imageId);
+      setEditingImageId((current) => (current === imageId ? null : current));
+
+      setImages((prev) =>
+        prev.map((image) =>
+          image.id === imageId
+            ? {
+                ...image,
+                detections: [],
+                ocrRegions: [],
+                maskedBlobUrl: null,
+                isProcessing: true,
+                processingError: false,
+              }
+            : image
+        )
+      );
+
+      try {
+        const result = await detectImageContent(target.imageUrl, { detectFaces, recognizeText });
+
+        if (isMounted()) {
+          setImages((prev) =>
+            prev.map((image) =>
+              image.id === imageId ? applyDetectionSuccess(image, result) : image
+            )
+          );
+          toast.success(`${target.name} の再検出が完了しました`);
+        }
+      } catch (err) {
+        if (isMounted()) {
+          setImages((prev) =>
+            prev.map((image) => (image.id === imageId ? applyDetectionFailure(image) : image))
+          );
+          const detail = err instanceof Error ? err.message : "不明なエラー";
+          toast.error(`${target.name} の再検出に失敗しました: ${detail}`);
+        }
+      }
+    },
+    [
+      images,
+      detectFaces,
+      recognizeText,
+      isModelLoading,
+      isModelError,
+      isMounted,
+      setImages,
+      setEditingImageId,
+    ]
+  );
+
+  return { handleUpload, handleRedetect };
+}

--- a/features/masking/hooks/useGalleryDetection.ts
+++ b/features/masking/hooks/useGalleryDetection.ts
@@ -7,6 +7,7 @@ import { detectImageContent } from "../lib/detectImageContent";
 import { prepareGalleryItemsFromFiles } from "../lib/prepareGalleryItemsFromFiles";
 import { runDetectionForGalleryItems } from "../lib/runDetectionForGalleryItems";
 import { clearImageEditorSnapshot } from "../lib/imageEditorCache";
+import { revokeGalleryItemImageUrls } from "../lib/revokeGalleryItemImageUrls";
 import type { MaskingImageItem } from "../types";
 
 /** useGalleryDetection の依存 */
@@ -64,7 +65,10 @@ export function useGalleryDetection(
         isMounted
       );
 
-      if (!isMounted()) return;
+      if (!isMounted()) {
+        revokeGalleryItemImageUrls(succeededItems);
+        return;
+      }
       if (succeededItems.length > 0) {
         setImages((prev) => [...prev, ...succeededItems]);
         setActiveImageId((prev) => prev ?? succeededItems[0].id);

--- a/features/masking/hooks/useGalleryImages.ts
+++ b/features/masking/hooks/useGalleryImages.ts
@@ -1,0 +1,125 @@
+"use client";
+
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type Dispatch,
+  type RefObject,
+  type SetStateAction,
+} from "react";
+import { toast } from "sonner";
+import { useConfirmStore } from "@/lib/confirmStore";
+import { clearAllImageEditorSnapshots } from "../lib/imageEditorCache";
+import type { MaskingImageItem } from "../types";
+
+/** useGalleryImages の戻り値 */
+export interface UseGalleryImagesReturn {
+  images: MaskingImageItem[];
+  setImages: Dispatch<SetStateAction<MaskingImageItem[]>>;
+  imagesRef: RefObject<MaskingImageItem[]>;
+  isMountedRef: RefObject<boolean>;
+  activeImageId: string | null;
+  setActiveImageId: Dispatch<SetStateAction<string | null>>;
+  editingImageId: string | null;
+  setEditingImageId: Dispatch<SetStateAction<string | null>>;
+  editingImage: MaskingImageItem | undefined;
+  handleOpenEdit: (imageId: string) => void;
+  handleRendered: (imageId: string, blobUrl: string) => void;
+  handleClearAll: () => Promise<void>;
+}
+
+/**
+ * ギャラリー画像コレクションの state と Blob URL lifecycle を管理する
+ *
+ * @returns 画像 state・編集状態・操作ハンドラ
+ */
+export function useGalleryImages(): UseGalleryImagesReturn {
+  const [images, setImages] = useState<MaskingImageItem[]>([]);
+  const [editingImageId, setEditingImageId] = useState<string | null>(null);
+  const [activeImageId, setActiveImageId] = useState<string | null>(null);
+  const imagesRef = useRef(images);
+  const isMountedRef = useRef(true);
+
+  useEffect(() => {
+    imagesRef.current = images;
+  }, [images]);
+
+  /** コンポーネント破棄時に imageUrl の Blob URL をすべて解放し isMountedRef を false にする */
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+      imagesRef.current.forEach((image) => {
+        URL.revokeObjectURL(image.imageUrl);
+        if (image.maskedBlobUrl?.startsWith("blob:")) {
+          URL.revokeObjectURL(image.maskedBlobUrl);
+        }
+      });
+      clearAllImageEditorSnapshots();
+    };
+  }, []);
+
+  const handleOpenEdit = useCallback((imageId: string) => {
+    const target = imagesRef.current.find((image) => image.id === imageId);
+    if (!target || target.isProcessing || target.processingError) return;
+    setEditingImageId(imageId);
+    setActiveImageId(imageId);
+  }, []);
+
+  const handleRendered = useCallback((imageId: string, blobUrl: string) => {
+    setImages((prev) =>
+      prev.map((image) => {
+        if (image.id !== imageId || image.maskedBlobUrl === blobUrl || image.processingError) {
+          return image;
+        }
+
+        return {
+          ...image,
+          maskedBlobUrl: blobUrl,
+        };
+      })
+    );
+  }, []);
+
+  const handleClearAll = useCallback(async () => {
+    try {
+      const ok = await useConfirmStore.getState().open("すべての画像と編集内容をクリアしますか？");
+      if (!ok) return;
+      if (!isMountedRef.current) return;
+      imagesRef.current.forEach((image) => {
+        URL.revokeObjectURL(image.imageUrl);
+        if (image.maskedBlobUrl?.startsWith("blob:")) {
+          URL.revokeObjectURL(image.maskedBlobUrl);
+        }
+      });
+      clearAllImageEditorSnapshots();
+      setImages([]);
+      setActiveImageId(null);
+      setEditingImageId(null);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "クリアに失敗しました";
+      toast.error(message);
+    }
+  }, []);
+
+  const editingImage = editingImageId
+    ? images.find((image) => image.id === editingImageId)
+    : undefined;
+
+  return {
+    images,
+    setImages,
+    imagesRef,
+    isMountedRef,
+    activeImageId,
+    setActiveImageId,
+    editingImageId,
+    setEditingImageId,
+    editingImage,
+    handleOpenEdit,
+    handleRendered,
+    handleClearAll,
+  };
+}

--- a/features/masking/hooks/useGalleryImages.ts
+++ b/features/masking/hooks/useGalleryImages.ts
@@ -36,15 +36,20 @@ export interface UseGalleryImagesReturn {
  * @returns 画像 state・編集状態・操作ハンドラ
  */
 export function useGalleryImages(): UseGalleryImagesReturn {
-  const [images, setImages] = useState<MaskingImageItem[]>([]);
+  const [images, setImagesState] = useState<MaskingImageItem[]>([]);
   const [editingImageId, setEditingImageId] = useState<string | null>(null);
   const [activeImageId, setActiveImageId] = useState<string | null>(null);
   const imagesRef = useRef(images);
   const isMountedRef = useRef(true);
 
-  useEffect(() => {
-    imagesRef.current = images;
-  }, [images]);
+  /** setImages 更新時に imagesRef も即同期し、effect 実行前の stale を防ぐ */
+  const setImages = useCallback((action: SetStateAction<MaskingImageItem[]>) => {
+    setImagesState((prev) => {
+      const next = typeof action === "function" ? action(prev) : action;
+      imagesRef.current = next;
+      return next;
+    });
+  }, []);
 
   /** コンポーネント破棄時に imageUrl の Blob URL をすべて解放し isMountedRef を false にする */
   useEffect(() => {
@@ -68,20 +73,23 @@ export function useGalleryImages(): UseGalleryImagesReturn {
     setActiveImageId(imageId);
   }, []);
 
-  const handleRendered = useCallback((imageId: string, blobUrl: string) => {
-    setImages((prev) =>
-      prev.map((image) => {
-        if (image.id !== imageId || image.maskedBlobUrl === blobUrl || image.processingError) {
-          return image;
-        }
+  const handleRendered = useCallback(
+    (imageId: string, blobUrl: string) => {
+      setImages((prev) =>
+        prev.map((image) => {
+          if (image.id !== imageId || image.maskedBlobUrl === blobUrl || image.processingError) {
+            return image;
+          }
 
-        return {
-          ...image,
-          maskedBlobUrl: blobUrl,
-        };
-      })
-    );
-  }, []);
+          return {
+            ...image,
+            maskedBlobUrl: blobUrl,
+          };
+        })
+      );
+    },
+    [setImages]
+  );
 
   const handleClearAll = useCallback(async () => {
     try {
@@ -102,7 +110,7 @@ export function useGalleryImages(): UseGalleryImagesReturn {
       const message = err instanceof Error ? err.message : "クリアに失敗しました";
       toast.error(message);
     }
-  }, []);
+  }, [setImages]);
 
   const editingImage = editingImageId
     ? images.find((image) => image.id === editingImageId)

--- a/features/masking/hooks/useStampImages.ts
+++ b/features/masking/hooks/useStampImages.ts
@@ -1,0 +1,29 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { loadStampImagesCached } from "@/features/editor/lib/loadStampImages";
+
+/**
+ * スタンプ画像を読み込み state として提供する
+ *
+ * @returns スタンプ画像の Map（キー: スタンプ ID）
+ */
+export function useStampImages(): Map<string, HTMLImageElement> {
+  const [stampImages, setStampImages] = useState<Map<string, HTMLImageElement>>(new Map());
+
+  useEffect(() => {
+    let cancelled = false;
+    void loadStampImagesCached()
+      .then((map) => {
+        if (!cancelled) setStampImages(map);
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) console.error("スタンプ画像の読み込みに失敗しました", err);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return stampImages;
+}

--- a/features/masking/lib/applyDetectionResult.ts
+++ b/features/masking/lib/applyDetectionResult.ts
@@ -1,0 +1,37 @@
+import type { ImageDetectionResult } from "./detectImageContent";
+import type { MaskingImageItem } from "../types";
+
+/**
+ * 検出成功結果を MaskingImageItem に反映する
+ *
+ * @param image - 更新対象の画像アイテム
+ * @param result - 顔検出・OCR の結果
+ * @returns 検出完了状態の画像アイテム
+ */
+export function applyDetectionSuccess(
+  image: MaskingImageItem,
+  result: ImageDetectionResult
+): MaskingImageItem {
+  return {
+    ...image,
+    detections: result.detections,
+    ocrRegions: result.ocrRegions,
+    naturalWidth: result.naturalWidth,
+    naturalHeight: result.naturalHeight,
+    isProcessing: false,
+  };
+}
+
+/**
+ * 検出失敗状態を MaskingImageItem に反映する
+ *
+ * @param image - 更新対象の画像アイテム
+ * @returns 検出失敗状態の画像アイテム
+ */
+export function applyDetectionFailure(image: MaskingImageItem): MaskingImageItem {
+  return {
+    ...image,
+    isProcessing: false,
+    processingError: true,
+  };
+}

--- a/features/masking/lib/detectImageContent.test.ts
+++ b/features/masking/lib/detectImageContent.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { detectImageContent } from "./detectImageContent";
+import { loadImageElement } from "./loadImageElement";
+
+vi.mock("./loadImageElement", () => ({
+  loadImageElement: vi.fn(),
+}));
+
+describe("detectImageContent", () => {
+  const mockDetectFaces = vi.fn();
+  const mockRecognizeText = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDetectFaces.mockResolvedValue([{ x: 0, y: 0, width: 10, height: 10, score: 0.9 }]);
+    mockRecognizeText.mockResolvedValue([]);
+    vi.mocked(loadImageElement).mockResolvedValue({
+      naturalWidth: 800,
+      naturalHeight: 600,
+    } as HTMLImageElement);
+  });
+
+  it("画像を読み込み顔検出とOCRを並行実行して結果を返す", async () => {
+    const result = await detectImageContent("blob:test", {
+      detectFaces: mockDetectFaces,
+      recognizeText: mockRecognizeText,
+    });
+
+    expect(loadImageElement).toHaveBeenCalledWith("blob:test");
+    expect(mockDetectFaces).toHaveBeenCalledOnce();
+    expect(mockRecognizeText).toHaveBeenCalledOnce();
+    expect(result).toEqual({
+      detections: [{ x: 0, y: 0, width: 10, height: 10, score: 0.9 }],
+      ocrRegions: [],
+      naturalWidth: 800,
+      naturalHeight: 600,
+    });
+  });
+
+  it("顔検出が失敗した場合はエラーを伝播する", async () => {
+    mockDetectFaces.mockRejectedValue(new Error("検出失敗"));
+
+    await expect(
+      detectImageContent("blob:test", {
+        detectFaces: mockDetectFaces,
+        recognizeText: mockRecognizeText,
+      })
+    ).rejects.toThrow("検出失敗");
+  });
+});

--- a/features/masking/lib/detectImageContent.ts
+++ b/features/masking/lib/detectImageContent.ts
@@ -1,0 +1,41 @@
+import type { DetectedFace, DetectedTextRegion } from "../types";
+import { loadImageElement } from "./loadImageElement";
+
+/** 顔検出・OCR の実行結果 */
+export interface ImageDetectionResult {
+  detections: DetectedFace[];
+  ocrRegions: DetectedTextRegion[];
+  naturalWidth: number;
+  naturalHeight: number;
+}
+
+/** detectImageContent の依存関数 */
+export interface DetectImageContentDeps {
+  detectFaces: (imageElement: HTMLImageElement) => Promise<DetectedFace[]>;
+  recognizeText: (imageElement: HTMLImageElement) => Promise<DetectedTextRegion[]>;
+}
+
+/**
+ * 画像 URL から HTMLImageElement を読み込み、顔検出と OCR を並行実行する
+ *
+ * @param imageUrl - 表示・検出用 Blob URL
+ * @param deps - 顔検出・OCR 関数
+ * @returns 検出結果と原画像サイズ
+ */
+export async function detectImageContent(
+  imageUrl: string,
+  deps: DetectImageContentDeps
+): Promise<ImageDetectionResult> {
+  const imageElement = await loadImageElement(imageUrl);
+  const [detections, ocrRegions] = await Promise.all([
+    deps.detectFaces(imageElement),
+    deps.recognizeText(imageElement),
+  ]);
+
+  return {
+    detections,
+    ocrRegions,
+    naturalWidth: imageElement.naturalWidth,
+    naturalHeight: imageElement.naturalHeight,
+  };
+}

--- a/features/masking/lib/downloadMaskedImagesAsZip.ts
+++ b/features/masking/lib/downloadMaskedImagesAsZip.ts
@@ -1,0 +1,61 @@
+import { zip } from "fflate";
+import { type MaskingImageItem, createDownloadFileName } from "../types";
+
+/**
+ * 描画済み画像をすべて ZIP にまとめてダウンロードする
+ *
+ * @param images - ギャラリー内の全画像
+ * @param onError - ZIP 生成失敗時のコールバック
+ */
+export function downloadMaskedImagesAsZip(images: MaskingImageItem[], onError?: () => void): void {
+  const downloadableImages = images.filter(
+    (image) => image.maskedBlobUrl !== null && !image.isProcessing
+  );
+  if (downloadableImages.length === 0) return;
+
+  const fetchAll = downloadableImages.map(async (image) => {
+    const res = await fetch(image.maskedBlobUrl as string);
+    if (!res.ok) {
+      throw new Error(`Failed to fetch masked image: ${image.name}`);
+    }
+    const buffer = await res.arrayBuffer();
+    return { name: createDownloadFileName(image.name), data: new Uint8Array(buffer) };
+  });
+
+  void Promise.allSettled(fetchAll).then((results) => {
+    const entries = results.flatMap((result) =>
+      result.status === "fulfilled" ? [result.value] : []
+    );
+
+    if (entries.length === 0) return;
+
+    /** 同名ファイルが複数ある場合に連番サフィックスを付与 */
+    const nameCounts = new Map<string, number>();
+    const fileMap: Record<string, Uint8Array> = {};
+
+    for (const entry of entries) {
+      const count = nameCounts.get(entry.name) ?? 0;
+      nameCounts.set(entry.name, count + 1);
+      const uniqueName =
+        count === 0 ? entry.name : entry.name.replace(/-masked\.png$/, `-masked-${count}.png`);
+      fileMap[uniqueName] = entry.data;
+    }
+
+    zip(fileMap, (err, data) => {
+      if (err) {
+        console.error("ZIPの生成に失敗しました", err);
+        onError?.();
+        return;
+      }
+      const blob = new Blob([data as Uint8Array<ArrayBuffer>], { type: "application/zip" });
+      const url = URL.createObjectURL(blob);
+      const anchor = document.createElement("a");
+      anchor.href = url;
+      anchor.download = "masked-images.zip";
+      anchor.click();
+      window.setTimeout(() => {
+        URL.revokeObjectURL(url);
+      }, 0);
+    });
+  });
+}

--- a/features/masking/lib/loadImageElement.ts
+++ b/features/masking/lib/loadImageElement.ts
@@ -1,0 +1,14 @@
+/**
+ * 画像URLから HTMLImageElement を生成する
+ *
+ * @param src - 画像の Data URL または Blob URL
+ * @returns 読み込み済みのHTMLImageElement
+ */
+export const loadImageElement = (src: string): Promise<HTMLImageElement> => {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => resolve(img);
+    img.onerror = () => reject(new Error("画像の読み込みに失敗しました"));
+    img.src = src;
+  });
+};

--- a/features/masking/lib/prepareGalleryItemsFromFiles.test.ts
+++ b/features/masking/lib/prepareGalleryItemsFromFiles.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { prepareGalleryItemsFromFiles } from "./prepareGalleryItemsFromFiles";
+
+describe("prepareGalleryItemsFromFiles", () => {
+  let createObjectURLSpy: ReturnType<typeof vi.spyOn>;
+  let revokeObjectURLSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    createObjectURLSpy = vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:mock-url");
+    revokeObjectURLSpy = vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    createObjectURLSpy.mockRestore();
+    revokeObjectURLSpy.mockRestore();
+  });
+
+  it("全ファイルを MaskingImageItem に変換して succeededItems を返す", async () => {
+    const file = new File(["data"], "photo.png", { type: "image/png" });
+    const { succeededItems, blobResults } = await prepareGalleryItemsFromFiles(
+      [file],
+      12345,
+      () => true
+    );
+
+    expect(succeededItems).toHaveLength(1);
+    expect(succeededItems[0].name).toBe("photo.png");
+    expect(succeededItems[0].imageUrl).toBe("blob:mock-url");
+    expect(succeededItems[0].isProcessing).toBe(true);
+    expect(blobResults).toHaveLength(1);
+    expect(blobResults[0].status).toBe("fulfilled");
+  });
+
+  it("アンマウント後は URL を生成せず rejected になる", async () => {
+    const file = new File(["data"], "photo.png", { type: "image/png" });
+    let mounted = true;
+    const arrayBufferSpy = vi.spyOn(file, "arrayBuffer").mockImplementation(async () => {
+      mounted = false;
+      return new ArrayBuffer(4);
+    });
+
+    const { succeededItems, blobResults } = await prepareGalleryItemsFromFiles(
+      [file],
+      12345,
+      () => mounted
+    );
+
+    expect(succeededItems).toHaveLength(0);
+    expect(blobResults[0].status).toBe("rejected");
+    arrayBufferSpy.mockRestore();
+  });
+});

--- a/features/masking/lib/prepareGalleryItemsFromFiles.ts
+++ b/features/masking/lib/prepareGalleryItemsFromFiles.ts
@@ -1,0 +1,58 @@
+import type { MaskingImageItem } from "../types";
+
+/** prepareGalleryItemsFromFiles の戻り値 */
+export interface PrepareGalleryItemsResult {
+  /** Blob 変換に成功した画像アイテム（files の順序を保持） */
+  succeededItems: MaskingImageItem[];
+  /** 各ファイルの Blob 変換結果（失敗も含む） */
+  blobResults: PromiseSettledResult<MaskingImageItem>[];
+}
+
+/**
+ * 全ファイルを ArrayBuffer 経由でメモリ上の Blob に変換し MaskingImageItem を生成する
+ *
+ * - File から直接 createObjectURL した URL はモバイルで ERR_UPLOAD_FILE_CHANGED が発生するため
+ *   ArrayBuffer 経由で生成する。
+ * - allSettled で個別失敗を吸収し、成功分のみ succeededItems に含める。
+ *
+ * @param files - アップロードされた画像ファイル一覧
+ * @param uploadedAt - アップロード時刻（ID 生成用）
+ * @param isMounted - コンポーネントがマウント中かどうか
+ * @returns 変換結果
+ */
+export async function prepareGalleryItemsFromFiles(
+  files: File[],
+  uploadedAt: number,
+  isMounted: () => boolean
+): Promise<PrepareGalleryItemsResult> {
+  const blobResults = await Promise.allSettled(
+    files.map(async (file, index) => {
+      const buffer = await file.arrayBuffer();
+      if (!isMounted()) return Promise.reject(new Error("unmounted"));
+      const memoryBlob = new Blob([buffer], { type: file.type });
+      const imageUrl = URL.createObjectURL(memoryBlob);
+      if (!isMounted()) {
+        URL.revokeObjectURL(imageUrl);
+        return Promise.reject(new Error("unmounted"));
+      }
+      const item: MaskingImageItem = {
+        id: `${file.name}-${file.lastModified}-${file.size}-${uploadedAt}-${index}`,
+        name: file.name,
+        size: file.size,
+        imageUrl,
+        detections: [],
+        ocrRegions: [],
+        maskedBlobUrl: null,
+        isProcessing: true,
+        processingError: false,
+      };
+      return item;
+    })
+  );
+
+  const succeededItems = blobResults.flatMap((result) =>
+    result.status === "fulfilled" ? [result.value] : []
+  );
+
+  return { succeededItems, blobResults };
+}

--- a/features/masking/lib/revokeGalleryItemImageUrls.ts
+++ b/features/masking/lib/revokeGalleryItemImageUrls.ts
@@ -1,0 +1,12 @@
+import type { MaskingImageItem } from "../types";
+
+/**
+ * ギャラリー画像アイテムの imageUrl（Blob URL）を解放する
+ *
+ * @param items - 解放対象の画像アイテム一覧
+ */
+export function revokeGalleryItemImageUrls(items: MaskingImageItem[]): void {
+  for (const item of items) {
+    URL.revokeObjectURL(item.imageUrl);
+  }
+}

--- a/features/masking/lib/runDetectionForGalleryItems.test.ts
+++ b/features/masking/lib/runDetectionForGalleryItems.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { runDetectionForGalleryItems } from "./runDetectionForGalleryItems";
+import type { MaskingImageItem } from "../types";
+
+vi.mock("./detectImageContent", () => ({
+  detectImageContent: vi.fn().mockResolvedValue({
+    detections: [],
+    ocrRegions: [],
+    naturalWidth: 100,
+    naturalHeight: 100,
+  }),
+}));
+
+const createItem = (id: string): MaskingImageItem => ({
+  id,
+  name: `${id}.png`,
+  size: 100,
+  imageUrl: `blob:${id}`,
+  detections: [],
+  ocrRegions: [],
+  maskedBlobUrl: null,
+  isProcessing: true,
+  processingError: false,
+});
+
+describe("runDetectionForGalleryItems", () => {
+  const detectFaces = vi.fn().mockResolvedValue([]);
+  const recognizeText = vi.fn().mockResolvedValue([]);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("concurrency が 0 以下でも最低 1 として全件処理する", async () => {
+    const onItemSuccess = vi.fn();
+    const items = [createItem("a"), createItem("b")];
+
+    const result = await runDetectionForGalleryItems({
+      items,
+      isMounted: () => true,
+      concurrency: 0,
+      detectFaces,
+      recognizeText,
+      onItemSuccess,
+      onItemFailure: vi.fn(),
+    });
+
+    expect(onItemSuccess).toHaveBeenCalledTimes(2);
+    expect(result.detectionSucceededCount).toBe(2);
+  });
+});

--- a/features/masking/lib/runDetectionForGalleryItems.ts
+++ b/features/masking/lib/runDetectionForGalleryItems.ts
@@ -1,0 +1,73 @@
+import type { MaskingImageItem } from "../types";
+import {
+  detectImageContent,
+  type DetectImageContentDeps,
+  type ImageDetectionResult,
+} from "./detectImageContent";
+
+/** 検出フェーズの同時実行数デフォルト値 */
+export const DETECTION_CONCURRENCY = 2;
+
+/** runDetectionForGalleryItems のオプション */
+export interface RunDetectionForGalleryItemsOptions extends DetectImageContentDeps {
+  items: MaskingImageItem[];
+  isMounted: () => boolean;
+  concurrency?: number;
+  onItemSuccess: (item: MaskingImageItem, result: ImageDetectionResult) => void;
+  onItemFailure: (item: MaskingImageItem) => void;
+}
+
+/** runDetectionForGalleryItems の戻り値 */
+export interface RunDetectionForGalleryItemsResult {
+  detectionSucceededCount: number;
+  detectionFailedCount: number;
+}
+
+/**
+ * 並行数を制限しながら各画像の顔検出・OCR を実行する
+ *
+ * 全画像を同時処理するとモバイルで CPU/メモリが競合して逆に遅くなるため、
+ * 同時実行数を concurrency に抑える。
+ *
+ * @param options - 検出対象・依存関数・コールバック
+ * @returns 成功・失敗件数
+ */
+export async function runDetectionForGalleryItems(
+  options: RunDetectionForGalleryItemsOptions
+): Promise<RunDetectionForGalleryItemsResult> {
+  const {
+    items,
+    isMounted,
+    detectFaces,
+    recognizeText,
+    concurrency = DETECTION_CONCURRENCY,
+    onItemSuccess,
+    onItemFailure,
+  } = options;
+
+  let detectionSucceededCount = 0;
+  let detectionFailedCount = 0;
+
+  for (let i = 0; i < items.length; i += concurrency) {
+    if (!isMounted()) break;
+    const chunk = items.slice(i, i + concurrency);
+    await Promise.allSettled(
+      chunk.map(async (item) => {
+        try {
+          const result = await detectImageContent(item.imageUrl, { detectFaces, recognizeText });
+          if (isMounted()) {
+            onItemSuccess(item, result);
+            detectionSucceededCount++;
+          }
+        } catch {
+          if (isMounted()) {
+            onItemFailure(item);
+            detectionFailedCount++;
+          }
+        }
+      })
+    );
+  }
+
+  return { detectionSucceededCount, detectionFailedCount };
+}

--- a/features/masking/lib/runDetectionForGalleryItems.ts
+++ b/features/masking/lib/runDetectionForGalleryItems.ts
@@ -45,12 +45,14 @@ export async function runDetectionForGalleryItems(
     onItemFailure,
   } = options;
 
+  const safeConcurrency = Math.max(1, concurrency);
+
   let detectionSucceededCount = 0;
   let detectionFailedCount = 0;
 
-  for (let i = 0; i < items.length; i += concurrency) {
+  for (let i = 0; i < items.length; i += safeConcurrency) {
     if (!isMounted()) break;
-    const chunk = items.slice(i, i + concurrency);
+    const chunk = items.slice(i, i + safeConcurrency);
     await Promise.allSettled(
       chunk.map(async (item) => {
         try {


### PR DESCRIPTION
## 概要

`MaskingGallery` の巨大な副作用・hooks を lib / hooks に分割し、コンポーネントを JSX 中心の ~140 行に整理する。動作・UX は変更しない。

## 関連Issue

Closes #80

## 変更内容

- [ ] 機能追加
- [ ] バグ修正
- [x] リファクタリング
- [x] テスト追加・修正
- [ ] ドキュメント修正
- [ ] 設定・環境変更
- [ ] その他

## 主な変更箇所

### UI・コンポーネント

- `MaskingGallery.tsx`: 542 行 → ~140 行。hook 呼び出し + JSX のみに整理

### ロジック・処理

- **lib**: `loadImageElement`, `detectImageContent`, `prepareGalleryItemsFromFiles`, `runDetectionForGalleryItems`, `applyDetectionResult`, `downloadMaskedImagesAsZip`
- **hooks**: `useGalleryImages`, `useGalleryDetection`, `useStampImages`, `useClipboardImagePaste`
- `step2*` 命名を `detectionSucceededCount` / `detectionFailedCount` に変更

### その他

- `detectImageContent.test.ts`, `prepareGalleryItemsFromFiles.test.ts` を追加

## 動作確認

- [x] ローカル環境での動作確認
- [x] テストの実行・通過確認
- [ ] UI動作確認
- [x] 既存機能への影響確認
- [ ] ブラウザ動作確認（Chrome / Firefox / Safari）

## スクリーンショット・動画

UI 変更なし

## テスト

### 追加したテスト

- `detectImageContent.test.ts`: 検出成功・失敗の伝播
- `prepareGalleryItemsFromFiles.test.ts`: Blob 変換成功・アンマウント時 rejected

### テスト結果

- [x] 全てのテストが通過（`pnpm test:run features/masking/` — 30 tests passed）
- [x] 新規テストを追加
- [ ] 既存テストの修正

## 破壊的変更

- [ ] 破壊的変更あり
- [x] 破壊的変更なし

### 破壊的変更の詳細

なし

## レビューポイント

- `useGalleryDetection` のアップロード・再検出フローが元の挙動と同等か
- Blob URL 解放タイミング（`useGalleryImages` の cleanup）
- `runDetectionForGalleryItems` の並行数制御（CONCURRENCY=2）

## 補足

Issue #80 の改善案を一括で実施。

## チェックリスト

- [x] コードレビューの準備ができている
- [x] 適切なラベルを付けている
- [x] セルフレビューを実施している
- [x] `pnpm lint` と `pnpm type-check` が通ることを確認した
- [ ] 必要に応じてドキュメントを更新している
