### PR TITLE
全ページにトップへ戻るボタンを表示する

### DIFF
--- a/app/app/page.tsx
+++ b/app/app/page.tsx
@@ -1,5 +1,4 @@
 import Link from "next/link";
-import { BackToTopButton } from "@/components/BackToTopButton";
 import { MaskingCompactDemo } from "@/components/MaskingCompactDemo";
 import { MaskingGallery } from "@/features/masking";
 import { buildPageMetadata } from "@/lib/buildPageMetadata";
@@ -54,8 +53,6 @@ export default function AppPage() {
         </div>
         <MaskingCompactDemo />
       </section>
-
-      <BackToTopButton />
     </div>
   );
 }

--- a/app/faq/page.tsx
+++ b/app/faq/page.tsx
@@ -1,4 +1,3 @@
-import { BackToTopButton } from "@/components/BackToTopButton";
 import { FaqAccordion } from "@/components/FaqAccordion";
 import { LegalPageLayout } from "@/components/LegalPageLayout";
 import { buildPageMetadata } from "@/lib/buildPageMetadata";
@@ -23,7 +22,6 @@ export default function FaqPage() {
       <LegalPageLayout title={doc.title} dateText={doc.lastUpdated}>
         <FaqAccordion intro={faq.intro} items={faq.items} footer={faq.footer} />
       </LegalPageLayout>
-      <BackToTopButton />
     </>
   );
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata, Viewport } from "next";
 import type { ReactNode } from "react";
 import { Geist, Geist_Mono } from "next/font/google";
+import { BackToTopButton } from "@/components/BackToTopButton";
 import { ConfirmDialog } from "@/components/ConfirmDialog";
 import { Header } from "@/components/Header";
 import { SearchIndexPreloader } from "@/components/SearchIndexPreloader";
@@ -91,6 +92,7 @@ export default function RootLayout({
         <Header />
         <main className="flex flex-1 flex-col">{children}</main>
         <SiteFooter />
+        <BackToTopButton />
         <SearchIndexPreloader />
         <SearchModal />
         <ConfirmDialog />

--- a/components/LandingPage/index.tsx
+++ b/components/LandingPage/index.tsx
@@ -1,4 +1,3 @@
-import { BackToTopButton } from "@/components/BackToTopButton";
 import { DemoSection } from "@/components/LandingPage/DemoSection";
 import { FinalCtaSection } from "@/components/LandingPage/FinalCtaSection";
 import { HeroSection } from "@/components/LandingPage/HeroSection";
@@ -18,7 +17,6 @@ export function LandingPage() {
       <PrivacySection />
       <UseCasesSection />
       <FinalCtaSection />
-      <BackToTopButton />
     </div>
   );
 }


### PR DESCRIPTION
## 概要

既存の `BackToTopButton` をルートレイアウトに配置し、全ページでスクロール後に「ページ上部へ戻る」ボタンが表示されるようにする。

## 関連Issue

Closes #110

## 変更内容

- [x] 機能追加
- [ ] バグ修正
- [x] リファクタリング
- [ ] テスト追加・修正
- [ ] ドキュメント修正
- [ ] 設定・環境変更
- [ ] その他

## 主な変更箇所

### UI・コンポーネント

- `app/layout.tsx` に `BackToTopButton` を追加（`SiteFooter` 直後）
- `/`・`/app`・`/faq` に個別配置されていた `BackToTopButton` を削除し、重複表示を防止

### ロジック・処理

- 変更なし（既存コンポーネントをそのまま再利用）

### その他

- 変更なし

## 動作確認

- [x] ローカル環境での動作確認
- [x] テストの実行・通過確認
- [ ] UI動作確認
- [x] 既存機能への影響確認
- [ ] ブラウザ動作確認（Chrome / Firefox / Safari）

## スクリーンショット・動画

なし（既存コンポーネントの配置変更のみ）

## テスト

### 追加したテスト

- なし（既存コンポーネントのグローバル配置のみのため）

### テスト結果

- [x] 全てのテストが通過
- [ ] 新規テストを追加
- [ ] 既存テストの修正

## 破壊的変更

- [ ] 破壊的変更あり
- [x] 破壊的変更なし

### 破壊的変更の詳細

該当なし

## レビューポイント

- `app/layout.tsx` への配置位置（`SiteFooter` 直後）が適切か
- `/app` ページでもボタン表示が問題ないか（エディタモーダル `z-50` より下の `z-20`）

## 補足

- ユーザー操作・体験に影響する変更だが、既存ページで既に利用されていた UI の配置統一のため `content/updates/` への記事追加は不要と判断

## チェックリスト

- [x] コードレビューの準備ができている
- [x] 適切なラベルを付けている
- [x] セルフレビューを実施している
- [x] `pnpm lint` と `pnpm type-check` が通ることを確認した
- [ ] 必要に応じてドキュメントを更新している
- [x] ユーザー操作・体験に影響する変更がある場合、`content/updates/` に更新情報記事を追加した（追加不要の場合は理由を補足に記載）
