### PR TITLE
検索結果カード全体をクリック可能にする

### DIFF
--- a/components/SiteSearch/index.tsx
+++ b/components/SiteSearch/index.tsx
@@ -128,7 +128,12 @@ export function SiteSearch({ onResultSelect }: SiteSearchProps) {
                   key={entry.id}
                   className={clsx([
                     SEARCH_RESULT_CARD_CLASS,
-                    "transition-colors hover:border-indigo-200",
+                    "relative",
+                    "transition-colors",
+                    "hover:border-indigo-200",
+                    "has-[:focus-visible]:ring-2",
+                    "has-[:focus-visible]:ring-indigo-500",
+                    "has-[:focus-visible]:ring-offset-2",
                   ])}
                 >
                   <p className="text-xs font-semibold tracking-wide text-indigo-600">
@@ -138,7 +143,19 @@ export function SiteSearch({ onResultSelect }: SiteSearchProps) {
                     <Link
                       href={entry.url}
                       onClick={onResultSelect}
-                      className="underline-offset-2 hover:text-indigo-700 hover:underline"
+                      className={clsx([
+                        "underline-offset-2",
+                        "transition-colors",
+                        "hover:text-indigo-700",
+                        "hover:underline",
+                        "focus-visible:text-indigo-700",
+                        "focus-visible:underline",
+                        "after:absolute",
+                        "after:inset-0",
+                        "after:rounded-xl",
+                        "after:content-['']",
+                        "focus-visible:outline-none",
+                      ])}
                     >
                       {entry.title}
                     </Link>


### PR DESCRIPTION
## 概要

サイト内検索モーダルの検索結果カードを、タイトルだけでなくカード全体クリックで遷移できるようにする。

## 関連Issue

なし（#108 サイト内検索の UX 改善）

## 変更内容

- [x] 機能追加
- [ ] バグ修正
- [ ] リファクタリング
- [ ] テスト追加・修正
- [ ] ドキュメント修正
- [ ] 設定・環境変更
- [ ] その他

## 主な変更箇所

### UI・コンポーネント

- `components/SiteSearch/index.tsx` の検索結果カードに stretched link パターンを適用
  - `GuidePostList` / `UpdatePostList` と同様に `::after` 疑似要素でカード全体をリンク領域に拡張
  - キーボードフォーカス時は `has-[:focus-visible]:ring-*` でカード全体にリングを表示

### ロジック・処理

- 変更なし

### その他

- テキスト選択とカード全体リンクの両立は検討したが、テキスト上でリンクが効かなくなるため見送り

## 動作確認

- [ ] ローカル環境での動作確認
- [x] テストの実行・通過確認
- [ ] UI動作確認
- [x] 既存機能への影響確認
- [ ] ブラウザ動作確認（Chrome / Firefox / Safari）

## スクリーンショット・動画

なし

## テスト

### 追加したテスト

- なし（既存 `SiteSearch.test.tsx` がリンクの href を検証済み）

### テスト結果

- [x] 全てのテストが通過
- [ ] 新規テストを追加
- [ ] 既存テストの修正

## 破壊的変更

- [ ] 破壊的変更あり
- [x] 破壊的変更なし

### 破壊的変更の詳細

該当なし

## レビューポイント

- `GuidePostList` / `UpdatePostList` と同じ stretched link パターンで統一されているか
- カード余白・種別ラベル・概要・タグ上のクリックで意図どおり遷移するか

## 補足

- ユーザー操作・体験に影響するが軽微な UX 改善のため `content/updates/` への記事追加は不要と判断

## チェックリスト

- [x] コードレビューの準備ができている
- [x] 適切なラベルを付けている
- [x] セルフレビューを実施している
- [x] `pnpm lint` と `pnpm type-check` が通ることを確認した
- [ ] 必要に応じてドキュメントを更新している
- [x] ユーザー操作・体験に影響する変更がある場合、`content/updates/` に更新情報記事を追加した（追加不要の場合は理由を補足に記載）
