### PR TITLE
オフライン手動編集モードを追加（PWA Phase 2）

### DIFF
--- a/app/sw.ts
+++ b/app/sw.ts
@@ -18,7 +18,11 @@ const serwist = new Serwist({
   navigationPreload: true,
   runtimeCaching: [
     {
-      matcher: ({ url }) => url.pathname.includes("/stamps/"),
+      matcher: ({ url, request }) =>
+        url.origin === self.location.origin &&
+        request.method === "GET" &&
+        request.destination === "image" &&
+        url.pathname.includes("/stamps/"),
       handler: new CacheFirst({
         cacheName: "stamp-images",
       }),

--- a/app/sw.ts
+++ b/app/sw.ts
@@ -1,3 +1,4 @@
+import { CacheFirst } from "serwist";
 import { defaultCache } from "@serwist/next/worker";
 import type { PrecacheEntry, SerwistGlobalConfig } from "serwist";
 import { Serwist } from "serwist";
@@ -15,7 +16,15 @@ const serwist = new Serwist({
   skipWaiting: true,
   clientsClaim: true,
   navigationPreload: true,
-  runtimeCaching: defaultCache,
+  runtimeCaching: [
+    {
+      matcher: ({ url }) => url.pathname.startsWith("/stamps/"),
+      handler: new CacheFirst({
+        cacheName: "stamp-images",
+      }),
+    },
+    ...defaultCache,
+  ],
   fallbacks: {
     entries: [
       {

--- a/app/sw.ts
+++ b/app/sw.ts
@@ -18,7 +18,7 @@ const serwist = new Serwist({
   navigationPreload: true,
   runtimeCaching: [
     {
-      matcher: ({ url }) => url.pathname.startsWith("/stamps/"),
+      matcher: ({ url }) => url.pathname.includes("/stamps/"),
       handler: new CacheFirst({
         cacheName: "stamp-images",
       }),

--- a/features/masking/components/GalleryItem.test.tsx
+++ b/features/masking/components/GalleryItem.test.tsx
@@ -70,6 +70,7 @@ describe("GalleryItem", () => {
         image={createImage()}
         isActive={false}
         isModelLoading={false}
+        isOffline={false}
         stampImages={new Map()}
         {...handlers}
       />
@@ -90,6 +91,7 @@ describe("GalleryItem", () => {
         image={createImage()}
         isActive={false}
         isModelLoading={false}
+        isOffline={false}
         stampImages={new Map()}
         {...handlers}
       />
@@ -105,6 +107,7 @@ describe("GalleryItem", () => {
         image={createImage({ processingError: true })}
         isActive={false}
         isModelLoading={false}
+        isOffline={false}
         stampImages={new Map()}
         {...handlers}
       />

--- a/features/masking/components/GalleryItem.test.tsx
+++ b/features/masking/components/GalleryItem.test.tsx
@@ -116,4 +116,23 @@ describe("GalleryItem", () => {
     expect(await screen.findByText("検出に失敗しました。再検出してください。")).toBeInTheDocument();
     expect(vi.mocked(exportEditorCanvas)).not.toHaveBeenCalled();
   });
+
+  it("オフライン時は再検出ボタンが無効で onRedetect が呼ばれない", async () => {
+    render(
+      <GalleryItem
+        image={createImage()}
+        isActive={false}
+        isModelLoading={false}
+        isOffline={true}
+        stampImages={new Map()}
+        {...handlers}
+      />
+    );
+
+    const redetectButton = await screen.findByRole("button", { name: "再検出" });
+    expect(redetectButton).toBeDisabled();
+
+    fireEvent.click(redetectButton);
+    expect(handlers.onRedetect).not.toHaveBeenCalled();
+  });
 });

--- a/features/masking/components/GalleryItem.tsx
+++ b/features/masking/components/GalleryItem.tsx
@@ -11,6 +11,8 @@ interface GalleryItemProps {
   isActive: boolean;
   /** face-api モデルのロード中フラグ（ロード中は再検出を無効化する） */
   isModelLoading: boolean;
+  /** オフライン手動編集モード（再検出を無効化する） */
+  isOffline: boolean;
   stampImages: Map<string, HTMLImageElement>;
   onSelect: (id: string) => void;
   onOpenEdit: (id: string) => void;
@@ -27,6 +29,7 @@ export function GalleryItem({
   image,
   isActive,
   isModelLoading,
+  isOffline,
   stampImages,
   onSelect,
   onOpenEdit,
@@ -39,7 +42,7 @@ export function GalleryItem({
   const imageElementRef = useRef<HTMLImageElement | null>(null);
   const [imageReadyVersion, setImageReadyVersion] = useState(0);
 
-  const isRedetectDisabled = image.isProcessing || isModelLoading;
+  const isRedetectDisabled = image.isProcessing || isModelLoading || isOffline;
   const canEdit = !image.isProcessing && !image.processingError;
 
   useEffect(() => {

--- a/features/masking/components/MaskingGallery.test.tsx
+++ b/features/masking/components/MaskingGallery.test.tsx
@@ -32,6 +32,10 @@ vi.mock("@/features/ocr", () => ({
   }),
 }));
 
+vi.mock("@/lib/useNetworkStatus", () => ({
+  useNetworkStatus: () => ({ isOnline: true, isOffline: false }),
+}));
+
 vi.mock("@/lib/confirmStore", () => ({
   useConfirmStore: {
     getState: () => ({ open: vi.fn().mockResolvedValue(true) }),

--- a/features/masking/components/MaskingGallery.tsx
+++ b/features/masking/components/MaskingGallery.tsx
@@ -8,6 +8,7 @@ import { ImageUpload } from "@/components/ImageUpload";
 import { useFaceDetection } from "@/features/face-detection";
 import { useOcr } from "@/features/ocr";
 import type { DetectionPrefs } from "@/lib/preferences";
+import { useNetworkStatus } from "@/lib/useNetworkStatus";
 import { useClipboardImagePaste } from "../hooks/useClipboardImagePaste";
 import { DETECTION_SETTINGS_BAR_REVEAL_MS, useDelayedReveal } from "../hooks/useDelayedReveal";
 import { useCustomMaskTerms } from "../hooks/useCustomMaskTerms";
@@ -20,11 +21,16 @@ import {
   formatCustomMaskTermsSummary,
   formatDetectionSettingsSummary,
 } from "../lib/detectionMessages";
+import {
+  getEffectiveDetectionSettings,
+  isUploadBlockedByModelState,
+} from "../lib/offlineManualEdit";
 import { CustomMaskTermsModal } from "./CustomMaskTermsModal";
 import { DetectionSettingsBarSkeleton } from "./DetectionSettingsBarSkeleton";
 import { DetectionSettingsModal } from "./DetectionSettingsModal";
 import { EditorModal } from "./EditorModal";
 import { GalleryItem } from "./GalleryItem";
+import { OfflineManualEditBanner } from "./OfflineManualEditBanner";
 
 /**
  * メインマスキングギャラリーコンポーネント
@@ -32,6 +38,7 @@ import { GalleryItem } from "./GalleryItem";
  * 画像アップロード、顔検出、Canvas表示を統合する。
  */
 export function MaskingGallery() {
+  const { isOffline } = useNetworkStatus();
   const stampImages = useStampImages();
   const {
     images,
@@ -72,18 +79,29 @@ export function MaskingGallery() {
   const getDetectionSettings = useCallback(() => detectionSettings, [detectionSettings]);
   const getCustomMaskTerms = useCallback(() => enabledCustomMaskTexts, [enabledCustomMaskTexts]);
 
+  const effectiveDetectionSettings = useMemo(
+    () => getEffectiveDetectionSettings(detectionSettings, isOffline),
+    [detectionSettings, isOffline]
+  );
+
   const detectionSettingsSummary = useMemo(
-    () => formatDetectionSettingsSummary(detectionSettings),
-    [detectionSettings]
+    () =>
+      isOffline ? "オフライン（手動のみ）" : formatDetectionSettingsSummary(detectionSettings),
+    [detectionSettings, isOffline]
   );
   const customMaskTermsSummary = useMemo(
     () =>
       formatCustomMaskTermsSummary(customMaskTerms, {
-        ocrEnabled: detectionSettings.autoDetectOcr,
+        ocrEnabled: effectiveDetectionSettings.autoDetectOcr,
       }),
-    [customMaskTerms, detectionSettings.autoDetectOcr]
+    [customMaskTerms, effectiveDetectionSettings.autoDetectOcr]
   );
-  const isCustomMaskTermsEditable = detectionSettings.autoDetectOcr;
+  const isCustomMaskTermsEditable = effectiveDetectionSettings.autoDetectOcr;
+  const isUploadBlockedByModel = isUploadBlockedByModelState(
+    isOffline,
+    isModelLoading,
+    isModelError
+  );
 
   const { handleUpload, handleRedetect } = useGalleryDetection({
     images,
@@ -97,9 +115,15 @@ export function MaskingGallery() {
     recognizeText,
     getDetectionSettings,
     getCustomMaskTerms,
+    isOffline,
   });
 
-  useClipboardImagePaste({ onUpload: handleUpload, isModelLoading, isModelError });
+  useClipboardImagePaste({
+    onUpload: handleUpload,
+    isModelLoading,
+    isModelError,
+    isOffline,
+  });
 
   const handleSaveDetectionSettings = useCallback(
     (settings: DetectionPrefs) => {
@@ -121,13 +145,14 @@ export function MaskingGallery() {
 
   const hasProcessingImage = images.some((image) => image.isProcessing);
   const isProcessing = isDetecting || isRecognizing || hasProcessingImage;
-  const loadingMessage = isModelLoading ? "顔検出モデルをロード中…" : null;
+  const loadingMessage = !isOffline && isModelLoading ? "顔検出モデルをロード中…" : null;
   const downloadableImagesCount = images.filter(
     (image) => image.maskedBlobUrl && !image.isProcessing
   ).length;
 
   return (
     <div className="flex flex-col gap-6">
+      <OfflineManualEditBanner visible={isOffline} />
       {!showDetectionSettingsBar ? (
         <DetectionSettingsBarSkeleton />
       ) : (
@@ -212,11 +237,11 @@ export function MaskingGallery() {
 
       <ImageUpload
         onUpload={handleUpload}
-        disabled={isProcessing || isModelLoading || isModelError}
+        disabled={isProcessing || isUploadBlockedByModel}
         multiple
         loadingMessage={loadingMessage}
       />
-      {isModelError && (
+      {isModelError && !isOffline && (
         <p role="alert" className="text-center text-sm text-red-600">
           顔検出モデルのロードに失敗しました。ページを再読み込みしてください。
         </p>
@@ -257,6 +282,7 @@ export function MaskingGallery() {
                 image={image}
                 isActive={image.id === activeImageId}
                 isModelLoading={isModelLoading}
+                isOffline={isOffline}
                 stampImages={stampImages}
                 onSelect={setActiveImageId}
                 onOpenEdit={handleOpenEdit}

--- a/features/masking/components/MaskingGallery.tsx
+++ b/features/masking/components/MaskingGallery.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useState } from "react";
 import clsx from "clsx";
 import { Settings, ListChecks } from "lucide-react";
 import { toast } from "sonner";
@@ -8,23 +8,15 @@ import { ImageUpload } from "@/components/ImageUpload";
 import { useFaceDetection } from "@/features/face-detection";
 import { useOcr } from "@/features/ocr";
 import type { DetectionPrefs } from "@/lib/preferences";
-import { useNetworkStatus } from "@/lib/useNetworkStatus";
 import { useClipboardImagePaste } from "../hooks/useClipboardImagePaste";
 import { DETECTION_SETTINGS_BAR_REVEAL_MS, useDelayedReveal } from "../hooks/useDelayedReveal";
 import { useCustomMaskTerms } from "../hooks/useCustomMaskTerms";
 import { useDetectionSettings } from "../hooks/useDetectionSettings";
 import { useGalleryDetection } from "../hooks/useGalleryDetection";
 import { useGalleryImages } from "../hooks/useGalleryImages";
+import { useOfflineManualEdit } from "../hooks/useOfflineManualEdit";
 import { useStampImages } from "../hooks/useStampImages";
 import { downloadMaskedImagesAsZip } from "../lib/downloadMaskedImagesAsZip";
-import {
-  formatCustomMaskTermsSummary,
-  formatDetectionSettingsSummary,
-} from "../lib/detectionMessages";
-import {
-  getEffectiveDetectionSettings,
-  isUploadBlockedByModelState,
-} from "../lib/offlineManualEdit";
 import { CustomMaskTermsModal } from "./CustomMaskTermsModal";
 import { DetectionSettingsBarSkeleton } from "./DetectionSettingsBarSkeleton";
 import { DetectionSettingsModal } from "./DetectionSettingsModal";
@@ -38,7 +30,6 @@ import { OfflineManualEditBanner } from "./OfflineManualEditBanner";
  * 画像アップロード、顔検出、Canvas表示を統合する。
  */
 export function MaskingGallery() {
-  const { isOffline } = useNetworkStatus();
   const stampImages = useStampImages();
   const {
     images,
@@ -79,29 +70,20 @@ export function MaskingGallery() {
   const getDetectionSettings = useCallback(() => detectionSettings, [detectionSettings]);
   const getCustomMaskTerms = useCallback(() => enabledCustomMaskTexts, [enabledCustomMaskTexts]);
 
-  const effectiveDetectionSettings = useMemo(
-    () => getEffectiveDetectionSettings(detectionSettings, isOffline),
-    [detectionSettings, isOffline]
-  );
-
-  const detectionSettingsSummary = useMemo(
-    () =>
-      isOffline ? "オフライン（手動のみ）" : formatDetectionSettingsSummary(detectionSettings),
-    [detectionSettings, isOffline]
-  );
-  const customMaskTermsSummary = useMemo(
-    () =>
-      formatCustomMaskTermsSummary(customMaskTerms, {
-        ocrEnabled: effectiveDetectionSettings.autoDetectOcr,
-      }),
-    [customMaskTerms, effectiveDetectionSettings.autoDetectOcr]
-  );
-  const isCustomMaskTermsEditable = effectiveDetectionSettings.autoDetectOcr;
-  const isUploadBlockedByModel = isUploadBlockedByModelState(
+  const {
     isOffline,
+    detectionSettingsSummary,
+    customMaskTermsSummary,
+    isCustomMaskTermsEditable,
+    isUploadBlockedByModel,
+    modelLoadingMessage,
+    showModelErrorAlert,
+  } = useOfflineManualEdit({
+    detectionSettings,
+    customMaskTerms,
     isModelLoading,
-    isModelError
-  );
+    isModelError,
+  });
 
   const { handleUpload, handleRedetect } = useGalleryDetection({
     images,
@@ -145,7 +127,6 @@ export function MaskingGallery() {
 
   const hasProcessingImage = images.some((image) => image.isProcessing);
   const isProcessing = isDetecting || isRecognizing || hasProcessingImage;
-  const loadingMessage = !isOffline && isModelLoading ? "顔検出モデルをロード中…" : null;
   const downloadableImagesCount = images.filter(
     (image) => image.maskedBlobUrl && !image.isProcessing
   ).length;
@@ -239,9 +220,9 @@ export function MaskingGallery() {
         onUpload={handleUpload}
         disabled={isProcessing || isUploadBlockedByModel}
         multiple
-        loadingMessage={loadingMessage}
+        loadingMessage={modelLoadingMessage}
       />
-      {isModelError && !isOffline && (
+      {showModelErrorAlert && (
         <p role="alert" className="text-center text-sm text-red-600">
           顔検出モデルのロードに失敗しました。ページを再読み込みしてください。
         </p>

--- a/features/masking/components/OfflineManualEditBanner.test.tsx
+++ b/features/masking/components/OfflineManualEditBanner.test.tsx
@@ -1,0 +1,16 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { OfflineManualEditBanner } from "./OfflineManualEditBanner";
+import { OFFLINE_MANUAL_EDIT_BANNER_MESSAGE } from "../lib/offlineManualEdit";
+
+describe("OfflineManualEditBanner", () => {
+  it("visible=false のときは何も表示しない", () => {
+    const { container } = render(<OfflineManualEditBanner visible={false} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("visible=true のときオフライン手動編集の説明を表示する", () => {
+    render(<OfflineManualEditBanner visible={true} />);
+    expect(screen.getByRole("status")).toHaveTextContent(OFFLINE_MANUAL_EDIT_BANNER_MESSAGE);
+  });
+});

--- a/features/masking/components/OfflineManualEditBanner.tsx
+++ b/features/masking/components/OfflineManualEditBanner.tsx
@@ -1,0 +1,26 @@
+import { WifiOff } from "lucide-react";
+import { OFFLINE_MANUAL_EDIT_BANNER_MESSAGE } from "../lib/offlineManualEdit";
+
+type OfflineManualEditBannerProps = {
+  /** 表示するか（オフライン時のみ true） */
+  visible: boolean;
+};
+
+/**
+ * オフライン手動編集モードであることを伝えるバナー。
+ */
+export function OfflineManualEditBanner({ visible }: OfflineManualEditBannerProps) {
+  if (!visible) {
+    return null;
+  }
+
+  return (
+    <div
+      role="status"
+      className="flex items-start gap-3 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900"
+    >
+      <WifiOff className="mt-0.5 size-4 shrink-0" aria-hidden="true" />
+      <p>{OFFLINE_MANUAL_EDIT_BANNER_MESSAGE}</p>
+    </div>
+  );
+}

--- a/features/masking/hooks/useClipboardImagePaste.ts
+++ b/features/masking/hooks/useClipboardImagePaste.ts
@@ -7,18 +7,21 @@ import {
   ACCEPTED_IMAGE_TYPES_ERROR,
   MAX_IMAGE_FILE_SIZE,
 } from "@/components/ImageUpload/constants";
+import { isUploadBlockedByModelState } from "../lib/offlineManualEdit";
 
 /** useClipboardImagePaste のオプション */
 export interface UseClipboardImagePasteOptions {
   onUpload: (files: File[]) => void;
   isModelLoading: boolean;
   isModelError: boolean;
+  /** オフライン手動編集モードではモデル状態でブロックしない */
+  isOffline: boolean;
 }
 
 /**
  * ページ全体の paste イベントをリッスンし、クリップボードの画像を onUpload へ渡す
  *
- * - モデル未ロード・エラー時は何もしない
+ * - モデル未ロード・エラー時は何もしない（オフライン時は除く）
  * - クリップボードに画像がない場合も何もしない
  * - ImageUpload と同じ基準（JPEG/PNG/WebP/GIF・20MB以下）でバリデーションを行う
  * - 貼り付け成功時にトースト通知を表示する
@@ -26,11 +29,13 @@ export interface UseClipboardImagePasteOptions {
  * @param options - アップロードコールバックとモデル状態
  */
 export function useClipboardImagePaste(options: UseClipboardImagePasteOptions): void {
-  const { onUpload, isModelLoading, isModelError } = options;
+  const { onUpload, isModelLoading, isModelError, isOffline } = options;
 
   useEffect(() => {
     const handlePaste = (e: ClipboardEvent) => {
-      if (isModelLoading || isModelError) return;
+      if (isUploadBlockedByModelState(isOffline, isModelLoading, isModelError)) {
+        return;
+      }
       const items = e.clipboardData?.items;
       if (!items) return;
 
@@ -69,5 +74,5 @@ export function useClipboardImagePaste(options: UseClipboardImagePasteOptions): 
     return () => {
       window.removeEventListener("paste", handlePaste);
     };
-  }, [onUpload, isModelLoading, isModelError]);
+  }, [onUpload, isOffline, isModelLoading, isModelError]);
 }

--- a/features/masking/hooks/useGalleryDetection.test.ts
+++ b/features/masking/hooks/useGalleryDetection.test.ts
@@ -63,6 +63,7 @@ describe("useGalleryDetection", () => {
         recognizeText: vi.fn(),
         getDetectionSettings: () => ({ autoDetectFace: false, autoDetectOcr: false }),
         getCustomMaskTerms: () => [],
+        isOffline: false,
       })
     );
 
@@ -103,6 +104,7 @@ describe("useGalleryDetection", () => {
         recognizeText: vi.fn(),
         getDetectionSettings: () => ({ autoDetectFace: true, autoDetectOcr: true }),
         getCustomMaskTerms: () => [],
+        isOffline: false,
       })
     );
 
@@ -113,5 +115,33 @@ describe("useGalleryDetection", () => {
     expect(clearImageEditorSnapshot).toHaveBeenCalledWith("img-1");
     expect(detectImageContent).toHaveBeenCalled();
     expect(setImages).toHaveBeenCalled();
+  });
+
+  it("オフライン時は再検出せず案内トーストを表示する", async () => {
+    const { result } = renderHook(() =>
+      useGalleryDetection({
+        images: [baseImage],
+        setImages: vi.fn(),
+        setActiveImageId: vi.fn(),
+        setEditingImageId: vi.fn(),
+        isMountedRef: { current: true },
+        isModelLoading: false,
+        isModelError: true,
+        detectFaces: vi.fn(),
+        recognizeText: vi.fn(),
+        getDetectionSettings: () => ({ autoDetectFace: true, autoDetectOcr: true }),
+        getCustomMaskTerms: () => [],
+        isOffline: true,
+      })
+    );
+
+    await act(async () => {
+      await result.current.handleRedetect("img-1");
+    });
+
+    expect(detectImageContent).not.toHaveBeenCalled();
+    expect(toast.info).toHaveBeenCalledWith(
+      "オフラインのため自動検出は利用できません。手動でマスキングしてください。"
+    );
   });
 });

--- a/features/masking/hooks/useGalleryDetection.ts
+++ b/features/masking/hooks/useGalleryDetection.ts
@@ -8,6 +8,11 @@ import {
   applyDetectionSkipped,
   applyDetectionSuccess,
 } from "../lib/applyDetectionResult";
+import {
+  getEffectiveDetectionSettings,
+  isUploadBlockedByModelState,
+  OFFLINE_REDETECT_MESSAGE,
+} from "../lib/offlineManualEdit";
 import { detectImageContent, shouldSkipAllDetection } from "../lib/detectImageContent";
 import {
   getDetectionBatchCompleteMessage,
@@ -35,6 +40,8 @@ export interface UseGalleryDetectionOptions {
   ) => Promise<MaskingImageItem["ocrRegions"]>;
   getDetectionSettings: () => DetectionPrefs;
   getCustomMaskTerms: () => readonly string[];
+  /** オフライン手動編集モードか */
+  isOffline: boolean;
 }
 
 /** useGalleryDetection の戻り値 */
@@ -66,13 +73,19 @@ export function useGalleryDetection(
     recognizeText,
     getDetectionSettings,
     getCustomMaskTerms,
+    isOffline,
   } = options;
 
   const isMounted = useCallback(() => isMountedRef.current === true, [isMountedRef]);
 
   const handleUpload = useCallback(
     async (files: File[]) => {
-      if (files.length === 0 || isModelLoading || isModelError) return;
+      if (
+        files.length === 0 ||
+        isUploadBlockedByModelState(isOffline, isModelLoading, isModelError)
+      ) {
+        return;
+      }
 
       const uploadedAt = Date.now();
       const { succeededItems, blobResults } = await prepareGalleryItemsFromFiles(
@@ -102,7 +115,7 @@ export function useGalleryDetection(
         toast.error(`${blobFailedCount} 件の画像の読み込みに失敗しました`);
       }
 
-      const detectionSettings = getDetectionSettings();
+      const detectionSettings = getEffectiveDetectionSettings(getDetectionSettings(), isOffline);
       const customMaskTerms = getCustomMaskTerms();
 
       const { detectionSucceededCount, detectionFailedCount } = await runDetectionForGalleryItems({
@@ -155,6 +168,7 @@ export function useGalleryDetection(
     [
       detectFaces,
       recognizeText,
+      isOffline,
       isModelLoading,
       isModelError,
       isMounted,
@@ -168,9 +182,16 @@ export function useGalleryDetection(
   const handleRedetect = useCallback(
     async (imageId: string) => {
       const target = images.find((image) => image.id === imageId);
-      if (!target || isModelLoading || isModelError || target.isProcessing) return;
+      if (!target || target.isProcessing) return;
 
-      const detectionSettings = getDetectionSettings();
+      if (isOffline) {
+        toast.info(OFFLINE_REDETECT_MESSAGE);
+        return;
+      }
+
+      if (isModelLoading || isModelError) return;
+
+      const detectionSettings = getEffectiveDetectionSettings(getDetectionSettings(), isOffline);
       const customMaskTerms = getCustomMaskTerms();
 
       if (shouldSkipAllDetection(detectionSettings)) {
@@ -235,6 +256,7 @@ export function useGalleryDetection(
       setEditingImageId,
       getDetectionSettings,
       getCustomMaskTerms,
+      isOffline,
     ]
   );
 

--- a/features/masking/hooks/useOfflineManualEdit.test.ts
+++ b/features/masking/hooks/useOfflineManualEdit.test.ts
@@ -1,0 +1,29 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useOfflineManualEdit } from "./useOfflineManualEdit";
+
+vi.mock("@/lib/useNetworkStatus", () => ({
+  useNetworkStatus: vi.fn(() => ({ isOnline: false, isOffline: true })),
+}));
+
+describe("useOfflineManualEdit", () => {
+  const detectionSettings = { autoDetectFace: true, autoDetectOcr: true };
+
+  it("オフライン時は手動編集向けの表示 state を返す", () => {
+    const { result } = renderHook(() =>
+      useOfflineManualEdit({
+        detectionSettings,
+        customMaskTerms: [],
+        isModelLoading: true,
+        isModelError: true,
+      })
+    );
+
+    expect(result.current.isOffline).toBe(true);
+    expect(result.current.detectionSettingsSummary).toBe("オフライン（手動のみ）");
+    expect(result.current.isCustomMaskTermsEditable).toBe(false);
+    expect(result.current.isUploadBlockedByModel).toBe(false);
+    expect(result.current.modelLoadingMessage).toBeNull();
+    expect(result.current.showModelErrorAlert).toBe(false);
+  });
+});

--- a/features/masking/hooks/useOfflineManualEdit.ts
+++ b/features/masking/hooks/useOfflineManualEdit.ts
@@ -1,0 +1,46 @@
+"use client";
+
+import { useMemo } from "react";
+import type { CustomMaskTerm, DetectionPrefs } from "@/lib/preferences";
+import { useNetworkStatus } from "@/lib/useNetworkStatus";
+import {
+  getOfflineAwareDetectionBarState,
+  isUploadBlockedByModelState,
+} from "../lib/offlineManualEdit";
+
+/** useOfflineManualEdit のオプション */
+export type UseOfflineManualEditOptions = {
+  detectionSettings: DetectionPrefs;
+  customMaskTerms: readonly CustomMaskTerm[];
+  isModelLoading: boolean;
+  isModelError: boolean;
+};
+
+/**
+ * オフライン手動編集モードに関する UI 状態をまとめて提供する。
+ */
+export function useOfflineManualEdit(options: UseOfflineManualEditOptions) {
+  const { detectionSettings, customMaskTerms, isModelLoading, isModelError } = options;
+  const { isOffline } = useNetworkStatus();
+
+  const detectionBar = useMemo(
+    () => getOfflineAwareDetectionBarState(detectionSettings, customMaskTerms, isOffline),
+    [customMaskTerms, detectionSettings, isOffline]
+  );
+
+  const isUploadBlockedByModel = isUploadBlockedByModelState(
+    isOffline,
+    isModelLoading,
+    isModelError
+  );
+  const modelLoadingMessage = !isOffline && isModelLoading ? "顔検出モデルをロード中…" : null;
+  const showModelErrorAlert = isModelError && !isOffline;
+
+  return {
+    isOffline,
+    ...detectionBar,
+    isUploadBlockedByModel,
+    modelLoadingMessage,
+    showModelErrorAlert,
+  };
+}

--- a/features/masking/lib/offlineManualEdit.test.ts
+++ b/features/masking/lib/offlineManualEdit.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   getEffectiveDetectionSettings,
+  getOfflineAwareDetectionBarState,
   isUploadBlockedByModelState,
   OFFLINE_MANUAL_EDIT_DETECTION_SETTINGS,
 } from "./offlineManualEdit";
@@ -26,5 +27,17 @@ describe("offlineManualEdit", () => {
     expect(isUploadBlockedByModelState(false, true, false)).toBe(true);
     expect(isUploadBlockedByModelState(false, false, true)).toBe(true);
     expect(isUploadBlockedByModelState(false, false, false)).toBe(false);
+  });
+
+  it("オフライン時は検出設定バー向けの表示 state を組み立てる", () => {
+    const state = getOfflineAwareDetectionBarState(
+      { autoDetectFace: true, autoDetectOcr: true },
+      [{ id: "1", text: "伏せ太郎", enabled: true }],
+      true
+    );
+
+    expect(state.detectionSettingsSummary).toBe("オフライン（手動のみ）");
+    expect(state.customMaskTermsSummary).toBe("利用不可（OCR オフ）");
+    expect(state.isCustomMaskTermsEditable).toBe(false);
   });
 });

--- a/features/masking/lib/offlineManualEdit.test.ts
+++ b/features/masking/lib/offlineManualEdit.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import {
+  getEffectiveDetectionSettings,
+  isUploadBlockedByModelState,
+  OFFLINE_MANUAL_EDIT_DETECTION_SETTINGS,
+} from "./offlineManualEdit";
+
+describe("offlineManualEdit", () => {
+  const onlineSettings = { autoDetectFace: true, autoDetectOcr: true };
+
+  it("オンライン時は元の検出設定をそのまま返す", () => {
+    expect(getEffectiveDetectionSettings(onlineSettings, false)).toEqual(onlineSettings);
+  });
+
+  it("オフライン時は自動検出をすべてオフにする", () => {
+    expect(getEffectiveDetectionSettings(onlineSettings, true)).toEqual(
+      OFFLINE_MANUAL_EDIT_DETECTION_SETTINGS
+    );
+  });
+
+  it("オフライン時はモデル状態でアップロードをブロックしない", () => {
+    expect(isUploadBlockedByModelState(true, true, true)).toBe(false);
+  });
+
+  it("オンライン時はモデルロード中・エラーでアップロードをブロックする", () => {
+    expect(isUploadBlockedByModelState(false, true, false)).toBe(true);
+    expect(isUploadBlockedByModelState(false, false, true)).toBe(true);
+    expect(isUploadBlockedByModelState(false, false, false)).toBe(false);
+  });
+});

--- a/features/masking/lib/offlineManualEdit.ts
+++ b/features/masking/lib/offlineManualEdit.ts
@@ -1,0 +1,51 @@
+import type { DetectionPrefs } from "@/lib/preferences";
+
+/** オフライン時に強制する検出設定（自動検出はすべてオフ） */
+export const OFFLINE_MANUAL_EDIT_DETECTION_SETTINGS: DetectionPrefs = {
+  autoDetectFace: false,
+  autoDetectOcr: false,
+};
+
+/** オフライン手動編集モードのバナー文言 */
+export const OFFLINE_MANUAL_EDIT_BANNER_MESSAGE =
+  "オフラインのため手動編集モードです。画像の追加と手動マスキングは利用できますが、自動検出は利用できません。";
+
+/** オフライン時の再検出トースト文言 */
+export const OFFLINE_REDETECT_MESSAGE =
+  "オフラインのため自動検出は利用できません。手動でマスキングしてください。";
+
+/**
+ * オフライン時は自動検出を無効化した検出設定を返す。
+ *
+ * @param settings - ユーザー設定の検出設定
+ * @param isOffline - オフラインかどうか
+ */
+export function getEffectiveDetectionSettings(
+  settings: DetectionPrefs,
+  isOffline: boolean
+): DetectionPrefs {
+  if (!isOffline) {
+    return settings;
+  }
+  return OFFLINE_MANUAL_EDIT_DETECTION_SETTINGS;
+}
+
+/**
+ * 顔検出モデルの状態によりアップロード等をブロックすべきか。
+ *
+ * オフライン手動編集モードではモデル未ロード・エラーでもブロックしない。
+ *
+ * @param isOffline - オフラインかどうか
+ * @param isModelLoading - 顔検出モデルロード中か
+ * @param isModelError - 顔検出モデルロード失敗か
+ */
+export function isUploadBlockedByModelState(
+  isOffline: boolean,
+  isModelLoading: boolean,
+  isModelError: boolean
+): boolean {
+  if (isOffline) {
+    return false;
+  }
+  return isModelLoading || isModelError;
+}

--- a/features/masking/lib/offlineManualEdit.ts
+++ b/features/masking/lib/offlineManualEdit.ts
@@ -1,4 +1,5 @@
-import type { DetectionPrefs } from "@/lib/preferences";
+import type { CustomMaskTerm, DetectionPrefs } from "@/lib/preferences";
+import { formatCustomMaskTermsSummary, formatDetectionSettingsSummary } from "./detectionMessages";
 
 /** オフライン時に強制する検出設定（自動検出はすべてオフ） */
 export const OFFLINE_MANUAL_EDIT_DETECTION_SETTINGS: DetectionPrefs = {
@@ -48,4 +49,38 @@ export function isUploadBlockedByModelState(
     return false;
   }
   return isModelLoading || isModelError;
+}
+
+/** 検出設定バー向けのオフライン考慮 UI 状態 */
+export type OfflineAwareDetectionBarState = {
+  effectiveDetectionSettings: DetectionPrefs;
+  detectionSettingsSummary: string;
+  customMaskTermsSummary: string;
+  isCustomMaskTermsEditable: boolean;
+};
+
+/**
+ * オフライン状態を反映した検出設定バーの表示用 state を組み立てる。
+ *
+ * @param detectionSettings - ユーザー設定の検出設定
+ * @param customMaskTerms - 登録済みマスク語句
+ * @param isOffline - オフラインかどうか
+ */
+export function getOfflineAwareDetectionBarState(
+  detectionSettings: DetectionPrefs,
+  customMaskTerms: readonly CustomMaskTerm[],
+  isOffline: boolean
+): OfflineAwareDetectionBarState {
+  const effectiveDetectionSettings = getEffectiveDetectionSettings(detectionSettings, isOffline);
+
+  return {
+    effectiveDetectionSettings,
+    detectionSettingsSummary: isOffline
+      ? "オフライン（手動のみ）"
+      : formatDetectionSettingsSummary(detectionSettings),
+    customMaskTermsSummary: formatCustomMaskTermsSummary(customMaskTerms, {
+      ocrEnabled: effectiveDetectionSettings.autoDetectOcr,
+    }),
+    isCustomMaskTermsEditable: effectiveDetectionSettings.autoDetectOcr,
+  };
 }

--- a/lib/useNetworkStatus.ts
+++ b/lib/useNetworkStatus.ts
@@ -1,0 +1,41 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+
+/**
+ * `online` / `offline` イベントを購読する。
+ *
+ * @param callback - ネットワーク状態が変わったときのコールバック
+ */
+function subscribeToNetworkStatus(callback: () => void): () => void {
+  window.addEventListener("online", callback);
+  window.addEventListener("offline", callback);
+  return () => {
+    window.removeEventListener("online", callback);
+    window.removeEventListener("offline", callback);
+  };
+}
+
+/** クライアントのオンライン状態を返す */
+function getOnlineSnapshot(): boolean {
+  return navigator.onLine;
+}
+
+/** SSR 時はオフラインバナーのチラつきを避けるためオンライン扱いにする */
+function getOnlineServerSnapshot(): boolean {
+  return true;
+}
+
+/**
+ * ブラウザのオンライン / オフライン状態を返すフック。
+ *
+ * SSR では `isOnline: true` を返し、クライアントで確定した値に更新する。
+ */
+export function useNetworkStatus(): { isOnline: boolean; isOffline: boolean } {
+  const isOnline = useSyncExternalStore(
+    subscribeToNetworkStatus,
+    getOnlineSnapshot,
+    getOnlineServerSnapshot
+  );
+  return { isOnline, isOffline: !isOnline };
+}


### PR DESCRIPTION
## 概要

PWA Phase 2 として、オフライン時は自動検出を無効化し手動編集モードでマスキングできるようにする。あわせてスタンプ画像の Service Worker キャッシュを追加する。

## 関連Issue

Related to #93（Phase 2。マージしても Issue はクローズしない）

## 変更内容

- [x] 機能追加
- [ ] バグ修正
- [ ] リファクタリング
- [x] テスト追加・修正
- [ ] ドキュメント修正
- [x] 設定・環境変更
- [ ] その他

## 主な変更箇所

### UI・コンポーネント

- `OfflineManualEditBanner`: オフライン時に手動編集モードであることを表示
- `MaskingGallery`: ネットワーク状態に応じたアップロード制御・検出設定表示・バナー表示
- `GalleryItem`: オフライン時は再検出ボタンを無効化

### ロジック・処理

- `lib/useNetworkStatus.ts`: `navigator.onLine` の監視
- `features/masking/lib/offlineManualEdit.ts`: オフライン時の検出設定オーバーライドとモデルブロック判定
- `useGalleryDetection` / `useClipboardImagePaste`: オフライン時はモデル未ロードでもアップロード可能、自動検出はスキップ

### その他

- `app/sw.ts`: `/stamps/` を `CacheFirst` で runtime cache（オフライン手動マスキング向け）
- `docs/` は含めない（マージ後 CD が再ビルド）

## 動作確認

- [x] ローカル環境での動作確認
- [x] テストの実行・通過確認
- [ ] UI動作確認
- [x] 既存機能への影響確認
- [ ] ブラウザ動作確認（Chrome / Firefox / Safari）

## スクリーンショット・動画

なし（デプロイ後に DevTools の Offline で `/app` の手動編集を確認予定）

## テスト

### 追加したテスト

- `offlineManualEdit.test.ts`
- `OfflineManualEditBanner.test.tsx`
- `useGalleryDetection` オフライン再検出のテスト

### テスト結果

- [x] 全てのテストが通過
- [x] 新規テストを追加
- [x] 既存テストの修正

## 破壊的変更

- [ ] 破壊的変更あり
- [x] 破壊的変更なし

### 破壊的変更の詳細

該当なし

## レビューポイント

- オフライン判定は `navigator.onLine` のみ（実際の到達性は見ていない）
- オフライン時のモデルロード失敗アラートを非表示にしている点
- スタンプキャッシュは初回オンライン訪問後に有効（precache ではない）

## 補足

- Phase 1（#94）はマージ済み
- 更新記事は挙動変更がオフライン限定のため今回は未追加

## チェックリスト

- [x] コードレビューの準備ができている
- [x] 適切なラベルを付けている
- [x] セルフレビューを実施している
- [x] `pnpm lint` と `pnpm type-check` が通ることを確認した
- [ ] 必要に応じてドキュメントを更新している
- [x] ユーザー操作・体験に影響する変更がある場合、`content/updates/` に更新情報記事を追加した（追加不要の場合は理由を補足に記載）
