### PR TITLE
Markdown 画像を拡大表示できるようにする

### DIFF
--- a/components/MarkdownContent/MarkdownContent.test.tsx
+++ b/components/MarkdownContent/MarkdownContent.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it } from "vitest";
 import { MarkdownContent } from "./index";
@@ -80,12 +80,20 @@ describe("MarkdownContent", () => {
 
     await user.click(screen.getByRole("button", { name: "操作画面を拡大表示" }));
 
-    expect(screen.getByRole("dialog", { name: "操作画面の拡大画像" })).toBeInTheDocument();
+    const dialog = screen.getByRole("dialog", { name: "操作画面" });
+    expect(within(dialog).getByRole("paragraph")).toHaveTextContent("操作画面");
     expect(screen.getAllByRole("img", { name: "操作画面" })).toHaveLength(2);
 
     await user.keyboard("{Escape}");
 
-    expect(screen.queryByRole("dialog", { name: "操作画面の拡大画像" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("dialog", { name: "操作画面" })).not.toBeInTheDocument();
+  });
+
+  it("画像 URL が欠けている場合は描画しない", () => {
+    render(<MarkdownContent content="![欠落画像]()" />);
+
+    expect(screen.queryByRole("img")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /拡大/ })).not.toBeInTheDocument();
   });
 
   it("右上の拡大ボタンからも画像モーダルを開ける", async () => {
@@ -98,7 +106,7 @@ describe("MarkdownContent", () => {
     await user.click(expandButton);
     await user.click(screen.getByRole("button", { name: "拡大画像を閉じる" }));
 
-    expect(screen.queryByRole("dialog", { name: "設定画面の拡大画像" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("dialog", { name: "設定画面" })).not.toBeInTheDocument();
   });
 
   it("HTML コメントを本文に表示しない", () => {

--- a/components/MarkdownContent/MarkdownContent.test.tsx
+++ b/components/MarkdownContent/MarkdownContent.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, expect, it } from "vitest";
 import { MarkdownContent } from "./index";
 
@@ -71,6 +72,33 @@ describe("MarkdownContent", () => {
     const image = screen.getByRole("img", { name: "スマホで画像を選択する場合" });
     expect(image).toHaveAttribute("src", "/guides/image-import/image-select-sp.png");
     expect(image).toHaveClass("max-w-48");
+  });
+
+  it("画像をクリックすると拡大モーダルを開閉できる", async () => {
+    const user = userEvent.setup();
+    render(<MarkdownContent content="![操作画面](/guides/manual-edit/edit-button.png)" />);
+
+    await user.click(screen.getByRole("button", { name: "操作画面を拡大表示" }));
+
+    expect(screen.getByRole("dialog", { name: "操作画面の拡大画像" })).toBeInTheDocument();
+    expect(screen.getAllByRole("img", { name: "操作画面" })).toHaveLength(2);
+
+    await user.keyboard("{Escape}");
+
+    expect(screen.queryByRole("dialog", { name: "操作画面の拡大画像" })).not.toBeInTheDocument();
+  });
+
+  it("右上の拡大ボタンからも画像モーダルを開ける", async () => {
+    const user = userEvent.setup();
+    render(<MarkdownContent content="![設定画面](/guides/settings/settings-modal.png)" />);
+
+    const expandButton = screen.getByRole("button", { name: "設定画面をモーダルで開く" });
+    expect(expandButton).toHaveClass("group-hover:opacity-100");
+
+    await user.click(expandButton);
+    await user.click(screen.getByRole("button", { name: "拡大画像を閉じる" }));
+
+    expect(screen.queryByRole("dialog", { name: "設定画面の拡大画像" })).not.toBeInTheDocument();
   });
 
   it("HTML コメントを本文に表示しない", () => {

--- a/components/MarkdownContent/index.tsx
+++ b/components/MarkdownContent/index.tsx
@@ -1,10 +1,15 @@
 "use client";
 
+/* eslint-disable @next/next/no-img-element -- Markdown 本文の画像は記事ごとに表示サイズを変えるため通常の img を使う。 */
+
 import Link from "next/link";
 import clsx from "clsx";
-import type { ReactNode } from "react";
+import { Maximize2, X } from "lucide-react";
+import type { KeyboardEvent, ReactNode } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type { Components } from "react-markdown";
 import ReactMarkdown from "react-markdown";
+import { createPortal } from "react-dom";
 import remarkDirective from "remark-directive";
 import remarkGfm from "remark-gfm";
 import { markdownHeadingToId } from "@/lib/markdownHeadingId";
@@ -19,6 +24,12 @@ type MarkdownContentProps = {
 };
 
 type MarkdownImageSize = (typeof IMAGE_SIZE_HASHES)[number] | "default";
+
+type MarkdownImageProps = {
+  src: string | undefined;
+  alt: string | undefined;
+  size: MarkdownImageSize;
+};
 
 type MarkdownAstNode = {
   type: string;
@@ -86,6 +97,185 @@ function parseMarkdownImageSrc(src: string | undefined): {
     src,
     size: "default",
   };
+}
+
+function getImageLabel(alt: string | undefined): string {
+  const trimmedAlt = alt?.trim();
+  return trimmedAlt && trimmedAlt.length > 0 ? trimmedAlt : "画像";
+}
+
+function getImageSizeClass(size: MarkdownImageSize): string {
+  if (size === "small") {
+    return "max-w-48";
+  }
+  if (size === "medium") {
+    return "max-w-sm";
+  }
+  return "max-w-full";
+}
+
+/**
+ * Markdown 本文内の画像を表示し、クリック時に拡大モーダルを開く。
+ */
+function MarkdownImage({ src, alt, size }: MarkdownImageProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const label = getImageLabel(alt);
+  const sizeClass = getImageSizeClass(size);
+  const openModal = useCallback(() => {
+    setIsOpen(true);
+  }, []);
+  const closeModal = useCallback(() => {
+    setIsOpen(false);
+  }, []);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    const prevOverflow = document.body.style.overflow;
+    const prevFocusedElement = document.activeElement as HTMLElement | null;
+    document.body.style.overflow = "hidden";
+    closeButtonRef.current?.focus();
+
+    return () => {
+      document.body.style.overflow = prevOverflow;
+      prevFocusedElement?.focus();
+    };
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    const handleKeyDown = (event: globalThis.KeyboardEvent) => {
+      if (event.key === "Escape") {
+        closeModal();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [closeModal, isOpen]);
+
+  const handleKeyDownDialog = useCallback((event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.key !== "Tab") {
+      return;
+    }
+
+    const focusable = dialogRef.current?.querySelectorAll<HTMLElement>(
+      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+    );
+    if (!focusable || focusable.length === 0) {
+      return;
+    }
+
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+
+    if (event.shiftKey) {
+      if (document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      }
+      return;
+    }
+
+    if (document.activeElement === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  }, []);
+
+  if (!src) {
+    return <img src={src} alt={alt ?? ""} className="mx-auto h-auto max-w-full" loading="lazy" />;
+  }
+
+  return (
+    <>
+      <span className={clsx(["group relative mx-auto block w-fit max-w-full", sizeClass])}>
+        <button
+          type="button"
+          aria-label={`${label}を拡大表示`}
+          onClick={openModal}
+          className="block cursor-zoom-in rounded-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2"
+        >
+          <img
+            src={src}
+            alt={alt ?? ""}
+            className={clsx([
+              "h-auto",
+              "rounded-lg",
+              "border border-zinc-200",
+              "shadow-sm",
+              sizeClass,
+            ])}
+            loading="lazy"
+          />
+        </button>
+        <button
+          type="button"
+          aria-label={`${label}をモーダルで開く`}
+          onClick={openModal}
+          className={clsx([
+            "absolute right-2 top-2 inline-flex size-8 items-center justify-center rounded-full",
+            "bg-zinc-950/70 text-white opacity-0 shadow-sm transition-opacity",
+            "hover:bg-zinc-950 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500",
+            "group-hover:opacity-100 group-focus-within:opacity-100",
+          ])}
+        >
+          <Maximize2 aria-hidden="true" className="size-4" />
+        </button>
+      </span>
+
+      {isOpen && typeof document !== "undefined"
+        ? createPortal(
+            <div
+              className="fixed inset-0 z-50 flex items-center justify-center p-4"
+              onKeyDown={handleKeyDownDialog}
+            >
+              <div
+                role="presentation"
+                className="absolute inset-0 cursor-zoom-out bg-black/70"
+                onClick={closeModal}
+              />
+              <div
+                ref={dialogRef}
+                role="dialog"
+                aria-modal="true"
+                aria-label={`${label}の拡大画像`}
+                className="relative z-10 flex max-h-[calc(100dvh-2rem)] w-full max-w-5xl flex-col gap-3"
+              >
+                <div className="flex justify-end">
+                  <button
+                    ref={closeButtonRef}
+                    type="button"
+                    aria-label="拡大画像を閉じる"
+                    onClick={closeModal}
+                    className="inline-flex size-10 items-center justify-center rounded-full bg-white text-zinc-800 shadow-lg transition-colors hover:bg-zinc-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
+                  >
+                    <X aria-hidden="true" className="size-5" />
+                  </button>
+                </div>
+                <div className="flex min-h-0 justify-center">
+                  <img
+                    src={src}
+                    alt={alt ?? ""}
+                    className="max-h-[calc(100dvh-7rem)] max-w-full rounded-lg bg-white object-contain shadow-2xl"
+                  />
+                </div>
+              </div>
+            </div>,
+            document.body
+          )
+        : null}
+    </>
+  );
 }
 
 /**
@@ -173,25 +363,7 @@ const markdownComponents: Components = {
   ),
   img: ({ src, alt }) => {
     const image = parseMarkdownImageSrc(typeof src === "string" ? src : undefined);
-    return (
-      // Markdown 本文内の画像はサイズが記事ごとに変わるため、通常の img として表示する。
-      // eslint-disable-next-line @next/next/no-img-element
-      <img
-        src={image.src}
-        alt={alt ?? ""}
-        className={clsx([
-          "mx-auto",
-          "h-auto",
-          "rounded-lg",
-          "border border-zinc-200",
-          "shadow-sm",
-          image.size === "small" && "max-w-48",
-          image.size === "medium" && "max-w-sm",
-          image.size === "default" && "max-w-full",
-        ])}
-        loading="lazy"
-      />
-    );
+    return <MarkdownImage src={image.src} alt={alt} size={image.size} />;
   },
   a: ({ href, children }) => {
     if (href?.startsWith("/") && !href.startsWith("//")) {

--- a/components/MarkdownContent/index.tsx
+++ b/components/MarkdownContent/index.tsx
@@ -6,7 +6,7 @@ import Link from "next/link";
 import clsx from "clsx";
 import { Maximize2, X } from "lucide-react";
 import type { KeyboardEvent, ReactNode } from "react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useId, useRef, useState } from "react";
 import type { Components } from "react-markdown";
 import ReactMarkdown from "react-markdown";
 import { createPortal } from "react-dom";
@@ -121,6 +121,7 @@ function MarkdownImage({ src, alt, size }: MarkdownImageProps) {
   const [isOpen, setIsOpen] = useState(false);
   const closeButtonRef = useRef<HTMLButtonElement>(null);
   const dialogRef = useRef<HTMLDivElement>(null);
+  const captionId = useId();
   const label = getImageLabel(alt);
   const sizeClass = getImageSizeClass(size);
   const openModal = useCallback(() => {
@@ -193,7 +194,7 @@ function MarkdownImage({ src, alt, size }: MarkdownImageProps) {
   }, []);
 
   if (!src) {
-    return <img src={src} alt={alt ?? ""} className="mx-auto h-auto max-w-full" loading="lazy" />;
+    return null;
   }
 
   return (
@@ -248,7 +249,7 @@ function MarkdownImage({ src, alt, size }: MarkdownImageProps) {
                 ref={dialogRef}
                 role="dialog"
                 aria-modal="true"
-                aria-label={`${label}の拡大画像`}
+                aria-labelledby={captionId}
                 className="relative z-10 flex max-h-[calc(100dvh-2rem)] w-full max-w-5xl flex-col gap-3"
               >
                 <div className="flex justify-end">
@@ -262,12 +263,15 @@ function MarkdownImage({ src, alt, size }: MarkdownImageProps) {
                     <X aria-hidden="true" className="size-5" />
                   </button>
                 </div>
-                <div className="flex min-h-0 justify-center">
+                <div className="flex min-h-0 flex-col items-center gap-3">
                   <img
                     src={src}
                     alt={alt ?? ""}
-                    className="max-h-[calc(100dvh-7rem)] max-w-full rounded-lg bg-white object-contain shadow-2xl"
+                    className="max-h-[calc(100dvh-9rem)] max-w-full rounded-lg bg-white object-contain shadow-2xl"
                   />
+                  <p id={captionId} className="max-w-full px-2 text-center text-sm text-white/90">
+                    {label}
+                  </p>
                 </div>
               </div>
             </div>,


### PR DESCRIPTION
## 概要

Markdown本文内の画像をクリックまたは右上の拡大アイコンからモーダル表示できるようにします。

このPRは `feature/102-guide-pages` をbaseにした stacked PR です。

## 関連Issue

Closes #105

## 変更内容

- [x] 機能追加
- [ ] バグ修正
- [ ] リファクタリング
- [x] テスト追加・修正
- [ ] ドキュメント修正
- [ ] 設定・環境変更
- [ ] その他

## 主な変更箇所

### UI・コンポーネント

- `MarkdownContent` の画像レンダリングをクリック可能に変更
- 画像ホバー/フォーカス時に右上へ拡大アイコンを表示
- 拡大画像を `dialog` として表示し、背景クリック・閉じるボタン・Escで閉じられるように変更
- モーダル表示中は body スクロールをロック

### ロジック・処理

- Markdown画像の `#small` / `#medium` サイズ指定を維持したまま、サムネイルとモーダル表示に適用
- モーダル本体は `document.body` へ portal し、Markdown段落内に固定配置DOMが入らないように実装

### その他

- 画像データのサーバー送信はありません。Markdownに記載済みの画像URLを同一ページ上で表示するだけです。

## 動作確認

- [x] ローカル環境での動作確認
- [x] テストの実行・通過確認
- [x] UI動作確認
- [x] 既存機能への影響確認
- [ ] ブラウザ動作確認（Chrome / Firefox / Safari）

## スクリーンショット・動画

未添付です。

## テスト

### 追加したテスト

- Markdown画像クリックで拡大モーダルを開き、Escで閉じられること
- 右上の拡大ボタンからモーダルを開き、閉じるボタンで閉じられること

### テスト結果

- [x] 全てのテストが通過
- [x] 新規テストを追加
- [ ] 既存テストの修正

## 破壊的変更

- [ ] 破壊的変更あり
- [x] 破壊的変更なし

### 破壊的変更の詳細

なし

## レビューポイント

- Markdownの段落内にモーダルDOMを直接入れないため、portalで `document.body` に出している点
- 画像クリックと拡大アイコンの両方で同じモーダルを開く点
- Esc/背景/閉じるボタンで閉じる操作ができる点

## 補足

- `pnpm build` は成功しています。既存の face-api 由来 warning は出ますが、今回の変更起因ではありません。
- buildで生成された `docs/` 差分はコミット対象から除外しています。
- `content/updates/` は、親PRのガイドページ基盤がまだ未マージのため、このPRでは追加していません。

## チェックリスト

- [x] コードレビューの準備ができている
- [x] 適切なラベルを付けている
- [x] セルフレビューを実施している
- [x] `pnpm lint` と `pnpm type-check` が通ることを確認した
- [x] 必要に応じてドキュメントを更新している
- [x] ユーザー操作・体験に影響する変更がある場合、`content/updates/` に更新情報記事を追加した（追加不要の場合は理由を補足に記載）
