### PR TITLE
OCR の電話番号取りこぼしを改善（Tesseract PSM 設定・郵便番号誤検出修正）

### DIFF
--- a/features/ocr/hooks/useOcr.test.ts
+++ b/features/ocr/hooks/useOcr.test.ts
@@ -105,6 +105,7 @@ describe("useOcr", () => {
   });
 
   it("Worker 初期化時に PSM.AUTO を設定する", async () => {
+    const { PSM } = await import("tesseract.js");
     const { result } = renderHook(() => useOcr());
     const mockImage = document.createElement("img");
     mockRecognize.mockResolvedValueOnce(buildMockPage([]));
@@ -113,7 +114,7 @@ describe("useOcr", () => {
       await result.current.recognizeText(mockImage);
     });
 
-    expect(mockSetParameters).toHaveBeenCalledWith({ tessedit_pageseg_mode: 3 });
+    expect(mockSetParameters).toHaveBeenCalledWith({ tessedit_pageseg_mode: PSM.AUTO });
   });
 
   it("recognizeText 完了後は isRecognizing が false になる", async () => {

--- a/features/ocr/hooks/useOcr.test.ts
+++ b/features/ocr/hooks/useOcr.test.ts
@@ -117,6 +117,25 @@ describe("useOcr", () => {
     expect(mockSetParameters).toHaveBeenCalledWith({ tessedit_pageseg_mode: PSM.AUTO });
   });
 
+  it("setParameters 失敗時に Worker を terminate し再初期化できる", async () => {
+    mockSetParameters.mockRejectedValueOnce(new Error("setParameters failed"));
+    mockRecognize.mockResolvedValueOnce(buildMockPage([]));
+
+    const { result } = renderHook(() => useOcr());
+    const mockImage = document.createElement("img");
+
+    await act(async () => {
+      await expect(result.current.recognizeText(mockImage)).rejects.toThrow("setParameters failed");
+    });
+    expect(mockTerminate).toHaveBeenCalledTimes(1);
+
+    mockSetParameters.mockResolvedValue(undefined);
+    await act(async () => {
+      await result.current.recognizeText(mockImage);
+    });
+    expect(mockSetParameters).toHaveBeenCalledTimes(2);
+  });
+
   it("recognizeText 完了後は isRecognizing が false になる", async () => {
     mockRecognize.mockResolvedValueOnce(buildMockPage([]));
 

--- a/features/ocr/hooks/useOcr.test.ts
+++ b/features/ocr/hooks/useOcr.test.ts
@@ -5,9 +5,11 @@ import { useOcr, detectPersonalInfoInLine } from "./useOcr";
 /** テスト用モックWorker */
 const mockTerminate = vi.fn().mockResolvedValue(undefined);
 const mockRecognize = vi.fn();
+const mockSetParameters = vi.fn().mockResolvedValue(undefined);
 const mockWorker = {
   recognize: mockRecognize,
   terminate: mockTerminate,
+  setParameters: mockSetParameters,
 };
 
 vi.mock("tesseract.js", () => ({
@@ -17,6 +19,9 @@ vi.mock("tesseract.js", () => ({
     LSTM_ONLY: 1,
     TESSERACT_LSTM_COMBINED: 2,
     DEFAULT: 3,
+  },
+  PSM: {
+    AUTO: 3,
   },
 }));
 
@@ -97,6 +102,18 @@ describe("useOcr", () => {
     const { result } = renderHook(() => useOcr());
     expect(result.current.isRecognizing).toBe(false);
     expect(result.current.ocrRegions).toHaveLength(0);
+  });
+
+  it("Worker 初期化時に PSM.AUTO を設定する", async () => {
+    const { result } = renderHook(() => useOcr());
+    const mockImage = document.createElement("img");
+    mockRecognize.mockResolvedValueOnce(buildMockPage([]));
+
+    await act(async () => {
+      await result.current.recognizeText(mockImage);
+    });
+
+    expect(mockSetParameters).toHaveBeenCalledWith({ tessedit_pageseg_mode: 3 });
   });
 
   it("recognizeText 完了後は isRecognizing が false になる", async () => {
@@ -379,6 +396,15 @@ describe("detectPersonalInfoInLine", () => {
     expect(result[0].patternType).toBe("phone");
   });
 
+  it("電話番号（携帯・ハイフンあり）を正しく検出する", () => {
+    const result = detectPersonalInfoInLine("080-1234-5678", [
+      { text: "080-1234-5678", bbox: { x0: 0, y0: 0, x1: 110, y1: 20 } },
+    ]);
+    expect(result).toHaveLength(1);
+    expect(result[0].patternType).toBe("phone");
+    expect(result[0].text).toBe("080-1234-5678");
+  });
+
   it("電話番号（携帯・ハイフンなし）を正しく検出する", () => {
     const result = detectPersonalInfoInLine("09012345678", [
       { text: "09012345678", bbox: { x0: 0, y0: 0, x1: 90, y1: 20 } },
@@ -458,6 +484,16 @@ describe("detectPersonalInfoInLine", () => {
     expect(result).toHaveLength(1);
     expect(result[0].patternType).toBe("postal");
     expect(result[0].text).toBe("〒123-4567");
+  });
+
+  it("郵便番号を phone の部分文字列として誤検出しない", () => {
+    const result = detectPersonalInfoInLine("の 〇 〒100-0001", [
+      { text: "の", bbox: { x0: 0, y0: 0, x1: 20, y1: 20 } },
+      { text: "〇", bbox: { x0: 25, y0: 0, x1: 40, y1: 20 } },
+      { text: "〒100-0001", bbox: { x0: 45, y0: 0, x1: 130, y1: 20 } },
+    ]);
+    expect(result.some((r) => r.patternType === "phone")).toBe(false);
+    expect(result.some((r) => r.patternType === "postal")).toBe(true);
   });
 
   it("郵便番号（区切りなし）を postal として検出する", () => {

--- a/features/ocr/hooks/useOcr.test.ts
+++ b/features/ocr/hooks/useOcr.test.ts
@@ -136,6 +136,23 @@ describe("useOcr", () => {
     expect(mockSetParameters).toHaveBeenCalledTimes(2);
   });
 
+  it("アンマウント時に Worker を terminate する", async () => {
+    mockRecognize.mockResolvedValueOnce(buildMockPage([]));
+
+    const { result, unmount } = renderHook(() => useOcr());
+    const mockImage = document.createElement("img");
+
+    await act(async () => {
+      await result.current.recognizeText(mockImage);
+    });
+
+    unmount();
+
+    await waitFor(() => {
+      expect(mockTerminate).toHaveBeenCalled();
+    });
+  });
+
   it("recognizeText 完了後は isRecognizing が false になる", async () => {
     mockRecognize.mockResolvedValueOnce(buildMockPage([]));
 

--- a/features/ocr/hooks/useOcr.test.ts
+++ b/features/ocr/hooks/useOcr.test.ts
@@ -533,6 +533,14 @@ describe("detectPersonalInfoInLine", () => {
     expect(result.some((r) => r.patternType === "postal")).toBe(true);
   });
 
+  it("0始まりの郵便番号を phone として誤検出しない", () => {
+    const result = detectPersonalInfoInLine("〒010-0001", [
+      { text: "〒010-0001", bbox: { x0: 0, y0: 0, x1: 90, y1: 20 } },
+    ]);
+    expect(result.some((r) => r.patternType === "phone")).toBe(false);
+    expect(result.some((r) => r.patternType === "postal")).toBe(true);
+  });
+
   it("郵便番号（区切りなし）を postal として検出する", () => {
     const result = detectPersonalInfoInLine("1234567", [
       { text: "1234567", bbox: { x0: 0, y0: 0, x1: 70, y1: 20 } },

--- a/features/ocr/hooks/useOcr.ts
+++ b/features/ocr/hooks/useOcr.ts
@@ -22,7 +22,9 @@ const PATTERNS: ReadonlyArray<{ type: OcrPatternType; source: string }> = [
      * 2. 国内番号（区切りあり）: 080-1234-5678 / 090-1234-5678 / 03-1234-5678 / 0120-123-456
      * 3. 国内番号（ハイフンなし）: 09012345678 / 0312345678
      *
-     * 国内番号の誤検出防止（直前が数字ならスキップ）は detectPersonalInfoInLine 側で行う。
+     * 国内番号の誤検出防止は detectPersonalInfoInLine 内の isDomesticPhoneFalsePositive で行う:
+     * - 直前が数字ならスキップ（例: 〒100-0001 内の 00-0001）
+     * - 0始まりかつ数字が10桁未満ならスキップ（例: 〒010-0001）
      * 正規表現の lookbehind は Safari 15 等で SyntaxError になるため使用しない。
      */
     source: String.raw`\+\d{1,3}[-\s]?\d{1,4}[-\s]?\d{1,4}[-\s]?\d{3,4}|0\d{1,4}[-\s]?\d{1,4}[-\s]?\d{3,4}|0\d{9,10}`,

--- a/features/ocr/hooks/useOcr.ts
+++ b/features/ocr/hooks/useOcr.ts
@@ -19,10 +19,13 @@ const PATTERNS: ReadonlyArray<{ type: OcrPatternType; source: string }> = [
     /**
      * 3つの表記を `|` で結合して検出する:
      * 1. 国際番号形式: +81-90-1234-5678 / +1-800-555-1234
-     * 2. 国内番号（区切りあり）: 090-1234-5678 / 03-1234-5678 / 0120-123-456
+     * 2. 国内番号（区切りあり）: 080-1234-5678 / 090-1234-5678 / 03-1234-5678 / 0120-123-456
      * 3. 国内番号（ハイフンなし）: 09012345678 / 0312345678
+     *
+     * 国内番号は `(?<![0-9])` で直前が数字でない場合のみマッチし、
+     * 〒100-0001 内の 00-0001 など郵便番号の部分文字列への誤検出を防ぐ。
      */
-    source: String.raw`\+\d{1,3}[-\s]?\d{1,4}[-\s]?\d{1,4}[-\s]?\d{3,4}|0\d{1,4}[-\s]?\d{1,4}[-\s]?\d{3,4}|0\d{9,10}`,
+    source: String.raw`\+\d{1,3}[-\s]?\d{1,4}[-\s]?\d{1,4}[-\s]?\d{3,4}|(?<![0-9])0\d{1,4}[-\s]?\d{1,4}[-\s]?\d{3,4}|(?<![0-9])0\d{9,10}`,
   },
   {
     type: "postal",
@@ -211,9 +214,15 @@ export function useOcr(): UseOcrReturn {
        * "Warning: Parameter not found: language_model_ngram_on" が出力されるが、
        * これは既知の無害な警告であり OCR の動作には影響しない。
        */
-      const promise = import("tesseract.js").then(({ createWorker, OEM }) =>
-        createWorker(["jpn", "eng"], OEM.LSTM_ONLY)
-      );
+      const promise = import("tesseract.js").then(async ({ createWorker, OEM, PSM }) => {
+        const worker = await createWorker(["jpn", "eng"], OEM.LSTM_ONLY);
+        /**
+         * PSM.AUTO: 名刺など散在テキストの行結合ミスを減らし、
+         * 080-1234-5678 等の電話番号の取りこぼしを防ぐ（デフォルト PSM では未検出）。
+         */
+        await worker.setParameters({ tessedit_pageseg_mode: PSM.AUTO });
+        return worker;
+      });
       workerRef.current = promise;
       /** reject 時はキャッシュを破棄し、次回呼び出しで再生成できるようにする */
       promise.catch(() => {

--- a/features/ocr/hooks/useOcr.ts
+++ b/features/ocr/hooks/useOcr.ts
@@ -265,16 +265,17 @@ export function useOcr(): UseOcrReturn {
   useEffect(() => {
     return () => {
       /** アンマウント時にWorkerを終了してリソースを解放 */
-      if (workerRef.current) {
+      const workerPromise = workerRef.current;
+      workerRef.current = null;
+      if (workerPromise) {
         void (async () => {
           try {
-            const worker = await workerRef.current!;
+            const worker = await workerPromise;
             await worker.terminate();
           } catch {
             /** 終了処理の失敗はアンマウント時のベストエフォート */
           }
         })();
-        workerRef.current = null;
       }
     };
   }, []);

--- a/features/ocr/hooks/useOcr.ts
+++ b/features/ocr/hooks/useOcr.ts
@@ -22,10 +22,10 @@ const PATTERNS: ReadonlyArray<{ type: OcrPatternType; source: string }> = [
      * 2. 国内番号（区切りあり）: 080-1234-5678 / 090-1234-5678 / 03-1234-5678 / 0120-123-456
      * 3. 国内番号（ハイフンなし）: 09012345678 / 0312345678
      *
-     * 国内番号は `(?<![0-9])` で直前が数字でない場合のみマッチし、
-     * 〒100-0001 内の 00-0001 など郵便番号の部分文字列への誤検出を防ぐ。
+     * 国内番号の誤検出防止（直前が数字ならスキップ）は detectPersonalInfoInLine 側で行う。
+     * 正規表現の lookbehind は Safari 15 等で SyntaxError になるため使用しない。
      */
-    source: String.raw`\+\d{1,3}[-\s]?\d{1,4}[-\s]?\d{1,4}[-\s]?\d{3,4}|(?<![0-9])0\d{1,4}[-\s]?\d{1,4}[-\s]?\d{3,4}|(?<![0-9])0\d{9,10}`,
+    source: String.raw`\+\d{1,3}[-\s]?\d{1,4}[-\s]?\d{1,4}[-\s]?\d{3,4}|0\d{1,4}[-\s]?\d{1,4}[-\s]?\d{3,4}|0\d{9,10}`,
   },
   {
     type: "postal",
@@ -111,6 +111,19 @@ export function detectPersonalInfoInLine(lineText: string, words: TesseractWord[
       /** 既にマッチ済みの範囲と重複する場合はスキップ */
       const alreadyMatched = matchedRanges.some((r) => r.start < matchEnd && r.end > matchStart);
       if (alreadyMatched) continue;
+
+      /**
+       * 国内電話番号（0始まり）が数字の直後から始まる場合はスキップする。
+       * 例: 〒100-0001 内の 00-0001 への誤マッチを防ぐ（lookbehind の代替）。
+       */
+      if (
+        pattern.type === "phone" &&
+        match[0].startsWith("0") &&
+        matchStart > 0 &&
+        /\d/.test(lineText[matchStart - 1]!)
+      ) {
+        continue;
+      }
 
       /** マッチ範囲と重なる単語のbboxを統合 */
       const overlapping = wordPositions.filter((w) => w.start < matchEnd && w.end > matchStart);

--- a/features/ocr/hooks/useOcr.ts
+++ b/features/ocr/hooks/useOcr.ts
@@ -192,6 +192,21 @@ function extractOcrRegions(page: TesseractPage): OcrRegion[] {
 }
 
 /**
+ * Tesseract Worker を生成し OCR 用パラメータを設定する
+ *
+ * PSM.AUTO: 名刺など散在テキストの行結合ミスを減らし、
+ * 080-1234-5678 等の電話番号の取りこぼしを防ぐ（デフォルト PSM では未検出）。
+ *
+ * @returns 初期化済みの Tesseract Worker
+ */
+async function initializeTesseractWorker(): Promise<import("tesseract.js").Worker> {
+  const { createWorker, OEM, PSM } = await import("tesseract.js");
+  const worker = await createWorker(["jpn", "eng"], OEM.LSTM_ONLY);
+  await worker.setParameters({ tessedit_pageseg_mode: PSM.AUTO });
+  return worker;
+}
+
+/**
  * OCRフック
  *
  * Tesseract.js の Web Worker を使用して画像内テキストを認識し、
@@ -227,15 +242,7 @@ export function useOcr(): UseOcrReturn {
        * "Warning: Parameter not found: language_model_ngram_on" が出力されるが、
        * これは既知の無害な警告であり OCR の動作には影響しない。
        */
-      const promise = import("tesseract.js").then(async ({ createWorker, OEM, PSM }) => {
-        const worker = await createWorker(["jpn", "eng"], OEM.LSTM_ONLY);
-        /**
-         * PSM.AUTO: 名刺など散在テキストの行結合ミスを減らし、
-         * 080-1234-5678 等の電話番号の取りこぼしを防ぐ（デフォルト PSM では未検出）。
-         */
-        await worker.setParameters({ tessedit_pageseg_mode: PSM.AUTO });
-        return worker;
-      });
+      const promise = initializeTesseractWorker();
       workerRef.current = promise;
       /** reject 時はキャッシュを破棄し、次回呼び出しで再生成できるようにする */
       promise.catch(() => {
@@ -250,7 +257,14 @@ export function useOcr(): UseOcrReturn {
     return () => {
       /** アンマウント時にWorkerを終了してリソースを解放 */
       if (workerRef.current) {
-        void workerRef.current.then((w) => w.terminate()).catch(() => {});
+        void (async () => {
+          try {
+            const worker = await workerRef.current!;
+            await worker.terminate();
+          } catch {
+            /** 終了処理の失敗はアンマウント時のベストエフォート */
+          }
+        })();
         workerRef.current = null;
       }
     };

--- a/features/ocr/hooks/useOcr.ts
+++ b/features/ocr/hooks/useOcr.ts
@@ -202,8 +202,17 @@ function extractOcrRegions(page: TesseractPage): OcrRegion[] {
 async function initializeTesseractWorker(): Promise<import("tesseract.js").Worker> {
   const { createWorker, OEM, PSM } = await import("tesseract.js");
   const worker = await createWorker(["jpn", "eng"], OEM.LSTM_ONLY);
-  await worker.setParameters({ tessedit_pageseg_mode: PSM.AUTO });
-  return worker;
+  try {
+    await worker.setParameters({ tessedit_pageseg_mode: PSM.AUTO });
+    return worker;
+  } catch (err) {
+    try {
+      await worker.terminate();
+    } catch {
+      /** 初期化失敗時の terminate はベストエフォート */
+    }
+    throw err;
+  }
 }
 
 /**

--- a/features/ocr/hooks/useOcr.ts
+++ b/features/ocr/hooks/useOcr.ts
@@ -79,6 +79,34 @@ interface TesseractPage {
   text?: string;
 }
 
+/** 国内電話番号として扱う最低桁数（郵便番号7桁との誤検出を防ぐ） */
+const MIN_DOMESTIC_PHONE_DIGITS = 10;
+
+/**
+ * 国内電話番号（0始まり）のマッチが郵便番号等への誤検出かどうかを判定する
+ *
+ * @param lineText - OCR結果の行テキスト
+ * @param matchStart - マッチ開始位置
+ * @param matchText - マッチした文字列
+ * @returns 誤検出と判断する場合は true
+ */
+function isDomesticPhoneFalsePositive(
+  lineText: string,
+  matchStart: number,
+  matchText: string
+): boolean {
+  if (!matchText.startsWith("0")) {
+    return false;
+  }
+  /** 直前が数字の場合は郵便番号内の部分文字列（例: 〒100-0001 の 00-0001） */
+  if (matchStart > 0 && /\d/.test(lineText[matchStart - 1]!)) {
+    return true;
+  }
+  /** 数字が10桁未満の場合は郵便番号（7桁）等への誤マッチ（例: 〒010-0001） */
+  const digitCount = matchText.replace(/\D/g, "").length;
+  return digitCount < MIN_DOMESTIC_PHONE_DIGITS;
+}
+
 /**
  * 1行のテキストと単語座標から個人情報領域を検出する
  *
@@ -112,15 +140,10 @@ export function detectPersonalInfoInLine(lineText: string, words: TesseractWord[
       const alreadyMatched = matchedRanges.some((r) => r.start < matchEnd && r.end > matchStart);
       if (alreadyMatched) continue;
 
-      /**
-       * 国内電話番号（0始まり）が数字の直後から始まる場合はスキップする。
-       * 例: 〒100-0001 内の 00-0001 への誤マッチを防ぐ（lookbehind の代替）。
-       */
+      /** 国内電話番号の郵便番号誤検出をスキップ（lookbehind 非使用・桁数チェック） */
       if (
         pattern.type === "phone" &&
-        match[0].startsWith("0") &&
-        matchStart > 0 &&
-        /\d/.test(lineText[matchStart - 1]!)
+        isDomesticPhoneFalsePositive(lineText, matchStart, match[0])
       ) {
         continue;
       }


### PR DESCRIPTION
## 概要

名刺サンプル（sample2）で `080-1234-5678` がマスキングされない問題を修正する。Tesseract の PSM を `AUTO` に設定して OCR 取りこぼしを減らし、郵便番号 `〒100-0001` が電話番号 `00-0001` と誤検出される問題も併せて修正する。

## 関連Issue

Closes #79

## 変更内容

- [ ] 機能追加
- [x] バグ修正
- [ ] リファクタリング
- [x] テスト追加・修正
- [ ] ドキュメント修正
- [ ] 設定・環境変更
- [ ] その他

## 主な変更箇所

### UI・コンポーネント

なし

### ロジック・処理

- `features/ocr/hooks/useOcr.ts`
  - Worker 初期化時に `PSM.AUTO` を設定（名刺など散在テキストの行結合ミスを軽減）
  - 国内電話番号の誤検出防止をマッチ後フィルタで実装（`〒100-0001` 内の `00-0001` 等）。正規表現の lookbehind は Safari 15 等で `SyntaxError` になるため不使用

### その他

- `features/ocr/hooks/useOcr.test.ts` に PSM 設定・080 番号・郵便番号誤検出のテストを追加

## 動作確認

- [x] ローカル環境での動作確認
- [x] テストの実行・通過確認
- [ ] UI動作確認
- [x] 既存機能への影響確認
- [ ] ブラウザ動作確認（Chrome / Firefox / Safari）

## スクリーンショット・動画

なし（ロジック修正のみ）

## テスト

### 追加したテスト

- Worker 初期化時に `PSM.AUTO` が設定されること
- `080-1234-5678` が phone として検出されること
- `の 〇 〒100-0001` が phone として誤検出されないこと

### テスト結果

- [x] 全てのテストが通過
- [x] 新規テストを追加
- [ ] 既存テストの修正

## 破壊的変更

- [ ] 破壊的変更あり
- [x] 破壊的変更なし

### 破壊的変更の詳細

なし

## レビューポイント

- `PSM.AUTO` による OCR 精度・速度への影響（sample2 では改善を確認済み）
- 国内電話番号のマッチ後フィルタ（直前が数字ならスキップ）が想定外のケースで取りこぼしを生まないか

## 補足

- 正規表現単体では `080-1234-5678` はもともとマッチしていたが、デフォルト PSM では Tesseract がその文字列を OCR できていなかった
- 郵便番号誤検出の防止は当初 `(?<![0-9])` lookbehind で実装したが、Safari 16.4 未満で `new RegExp` が例外になるため、同等ロジックをマッチ後の文字チェックに置き換えた。OCR 行テキストは短いため実行速度への影響は無視できる
- #77（検出設定）とは独立した変更

## チェックリスト

- [x] コードレビューの準備ができている
- [x] 適切なラベルを付けている
- [x] セルフレビューを実施している
- [x] `pnpm lint` と `pnpm type-check` が通ることを確認した
- [ ] 必要に応じてドキュメントを更新している
