### PR TITLE
ブログ・ガイド詳細に追従 TOC（目次）を追加

### DIFF
--- a/app/blog/[slug]/page.test.tsx
+++ b/app/blog/[slug]/page.test.tsx
@@ -16,7 +16,8 @@ vi.mock("@/lib/blog/loadBlogPosts", () => ({
       pageTitle: "イベント写真を SNS に投稿する前に顔を隠すべき理由 | ブログ | 伏せ太郎（Fusely）",
       description: "投稿前のチェックポイントをまとめます",
       canonicalPath: "blog/2026-07-08-event-photo-face-masking",
-      content: "投稿前チェックリストを確認しましょう。\n\n[ブログ一覧へ](/blog)",
+      content:
+        "## 投稿前チェックリスト\n\n確認しましょう。\n\n## まとめ\n\n公開前に見直しましょう。",
     };
   }),
   loadBlogPostSlugs: vi.fn(() => ["2026-07-08-event-photo-face-masking"]),
@@ -40,6 +41,11 @@ describe("BlogPostPage", () => {
     expect(screen.getByText("公開日: 2026年7月8日")).toBeInTheDocument();
     expect(screen.getByText("プライバシー")).toBeInTheDocument();
     expect(screen.getByText("SNS")).toBeInTheDocument();
+    expect(screen.getAllByRole("navigation", { name: "目次" }).length).toBeGreaterThan(0);
+    expect(screen.getAllByRole("link", { name: "投稿前チェックリスト" })[0]).toHaveAttribute(
+      "href",
+      "#投稿前チェックリスト"
+    );
     expect(screen.getByRole("link", { name: "ブログ一覧へ戻る" })).toHaveAttribute("href", "/blog");
   });
 });

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -1,10 +1,11 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
-import { LegalPageLayout } from "@/components/LegalPageLayout";
 import { MarkdownContent } from "@/components/MarkdownContent";
+import { MarkdownWithToc } from "@/components/MarkdownWithToc";
 import { isBlogPostNotFoundError } from "@/lib/blog/notFoundError";
 import { loadBlogPost, loadBlogPostSlugs } from "@/lib/blog/loadBlogPosts";
 import { buildPageMetadata } from "@/lib/buildPageMetadata";
+import { extractMarkdownH2Headings } from "@/lib/extractMarkdownH2Headings";
 import { formatUpdateDate } from "@/lib/formatUpdateDate";
 
 type BlogPostPageProps = {
@@ -55,21 +56,33 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
     throw error;
   }
 
+  const headings = extractMarkdownH2Headings(post.content);
+
   return (
-    <LegalPageLayout title={post.title} dateText={formatUpdateDate(post.date)} dateLabel="公開日">
-      <p className="text-xs font-semibold tracking-wide text-indigo-600">{post.category}</p>
-      {post.tags.length > 0 ? (
-        <ul className="flex flex-wrap gap-2">
-          {post.tags.map((tag) => (
-            <li
-              key={tag}
-              className="rounded-full bg-zinc-100 px-2.5 py-0.5 text-xs font-medium text-zinc-600"
-            >
-              {tag}
-            </li>
-          ))}
-        </ul>
-      ) : null}
+    <MarkdownWithToc
+      headings={headings}
+      header={
+        <>
+          <h1 className="text-2xl font-bold tracking-tight text-zinc-900">{post.title}</h1>
+          <p className="mt-2 text-sm text-zinc-500">公開日: {formatUpdateDate(post.date)}</p>
+          <p className="mt-3 text-xs font-semibold tracking-wide text-indigo-600">
+            {post.category}
+          </p>
+          {post.tags.length > 0 ? (
+            <ul className="mt-3 flex flex-wrap gap-2">
+              {post.tags.map((tag) => (
+                <li
+                  key={tag}
+                  className="rounded-full bg-zinc-100 px-2.5 py-0.5 text-xs font-medium text-zinc-600"
+                >
+                  {tag}
+                </li>
+              ))}
+            </ul>
+          ) : null}
+        </>
+      }
+    >
       <MarkdownContent content={post.content} />
       <p className="pt-2">
         <Link
@@ -79,7 +92,7 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
           ブログ一覧へ戻る
         </Link>
       </p>
-    </LegalPageLayout>
+    </MarkdownWithToc>
   );
 }
 

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -6,6 +6,7 @@ import { isBlogPostNotFoundError } from "@/lib/blog/notFoundError";
 import { loadBlogPost, loadBlogPostSlugs } from "@/lib/blog/loadBlogPosts";
 import { buildPageMetadata } from "@/lib/buildPageMetadata";
 import { extractMarkdownH2Headings } from "@/lib/extractMarkdownH2Headings";
+import { normalizeMarkdownContent } from "@/lib/normalizeMarkdownContent";
 import { formatUpdateDate } from "@/lib/formatUpdateDate";
 
 type BlogPostPageProps = {
@@ -56,7 +57,7 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
     throw error;
   }
 
-  const headings = extractMarkdownH2Headings(post.content);
+  const headings = extractMarkdownH2Headings(normalizeMarkdownContent(post.content));
 
   return (
     <MarkdownWithToc

--- a/app/guides/[slug]/page.test.tsx
+++ b/app/guides/[slug]/page.test.tsx
@@ -14,8 +14,7 @@ vi.mock("@/lib/guides/loadGuidePosts", () => ({
       pageTitle: "画像の読み込ませ方 | 使い方ガイド | 伏せ太郎（Fusely）",
       description: "画像を追加して編集を始める手順",
       canonicalPath: "guides/image-import",
-      content:
-        "## ドロップゾーンに画像をドラッグ&ドロップ\n\n画像はブラウザ内で処理されます。\n\n## まとめ\n\n準備完了です。",
+      content: "## ドロップゾーンに画像をドラッグ&ドロップ\n\n画像はブラウザ内で処理されます。",
     };
   }),
   loadGuidePostSlugs: vi.fn(() => ["image-import"]),
@@ -36,6 +35,9 @@ describe("GuidePostPage", () => {
     ).toBeInTheDocument();
     expect(screen.getByText("画像はブラウザ内で処理されます。")).toBeInTheDocument();
     expect(screen.getAllByRole("navigation", { name: "目次" }).length).toBeGreaterThan(0);
+    expect(
+      screen.getAllByRole("link", { name: "ドロップゾーンに画像をドラッグ&ドロップ" })[0]
+    ).toHaveAttribute("href", "#ドロップゾーンに画像をドラッグドロップ");
     expect(screen.getByRole("link", { name: "使い方ガイド一覧へ戻る" })).toHaveAttribute(
       "href",
       "/guides"

--- a/app/guides/[slug]/page.test.tsx
+++ b/app/guides/[slug]/page.test.tsx
@@ -14,7 +14,8 @@ vi.mock("@/lib/guides/loadGuidePosts", () => ({
       pageTitle: "画像の読み込ませ方 | 使い方ガイド | 伏せ太郎（Fusely）",
       description: "画像を追加して編集を始める手順",
       canonicalPath: "guides/image-import",
-      content: "画像はブラウザ内で処理されます。",
+      content:
+        "## ドロップゾーンに画像をドラッグ&ドロップ\n\n画像はブラウザ内で処理されます。\n\n## まとめ\n\n準備完了です。",
     };
   }),
   loadGuidePostSlugs: vi.fn(() => ["image-import"]),
@@ -34,6 +35,7 @@ describe("GuidePostPage", () => {
       screen.getByRole("heading", { level: 1, name: "画像の読み込ませ方" })
     ).toBeInTheDocument();
     expect(screen.getByText("画像はブラウザ内で処理されます。")).toBeInTheDocument();
+    expect(screen.getAllByRole("navigation", { name: "目次" }).length).toBeGreaterThan(0);
     expect(screen.getByRole("link", { name: "使い方ガイド一覧へ戻る" })).toHaveAttribute(
       "href",
       "/guides"

--- a/app/guides/[slug]/page.tsx
+++ b/app/guides/[slug]/page.tsx
@@ -4,6 +4,7 @@ import { MarkdownContent } from "@/components/MarkdownContent";
 import { MarkdownWithToc } from "@/components/MarkdownWithToc";
 import { buildPageMetadata } from "@/lib/buildPageMetadata";
 import { extractMarkdownH2Headings } from "@/lib/extractMarkdownH2Headings";
+import { normalizeMarkdownContent } from "@/lib/normalizeMarkdownContent";
 import { isGuidePostNotFoundError } from "@/lib/guides/notFoundError";
 import { loadGuidePost, loadGuidePostSlugs } from "@/lib/guides/loadGuidePosts";
 
@@ -55,7 +56,7 @@ export default async function GuidePostPage({ params }: GuidePostPageProps) {
     throw error;
   }
 
-  const headings = extractMarkdownH2Headings(post.content);
+  const headings = extractMarkdownH2Headings(normalizeMarkdownContent(post.content));
 
   return (
     <MarkdownWithToc

--- a/app/guides/[slug]/page.tsx
+++ b/app/guides/[slug]/page.tsx
@@ -1,7 +1,9 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { MarkdownContent } from "@/components/MarkdownContent";
+import { MarkdownWithToc } from "@/components/MarkdownWithToc";
 import { buildPageMetadata } from "@/lib/buildPageMetadata";
+import { extractMarkdownH2Headings } from "@/lib/extractMarkdownH2Headings";
 import { isGuidePostNotFoundError } from "@/lib/guides/notFoundError";
 import { loadGuidePost, loadGuidePostSlugs } from "@/lib/guides/loadGuidePosts";
 
@@ -53,23 +55,29 @@ export default async function GuidePostPage({ params }: GuidePostPageProps) {
     throw error;
   }
 
+  const headings = extractMarkdownH2Headings(post.content);
+
   return (
-    <div className="mx-auto w-full max-w-3xl px-4 py-10">
-      <p className="text-xs font-semibold tracking-wide text-indigo-600">ガイド {post.order}</p>
-      <h1 className="mt-2 text-2xl font-bold tracking-tight text-zinc-900">{post.title}</h1>
-      <p className="mt-3 text-sm leading-relaxed text-zinc-600">{post.summary}</p>
-      <div className="mt-8 space-y-6 text-sm leading-relaxed text-zinc-700">
-        <MarkdownContent content={post.content} />
-        <p className="pt-2">
-          <Link
-            href="/guides"
-            className="font-medium text-indigo-600 underline-offset-2 hover:underline"
-          >
-            使い方ガイド一覧へ戻る
-          </Link>
-        </p>
-      </div>
-    </div>
+    <MarkdownWithToc
+      headings={headings}
+      header={
+        <>
+          <p className="text-xs font-semibold tracking-wide text-indigo-600">ガイド {post.order}</p>
+          <h1 className="mt-2 text-2xl font-bold tracking-tight text-zinc-900">{post.title}</h1>
+          <p className="mt-3 text-sm leading-relaxed text-zinc-600">{post.summary}</p>
+        </>
+      }
+    >
+      <MarkdownContent content={post.content} />
+      <p className="pt-2">
+        <Link
+          href="/guides"
+          className="font-medium text-indigo-600 underline-offset-2 hover:underline"
+        >
+          使い方ガイド一覧へ戻る
+        </Link>
+      </p>
+    </MarkdownWithToc>
   );
 }
 

--- a/components/MarkdownContent/MarkdownContent.test.tsx
+++ b/components/MarkdownContent/MarkdownContent.test.tsx
@@ -156,6 +156,17 @@ describe("MarkdownContent", () => {
     expect(screen.queryByText("画像 TODO")).not.toBeInTheDocument();
   });
 
+  it("HTML コメント内の h2 は id 割り当てに含めない", () => {
+    render(
+      <MarkdownContent
+        content={["<!--", "## コメント内見出し", "-->", "## 実際の見出し"].join("\n")}
+      />
+    );
+
+    const heading = screen.getByRole("heading", { level: 2, name: "実際の見出し" });
+    expect(heading).toHaveAttribute("id", "実際の見出し");
+  });
+
   it("テーブルに表示用スタイルを適用する", () => {
     render(<MarkdownContent content={["| 左 | 右 |", "| --- | --- |", "| A | B |"].join("\n")} />);
 

--- a/components/MarkdownContent/MarkdownContent.test.tsx
+++ b/components/MarkdownContent/MarkdownContent.test.tsx
@@ -50,6 +50,14 @@ describe("MarkdownContent", () => {
     expect(heading).toHaveClass("scroll-mt-24");
   });
 
+  it("重複 h2 には連番 id を付与する", () => {
+    render(<MarkdownContent content={["## まとめ", "", "## まとめ"].join("\n")} />);
+
+    const headings = screen.getAllByRole("heading", { level: 2, name: "まとめ" });
+    expect(headings[0]).toHaveAttribute("id", "まとめ");
+    expect(headings[1]).toHaveAttribute("id", "まとめ-2");
+  });
+
   it("details 記法を開閉ブロックとして表示する", () => {
     render(
       <MarkdownContent

--- a/components/MarkdownContent/MarkdownContent.test.tsx
+++ b/components/MarkdownContent/MarkdownContent.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { useState } from "react";
 import { describe, expect, it } from "vitest";
 import { MarkdownContent } from "./index";
 
@@ -52,6 +53,31 @@ describe("MarkdownContent", () => {
 
   it("重複 h2 には連番 id を付与する", () => {
     render(<MarkdownContent content={["## まとめ", "", "## まとめ"].join("\n")} />);
+
+    const headings = screen.getAllByRole("heading", { level: 2, name: "まとめ" });
+    expect(headings[0]).toHaveAttribute("id", "まとめ");
+    expect(headings[1]).toHaveAttribute("id", "まとめ-2");
+  });
+
+  it("親の再レンダー後も h2 id がずれない", async () => {
+    const user = userEvent.setup();
+
+    function Wrapper({ content }: { content: string }) {
+      const [count, setCount] = useState(0);
+
+      return (
+        <div>
+          <button type="button" onClick={() => setCount((value) => value + 1)}>
+            rerender {count}
+          </button>
+          <MarkdownContent content={content} />
+        </div>
+      );
+    }
+
+    render(<Wrapper content={["## まとめ", "", "## まとめ"].join("\n")} />);
+
+    await user.click(screen.getByRole("button", { name: "rerender 0" }));
 
     const headings = screen.getAllByRole("heading", { level: 2, name: "まとめ" });
     expect(headings[0]).toHaveAttribute("id", "まとめ");

--- a/components/MarkdownContent/MarkdownContent.test.tsx
+++ b/components/MarkdownContent/MarkdownContent.test.tsx
@@ -47,6 +47,7 @@ describe("MarkdownContent", () => {
 
     const heading = screen.getByRole("heading", { level: 2, name: "第1条（適用）" });
     expect(heading).toHaveAttribute("id", "第1条適用");
+    expect(heading).toHaveClass("scroll-mt-24");
   });
 
   it("details 記法を開閉ブロックとして表示する", () => {

--- a/components/MarkdownContent/index.tsx
+++ b/components/MarkdownContent/index.tsx
@@ -415,7 +415,7 @@ export function MarkdownContent({ content }: MarkdownContentProps) {
     () => extractMarkdownH2Headings(content).map((heading) => heading.id),
     [content]
   );
-  const components = useMemo(() => createMarkdownComponents(h2Ids), [h2Ids]);
+  const components = createMarkdownComponents(h2Ids);
 
   return (
     <div className="space-y-6">

--- a/components/MarkdownContent/index.tsx
+++ b/components/MarkdownContent/index.tsx
@@ -342,7 +342,7 @@ const markdownComponents: Components = {
     const text = getHeadingText(children);
     const id = markdownHeadingToId(text);
     return (
-      <h2 id={id} className="text-base font-semibold text-zinc-900">
+      <h2 id={id} className="scroll-mt-24 text-base font-semibold text-zinc-900">
         {children}
       </h2>
     );

--- a/components/MarkdownContent/index.tsx
+++ b/components/MarkdownContent/index.tsx
@@ -6,13 +6,14 @@ import Link from "next/link";
 import clsx from "clsx";
 import { Maximize2, X } from "lucide-react";
 import type { KeyboardEvent, ReactNode } from "react";
-import { useCallback, useEffect, useId, useRef, useState } from "react";
+import { useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
 import type { Components } from "react-markdown";
 import ReactMarkdown from "react-markdown";
 import { createPortal } from "react-dom";
 import remarkDirective from "remark-directive";
 import remarkGfm from "remark-gfm";
 import { markdownHeadingToId } from "@/lib/markdownHeadingId";
+import { extractMarkdownH2Headings } from "@/lib/extractMarkdownH2Headings";
 
 const LINK_CLASS = "font-medium text-indigo-600 underline-offset-2 hover:underline";
 const DETAILS_DIRECTIVE_PATTERN = /^(:{3,})details[ \t]+(.+)$/gm;
@@ -337,16 +338,7 @@ function visitMarkdownAst(node: MarkdownAstNode, visitor: (node: MarkdownAstNode
   });
 }
 
-const markdownComponents: Components = {
-  h2: ({ children }) => {
-    const text = getHeadingText(children);
-    const id = markdownHeadingToId(text);
-    return (
-      <h2 id={id} className="scroll-mt-24 text-base font-semibold text-zinc-900">
-        {children}
-      </h2>
-    );
-  },
+const baseMarkdownComponents: Components = {
   p: ({ children }) => <p>{children}</p>,
   ul: ({ children }) => <ul className="list-inside list-disc space-y-1 pl-1">{children}</ul>,
   li: ({ children }) => <li>{children}</li>,
@@ -393,16 +385,43 @@ const markdownComponents: Components = {
 };
 
 /**
+ * h2 用 id 一覧に沿って Markdown コンポーネントを組み立てる。
+ */
+function createMarkdownComponents(h2Ids: string[]): Components {
+  let h2Index = 0;
+
+  return {
+    ...baseMarkdownComponents,
+    h2: ({ children }) => {
+      const text = getHeadingText(children);
+      const id = h2Ids[h2Index] ?? markdownHeadingToId(text);
+      h2Index += 1;
+
+      return (
+        <h2 id={id} className="scroll-mt-24 text-base font-semibold text-zinc-900">
+          {children}
+        </h2>
+      );
+    },
+  };
+}
+
+/**
  * Markdown 本文をサイト共通デザインに合わせてレンダリングする。
  */
 export function MarkdownContent({ content }: MarkdownContentProps) {
   const normalizedContent = normalizeDetailsDirective(stripMarkdownComments(content));
+  const h2Ids = useMemo(
+    () => extractMarkdownH2Headings(content).map((heading) => heading.id),
+    [content]
+  );
+  const components = useMemo(() => createMarkdownComponents(h2Ids), [h2Ids]);
 
   return (
     <div className="space-y-6">
       <ReactMarkdown
         remarkPlugins={[remarkGfm, remarkDirective, remarkDetailsDirective]}
-        components={markdownComponents}
+        components={components}
       >
         {normalizedContent}
       </ReactMarkdown>

--- a/components/MarkdownContent/index.tsx
+++ b/components/MarkdownContent/index.tsx
@@ -14,10 +14,9 @@ import remarkDirective from "remark-directive";
 import remarkGfm from "remark-gfm";
 import { markdownHeadingToId } from "@/lib/markdownHeadingId";
 import { extractMarkdownH2Headings } from "@/lib/extractMarkdownH2Headings";
+import { normalizeMarkdownContent } from "@/lib/normalizeMarkdownContent";
 
 const LINK_CLASS = "font-medium text-indigo-600 underline-offset-2 hover:underline";
-const DETAILS_DIRECTIVE_PATTERN = /^(:{3,})details[ \t]+(.+)$/gm;
-const HTML_COMMENT_PATTERN = /<!--[\s\S]*?-->/g;
 const IMAGE_SIZE_HASHES = ["small", "medium"] as const;
 
 type MarkdownContentProps = {
@@ -43,23 +42,6 @@ type MarkdownAstNode = {
     hProperties?: Record<string, string | string[]>;
   };
 };
-
-/**
- * Qiita 風の `:::details タイトル` を remark-directive のラベル構文へ正規化する。
- */
-function normalizeDetailsDirective(content: string): string {
-  return content.replace(DETAILS_DIRECTIVE_PATTERN, (_, fence: string, rawTitle: string) => {
-    const title = rawTitle.trim();
-    return title.length > 0 ? `${fence}details[${title}]` : `${fence}details`;
-  });
-}
-
-/**
- * 執筆メモ用の HTML コメントを公開本文から取り除く。
- */
-function stripMarkdownComments(content: string): string {
-  return content.replace(HTML_COMMENT_PATTERN, "");
-}
 
 function getHeadingText(children: ReactNode): string {
   if (typeof children === "string") {
@@ -410,10 +392,10 @@ function createMarkdownComponents(h2Ids: string[]): Components {
  * Markdown 本文をサイト共通デザインに合わせてレンダリングする。
  */
 export function MarkdownContent({ content }: MarkdownContentProps) {
-  const normalizedContent = normalizeDetailsDirective(stripMarkdownComments(content));
+  const normalizedContent = normalizeMarkdownContent(content);
   const h2Ids = useMemo(
-    () => extractMarkdownH2Headings(content).map((heading) => heading.id),
-    [content]
+    () => extractMarkdownH2Headings(normalizedContent).map((heading) => heading.id),
+    [normalizedContent]
   );
   const components = createMarkdownComponents(h2Ids);
 

--- a/components/MarkdownWithToc/MarkdownWithToc.test.tsx
+++ b/components/MarkdownWithToc/MarkdownWithToc.test.tsx
@@ -7,7 +7,7 @@ vi.mock("@/lib/useActiveHeadingId", () => ({
 }));
 
 describe("MarkdownWithToc", () => {
-  it("見出しが2件以上なら目次を表示する", () => {
+  it("見出しが1件以上なら目次を表示する", () => {
     render(
       <MarkdownWithToc
         headings={[
@@ -25,13 +25,23 @@ describe("MarkdownWithToc", () => {
     expect(screen.getByText("本文")).toBeInTheDocument();
   });
 
-  it("見出しが1件以下なら目次を出さない", () => {
+  it("見出しが0件なら目次を出さない", () => {
+    render(
+      <MarkdownWithToc headings={[]} header={<h1>短い記事</h1>}>
+        <p>本文</p>
+      </MarkdownWithToc>
+    );
+
+    expect(screen.queryByRole("navigation", { name: "目次" })).not.toBeInTheDocument();
+  });
+
+  it("見出しが1件でも目次を表示する", () => {
     render(
       <MarkdownWithToc headings={[{ id: "ひとつ", text: "ひとつ" }]} header={<h1>短い記事</h1>}>
         <p>本文</p>
       </MarkdownWithToc>
     );
 
-    expect(screen.queryByRole("navigation", { name: "目次" })).not.toBeInTheDocument();
+    expect(screen.getAllByRole("navigation", { name: "目次" }).length).toBeGreaterThan(0);
   });
 });

--- a/components/MarkdownWithToc/MarkdownWithToc.test.tsx
+++ b/components/MarkdownWithToc/MarkdownWithToc.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { MarkdownWithToc } from "./index";
+
+vi.mock("@/lib/useActiveHeadingId", () => ({
+  useActiveHeadingId: vi.fn(() => "まとめ"),
+}));
+
+describe("MarkdownWithToc", () => {
+  it("見出しが2件以上なら目次を表示する", () => {
+    render(
+      <MarkdownWithToc
+        headings={[
+          { id: "投稿前チェックリスト", text: "投稿前チェックリスト" },
+          { id: "まとめ", text: "まとめ" },
+        ]}
+        header={<h1>記事タイトル</h1>}
+      >
+        <p>本文</p>
+      </MarkdownWithToc>
+    );
+
+    expect(screen.getAllByRole("navigation", { name: "目次" }).length).toBeGreaterThan(0);
+    expect(screen.getByRole("heading", { level: 1, name: "記事タイトル" })).toBeInTheDocument();
+    expect(screen.getByText("本文")).toBeInTheDocument();
+  });
+
+  it("見出しが1件以下なら目次を出さない", () => {
+    render(
+      <MarkdownWithToc headings={[{ id: "ひとつ", text: "ひとつ" }]} header={<h1>短い記事</h1>}>
+        <p>本文</p>
+      </MarkdownWithToc>
+    );
+
+    expect(screen.queryByRole("navigation", { name: "目次" })).not.toBeInTheDocument();
+  });
+});

--- a/components/MarkdownWithToc/MarkdownWithToc.test.tsx
+++ b/components/MarkdownWithToc/MarkdownWithToc.test.tsx
@@ -6,6 +6,12 @@ vi.mock("@/lib/useActiveHeadingId", () => ({
   useActiveHeadingId: vi.fn(() => "まとめ"),
 }));
 
+vi.mock("@/lib/scrollToHeadingId", () => ({
+  navigateToHeadingId: vi.fn(),
+}));
+
+import { navigateToHeadingId } from "@/lib/scrollToHeadingId";
+
 describe("MarkdownWithToc", () => {
   it("見出しが1件以上なら目次を表示する", () => {
     render(
@@ -43,5 +49,18 @@ describe("MarkdownWithToc", () => {
     );
 
     expect(screen.getAllByRole("navigation", { name: "目次" }).length).toBeGreaterThan(0);
+  });
+
+  it("TOC 対象外の hash では navigateToHeadingId を呼ばない", () => {
+    window.location.hash = "#unknown-section";
+
+    render(
+      <MarkdownWithToc headings={[{ id: "まとめ", text: "まとめ" }]} header={<h1>記事タイトル</h1>}>
+        <p>本文</p>
+      </MarkdownWithToc>
+    );
+
+    expect(navigateToHeadingId).not.toHaveBeenCalled();
+    window.location.hash = "";
   });
 });

--- a/components/MarkdownWithToc/index.tsx
+++ b/components/MarkdownWithToc/index.tsx
@@ -4,7 +4,8 @@ import clsx from "clsx";
 import { useEffect, useMemo, type ReactNode } from "react";
 import { TableOfContents } from "@/components/TableOfContents";
 import type { MarkdownHeading } from "@/lib/extractMarkdownH2Headings";
-import { scrollToHeadingId } from "@/lib/scrollToHeadingId";
+import { decodeLocationHash } from "@/lib/decodeLocationHash";
+import { navigateToHeadingId } from "@/lib/scrollToHeadingId";
 import { useActiveHeadingId } from "@/lib/useActiveHeadingId";
 
 type MarkdownWithTocProps = {
@@ -38,21 +39,9 @@ export function MarkdownWithToc({ headings, header, children }: MarkdownWithTocP
       return;
     }
 
-    const targetId = decodeURIComponent(hash);
-    let attempts = 0;
+    const targetId = decodeLocationHash(hash);
 
-    const scrollToHash = (): void => {
-      if (scrollToHeadingId(targetId)) {
-        return;
-      }
-
-      attempts += 1;
-      if (attempts < 60) {
-        requestAnimationFrame(scrollToHash);
-      }
-    };
-
-    requestAnimationFrame(scrollToHash);
+    navigateToHeadingId(targetId);
   }, [showToc, headingIdsKey]);
 
   return (

--- a/components/MarkdownWithToc/index.tsx
+++ b/components/MarkdownWithToc/index.tsx
@@ -40,9 +40,12 @@ export function MarkdownWithToc({ headings, header, children }: MarkdownWithTocP
     }
 
     const targetId = decodeLocationHash(hash);
+    if (!headingIds.includes(targetId)) {
+      return;
+    }
 
     navigateToHeadingId(targetId);
-  }, [showToc, headingIdsKey]);
+  }, [showToc, headingIds, headingIdsKey]);
 
   return (
     <div className={clsx(["mx-auto w-full px-4 py-10", showToc ? "max-w-5xl" : "max-w-3xl"])}>

--- a/components/MarkdownWithToc/index.tsx
+++ b/components/MarkdownWithToc/index.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useMemo, type ReactNode } from "react";
+import { useEffect, useMemo, type ReactNode } from "react";
 import { TableOfContents } from "@/components/TableOfContents";
 import type { MarkdownHeading } from "@/lib/extractMarkdownH2Headings";
+import { scrollToHeadingId } from "@/lib/scrollToHeadingId";
 import { useActiveHeadingId } from "@/lib/useActiveHeadingId";
 
 type MarkdownWithTocProps = {
@@ -23,7 +24,35 @@ type MarkdownWithTocProps = {
 export function MarkdownWithToc({ headings, header, children }: MarkdownWithTocProps) {
   const showToc = headings.length >= 2;
   const headingIds = useMemo(() => headings.map((heading) => heading.id), [headings]);
+  const headingIdsKey = headingIds.join("\0");
   const activeId = useActiveHeadingId(showToc ? headingIds : []);
+
+  useEffect(() => {
+    if (!showToc || typeof window === "undefined") {
+      return;
+    }
+
+    const hash = window.location.hash.slice(1);
+    if (hash.length === 0) {
+      return;
+    }
+
+    const targetId = decodeURIComponent(hash);
+    let attempts = 0;
+
+    const scrollToHash = (): void => {
+      if (scrollToHeadingId(targetId)) {
+        return;
+      }
+
+      attempts += 1;
+      if (attempts < 60) {
+        requestAnimationFrame(scrollToHash);
+      }
+    };
+
+    requestAnimationFrame(scrollToHash);
+  }, [showToc, headingIdsKey]);
 
   return (
     <div className="mx-auto w-full max-w-6xl px-4 py-10">

--- a/components/MarkdownWithToc/index.tsx
+++ b/components/MarkdownWithToc/index.tsx
@@ -8,7 +8,7 @@ import { scrollToHeadingId } from "@/lib/scrollToHeadingId";
 import { useActiveHeadingId } from "@/lib/useActiveHeadingId";
 
 type MarkdownWithTocProps = {
-  /** 抽出済みの h2 見出し（2件未満なら TOC は出さない） */
+  /** 抽出済みの h2 見出し（1件以上あれば TOC を出す） */
   headings: MarkdownHeading[];
   /** ページ見出しブロック（タイトル・メタ情報など） */
   header: ReactNode;
@@ -23,7 +23,7 @@ type MarkdownWithTocProps = {
  * 現在位置ハイライト用の Observer は 1 箇所で共有する。
  */
 export function MarkdownWithToc({ headings, header, children }: MarkdownWithTocProps) {
-  const showToc = headings.length >= 2;
+  const showToc = headings.length >= 1;
   const headingIds = useMemo(() => headings.map((heading) => heading.id), [headings]);
   const headingIdsKey = headingIds.join("\0");
   const activeId = useActiveHeadingId(showToc ? headingIds : []);

--- a/components/MarkdownWithToc/index.tsx
+++ b/components/MarkdownWithToc/index.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import clsx from "clsx";
 import { useEffect, useMemo, type ReactNode } from "react";
 import { TableOfContents } from "@/components/TableOfContents";
 import type { MarkdownHeading } from "@/lib/extractMarkdownH2Headings";
@@ -55,11 +56,11 @@ export function MarkdownWithToc({ headings, header, children }: MarkdownWithTocP
   }, [showToc, headingIdsKey]);
 
   return (
-    <div className="mx-auto w-full max-w-6xl px-4 py-10">
+    <div className={clsx(["mx-auto w-full px-4 py-10", showToc ? "max-w-5xl" : "max-w-3xl"])}>
       <div
         className={
           showToc
-            ? "lg:grid lg:grid-cols-[minmax(0,1fr)_14rem] lg:items-start lg:gap-10"
+            ? "lg:grid lg:grid-cols-[minmax(0,48rem)_11rem] lg:items-start lg:gap-8"
             : undefined
         }
       >

--- a/components/MarkdownWithToc/index.tsx
+++ b/components/MarkdownWithToc/index.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useMemo, type ReactNode } from "react";
+import { TableOfContents } from "@/components/TableOfContents";
+import type { MarkdownHeading } from "@/lib/extractMarkdownH2Headings";
+import { useActiveHeadingId } from "@/lib/useActiveHeadingId";
+
+type MarkdownWithTocProps = {
+  /** 抽出済みの h2 見出し（2件未満なら TOC は出さない） */
+  headings: MarkdownHeading[];
+  /** ページ見出しブロック（タイトル・メタ情報など） */
+  header: ReactNode;
+  /** Markdown 本文など */
+  children: ReactNode;
+};
+
+/**
+ * 長文 Markdown 向けの TOC 付きレイアウト。
+ *
+ * PC（lg+）では右側に sticky TOC、SP では本文上に折りたたみ TOC を置く。
+ * 現在位置ハイライト用の Observer は 1 箇所で共有する。
+ */
+export function MarkdownWithToc({ headings, header, children }: MarkdownWithTocProps) {
+  const showToc = headings.length >= 2;
+  const headingIds = useMemo(() => headings.map((heading) => heading.id), [headings]);
+  const activeId = useActiveHeadingId(showToc ? headingIds : []);
+
+  return (
+    <div className="mx-auto w-full max-w-6xl px-4 py-10">
+      <div
+        className={
+          showToc
+            ? "lg:grid lg:grid-cols-[minmax(0,1fr)_14rem] lg:items-start lg:gap-10"
+            : undefined
+        }
+      >
+        <div className="min-w-0">
+          {header}
+          {showToc ? (
+            <div className="mt-6 lg:hidden">
+              <TableOfContents headings={headings} activeId={activeId} collapsible />
+            </div>
+          ) : null}
+          <div className="mt-8 space-y-6 text-sm leading-relaxed text-zinc-700">{children}</div>
+        </div>
+        {showToc ? (
+          <aside className="hidden lg:sticky lg:top-24 lg:block lg:self-start">
+            <TableOfContents headings={headings} activeId={activeId} />
+          </aside>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/components/TableOfContents/TableOfContents.test.tsx
+++ b/components/TableOfContents/TableOfContents.test.tsx
@@ -4,10 +4,10 @@ import { describe, expect, it, vi } from "vitest";
 import { TableOfContents } from "./index";
 
 vi.mock("@/lib/scrollToHeadingId", () => ({
-  scrollToHeadingId: vi.fn(() => true),
+  navigateToHeadingId: vi.fn(),
 }));
 
-import { scrollToHeadingId } from "@/lib/scrollToHeadingId";
+import { navigateToHeadingId } from "@/lib/scrollToHeadingId";
 
 describe("TableOfContents", () => {
   it("見出しが0件なら何も描画しない", () => {
@@ -57,7 +57,7 @@ describe("TableOfContents", () => {
     expect(document.querySelector("details")).toBeInTheDocument();
   });
 
-  it("リンククリックで scrollToHeadingId を呼ぶ", async () => {
+  it("リンククリックで navigateToHeadingId を呼ぶ", async () => {
     const user = userEvent.setup();
 
     render(
@@ -72,6 +72,6 @@ describe("TableOfContents", () => {
 
     await user.click(screen.getByRole("link", { name: "まとめ" }));
 
-    expect(scrollToHeadingId).toHaveBeenCalledWith("まとめ");
+    expect(navigateToHeadingId).toHaveBeenCalledWith("まとめ");
   });
 });

--- a/components/TableOfContents/TableOfContents.test.tsx
+++ b/components/TableOfContents/TableOfContents.test.tsx
@@ -1,6 +1,13 @@
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
 import { TableOfContents } from "./index";
+
+vi.mock("@/lib/scrollToHeadingId", () => ({
+  scrollToHeadingId: vi.fn(() => true),
+}));
+
+import { scrollToHeadingId } from "@/lib/scrollToHeadingId";
 
 describe("TableOfContents", () => {
   it("見出しが2件未満なら何も描画しない", () => {
@@ -44,5 +51,23 @@ describe("TableOfContents", () => {
 
     expect(screen.getByText("目次").closest("summary")).toBeInTheDocument();
     expect(document.querySelector("details")).toBeInTheDocument();
+  });
+
+  it("リンククリックで scrollToHeadingId を呼ぶ", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <TableOfContents
+        headings={[
+          { id: "投稿前チェックリスト", text: "投稿前チェックリスト" },
+          { id: "まとめ", text: "まとめ" },
+        ]}
+        activeId="投稿前チェックリスト"
+      />
+    );
+
+    await user.click(screen.getByRole("link", { name: "まとめ" }));
+
+    expect(scrollToHeadingId).toHaveBeenCalledWith("まとめ");
   });
 });

--- a/components/TableOfContents/TableOfContents.test.tsx
+++ b/components/TableOfContents/TableOfContents.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { TableOfContents } from "./index";
+
+describe("TableOfContents", () => {
+  it("見出しが2件未満なら何も描画しない", () => {
+    const { container } = render(
+      <TableOfContents headings={[{ id: "ひとつ", text: "ひとつ" }]} activeId="ひとつ" />
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("見出しへのアンカーリンクを表示する", () => {
+    render(
+      <TableOfContents
+        headings={[
+          { id: "投稿前チェックリスト", text: "投稿前チェックリスト" },
+          { id: "まとめ", text: "まとめ" },
+        ]}
+        activeId="まとめ"
+      />
+    );
+
+    expect(screen.getByRole("navigation", { name: "目次" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "投稿前チェックリスト" })).toHaveAttribute(
+      "href",
+      "#投稿前チェックリスト"
+    );
+    expect(screen.getByRole("link", { name: "まとめ" })).toHaveAttribute("aria-current", "true");
+  });
+
+  it("collapsible のとき details で折りたためる", () => {
+    render(
+      <TableOfContents
+        headings={[
+          { id: "a", text: "見出しA" },
+          { id: "b", text: "見出しB" },
+        ]}
+        activeId="a"
+        collapsible
+      />
+    );
+
+    expect(screen.getByText("目次").closest("summary")).toBeInTheDocument();
+    expect(document.querySelector("details")).toBeInTheDocument();
+  });
+});

--- a/components/TableOfContents/TableOfContents.test.tsx
+++ b/components/TableOfContents/TableOfContents.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import { TableOfContents } from "./index";
 
 describe("TableOfContents", () => {

--- a/components/TableOfContents/TableOfContents.test.tsx
+++ b/components/TableOfContents/TableOfContents.test.tsx
@@ -10,12 +10,16 @@ vi.mock("@/lib/scrollToHeadingId", () => ({
 import { scrollToHeadingId } from "@/lib/scrollToHeadingId";
 
 describe("TableOfContents", () => {
-  it("見出しが2件未満なら何も描画しない", () => {
-    const { container } = render(
-      <TableOfContents headings={[{ id: "ひとつ", text: "ひとつ" }]} activeId="ひとつ" />
-    );
+  it("見出しが0件なら何も描画しない", () => {
+    const { container } = render(<TableOfContents headings={[]} activeId={null} />);
 
     expect(container).toBeEmptyDOMElement();
+  });
+
+  it("見出しが1件でもアンカーリンクを表示する", () => {
+    render(<TableOfContents headings={[{ id: "ひとつ", text: "ひとつ" }]} activeId="ひとつ" />);
+
+    expect(screen.getByRole("link", { name: "ひとつ" })).toHaveAttribute("href", "#ひとつ");
   });
 
   it("見出しへのアンカーリンクを表示する", () => {

--- a/components/TableOfContents/TableOfContents.test.tsx
+++ b/components/TableOfContents/TableOfContents.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { TableOfContents } from "./index";
 
 vi.mock("@/lib/scrollToHeadingId", () => ({
@@ -10,6 +10,9 @@ vi.mock("@/lib/scrollToHeadingId", () => ({
 import { navigateToHeadingId } from "@/lib/scrollToHeadingId";
 
 describe("TableOfContents", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
   it("見出しが0件なら何も描画しない", () => {
     const { container } = render(<TableOfContents headings={[]} activeId={null} />);
 
@@ -73,5 +76,24 @@ describe("TableOfContents", () => {
     await user.click(screen.getByRole("link", { name: "まとめ" }));
 
     expect(navigateToHeadingId).toHaveBeenCalledWith("まとめ");
+  });
+
+  it("修飾キー付きクリックでは navigateToHeadingId を呼ばない", () => {
+    render(
+      <TableOfContents
+        headings={[
+          { id: "投稿前チェックリスト", text: "投稿前チェックリスト" },
+          { id: "まとめ", text: "まとめ" },
+        ]}
+        activeId="投稿前チェックリスト"
+      />
+    );
+
+    const link = screen.getByRole("link", { name: "まとめ" });
+    link.dispatchEvent(
+      new MouseEvent("click", { bubbles: true, cancelable: true, ctrlKey: true, button: 0 })
+    );
+
+    expect(navigateToHeadingId).not.toHaveBeenCalled();
   });
 });

--- a/components/TableOfContents/index.tsx
+++ b/components/TableOfContents/index.tsx
@@ -2,7 +2,9 @@
 
 import clsx from "clsx";
 import { ChevronDown } from "lucide-react";
+import type { MouseEvent } from "react";
 import type { MarkdownHeading } from "@/lib/extractMarkdownH2Headings";
+import { scrollToHeadingId } from "@/lib/scrollToHeadingId";
 
 type TableOfContentsProps = {
   headings: MarkdownHeading[];
@@ -70,6 +72,11 @@ type TocLinkListProps = {
  * TOC のリンク一覧を描画する。
  */
 function TocLinkList({ headings, activeId }: TocLinkListProps) {
+  const handleClick = (event: MouseEvent<HTMLAnchorElement>, id: string): void => {
+    event.preventDefault();
+    scrollToHeadingId(id);
+  };
+
   return (
     <ol className="space-y-1">
       {headings.map((heading) => {
@@ -78,6 +85,9 @@ function TocLinkList({ headings, activeId }: TocLinkListProps) {
           <li key={heading.id}>
             <a
               href={`#${heading.id}`}
+              onClick={(event) => {
+                handleClick(event, heading.id);
+              }}
               className={clsx([
                 "block",
                 "rounded-md",

--- a/components/TableOfContents/index.tsx
+++ b/components/TableOfContents/index.tsx
@@ -4,7 +4,7 @@ import clsx from "clsx";
 import { ChevronDown } from "lucide-react";
 import type { MouseEvent } from "react";
 import type { MarkdownHeading } from "@/lib/extractMarkdownH2Headings";
-import { scrollToHeadingId } from "@/lib/scrollToHeadingId";
+import { navigateToHeadingId } from "@/lib/scrollToHeadingId";
 
 type TableOfContentsProps = {
   headings: MarkdownHeading[];
@@ -74,7 +74,7 @@ type TocLinkListProps = {
 function TocLinkList({ headings, activeId }: TocLinkListProps) {
   const handleClick = (event: MouseEvent<HTMLAnchorElement>, id: string): void => {
     event.preventDefault();
-    scrollToHeadingId(id);
+    navigateToHeadingId(id);
   };
 
   return (

--- a/components/TableOfContents/index.tsx
+++ b/components/TableOfContents/index.tsx
@@ -73,6 +73,10 @@ type TocLinkListProps = {
  */
 function TocLinkList({ headings, activeId }: TocLinkListProps) {
   const handleClick = (event: MouseEvent<HTMLAnchorElement>, id: string): void => {
+    if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey || event.button !== 0) {
+      return;
+    }
+
     event.preventDefault();
     navigateToHeadingId(id);
   };

--- a/components/TableOfContents/index.tsx
+++ b/components/TableOfContents/index.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import clsx from "clsx";
+import { ChevronDown } from "lucide-react";
+import type { MarkdownHeading } from "@/lib/extractMarkdownH2Headings";
+
+type TableOfContentsProps = {
+  headings: MarkdownHeading[];
+  activeId: string | null;
+  /** SP 向けに details 折りたたみで表示する */
+  collapsible?: boolean;
+};
+
+/**
+ * Markdown の h2 目次リンク一覧。現在位置をハイライトする。
+ */
+export function TableOfContents({ headings, activeId, collapsible = false }: TableOfContentsProps) {
+  if (headings.length < 2) {
+    return null;
+  }
+
+  const linkList = <TocLinkList headings={headings} activeId={activeId} />;
+
+  if (!collapsible) {
+    return (
+      <nav aria-label="目次" className="text-sm">
+        <p className="text-xs font-semibold tracking-wide text-zinc-500">目次</p>
+        <div className="mt-3">{linkList}</div>
+      </nav>
+    );
+  }
+
+  return (
+    <nav aria-label="目次" className="text-sm">
+      <details className="group rounded-xl border border-zinc-200 bg-white">
+        <summary
+          className={clsx([
+            "flex",
+            "cursor-pointer",
+            "list-none",
+            "items-center",
+            "justify-between",
+            "gap-2",
+            "px-4",
+            "py-3",
+            "font-semibold",
+            "text-zinc-900",
+            "marker:content-none",
+            "[&::-webkit-details-marker]:hidden",
+          ])}
+        >
+          目次
+          <ChevronDown
+            aria-hidden="true"
+            className="size-4 shrink-0 text-zinc-500 transition-transform group-open:rotate-180"
+          />
+        </summary>
+        <div className="border-t border-zinc-100 px-2 pb-3 pt-1">{linkList}</div>
+      </details>
+    </nav>
+  );
+}
+
+type TocLinkListProps = {
+  headings: MarkdownHeading[];
+  activeId: string | null;
+};
+
+/**
+ * TOC のリンク一覧を描画する。
+ */
+function TocLinkList({ headings, activeId }: TocLinkListProps) {
+  return (
+    <ol className="space-y-1">
+      {headings.map((heading) => {
+        const isActive = heading.id === activeId;
+        return (
+          <li key={heading.id}>
+            <a
+              href={`#${heading.id}`}
+              className={clsx([
+                "block",
+                "rounded-md",
+                "px-2",
+                "py-1.5",
+                "leading-snug",
+                "transition-colors",
+                "focus-visible:outline-none",
+                "focus-visible:ring-2",
+                "focus-visible:ring-indigo-500",
+                isActive
+                  ? "bg-indigo-50 font-medium text-indigo-700"
+                  : "text-zinc-600 hover:bg-zinc-50 hover:text-zinc-900",
+              ])}
+              aria-current={isActive ? "true" : undefined}
+            >
+              {heading.text}
+            </a>
+          </li>
+        );
+      })}
+    </ol>
+  );
+}

--- a/components/TableOfContents/index.tsx
+++ b/components/TableOfContents/index.tsx
@@ -17,7 +17,7 @@ type TableOfContentsProps = {
  * Markdown の h2 目次リンク一覧。現在位置をハイライトする。
  */
 export function TableOfContents({ headings, activeId, collapsible = false }: TableOfContentsProps) {
-  if (headings.length < 2) {
+  if (headings.length === 0) {
     return null;
   }
 

--- a/lib/decodeLocationHash.test.ts
+++ b/lib/decodeLocationHash.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { decodeLocationHash } from "./decodeLocationHash";
+
+describe("decodeLocationHash", () => {
+  it("通常のハッシュをデコードする", () => {
+    expect(decodeLocationHash("%E6%8A%95%E7%A8%BF")).toBe("投稿");
+  });
+
+  it("不正な % シーケンスのとき raw を返す", () => {
+    expect(decodeLocationHash("%E0%A4%A")).toBe("%E0%A4%A");
+  });
+
+  it("空文字列のときそのまま返す", () => {
+    expect(decodeLocationHash("")).toBe("");
+  });
+});

--- a/lib/decodeLocationHash.ts
+++ b/lib/decodeLocationHash.ts
@@ -1,0 +1,14 @@
+/**
+ * location.hash から取り出した文字列を安全にデコードする。
+ */
+export function decodeLocationHash(hash: string): string {
+  if (hash.length === 0) {
+    return hash;
+  }
+
+  try {
+    return decodeURIComponent(hash);
+  } catch {
+    return hash;
+  }
+}

--- a/lib/extractMarkdownH2Headings.test.ts
+++ b/lib/extractMarkdownH2Headings.test.ts
@@ -74,4 +74,18 @@ describe("extractMarkdownH2Headings", () => {
 
     expect(headings).toEqual([{ text: "対象", id: "対象" }]);
   });
+
+  it("重複見出しには連番サフィックス付き id を付与する", () => {
+    const headings = extractMarkdownH2Headings(`## まとめ
+
+本文
+
+## まとめ
+`);
+
+    expect(headings).toEqual([
+      { text: "まとめ", id: "まとめ" },
+      { text: "まとめ", id: "まとめ-2" },
+    ]);
+  });
 });

--- a/lib/extractMarkdownH2Headings.test.ts
+++ b/lib/extractMarkdownH2Headings.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { extractMarkdownH2Headings } from "./extractMarkdownH2Headings";
+
+describe("extractMarkdownH2Headings", () => {
+  it("h2 見出しのテキストと id を返す", () => {
+    const headings = extractMarkdownH2Headings(`導入文
+
+## 投稿前チェックリスト
+
+本文
+
+## まとめ
+`);
+
+    expect(headings).toEqual([
+      { text: "投稿前チェックリスト", id: "投稿前チェックリスト" },
+      { text: "まとめ", id: "まとめ" },
+    ]);
+  });
+
+  it("コードフェンス内の ## は無視する", () => {
+    const headings = extractMarkdownH2Headings(`## 本番見出し
+
+\`\`\`md
+## 無視される見出し
+\`\`\`
+
+## もう一つの見出し
+`);
+
+    expect(headings.map((heading) => heading.text)).toEqual(["本番見出し", "もう一つの見出し"]);
+  });
+
+  it("h1 / h3 は含めない", () => {
+    const headings = extractMarkdownH2Headings(`# タイトル
+
+### 小見出し
+
+## 対象
+`);
+
+    expect(headings).toEqual([{ text: "対象", id: "対象" }]);
+  });
+});

--- a/lib/extractMarkdownH2Headings.test.ts
+++ b/lib/extractMarkdownH2Headings.test.ts
@@ -41,4 +41,37 @@ describe("extractMarkdownH2Headings", () => {
 
     expect(headings).toEqual([{ text: "対象", id: "対象" }]);
   });
+
+  it("先頭インデント付き h2 を抽出する", () => {
+    const headings = extractMarkdownH2Headings(`   ## 先頭インデント
+
+## 通常
+`);
+
+    expect(headings).toEqual([
+      { text: "先頭インデント", id: "先頭インデント" },
+      { text: "通常", id: "通常" },
+    ]);
+  });
+
+  it("閉じ ## 付き h2 から見出しテキストだけを取り出す", () => {
+    const headings = extractMarkdownH2Headings(`## 閉じ記法 ##
+
+## 通常
+`);
+
+    expect(headings).toEqual([
+      { text: "閉じ記法", id: "閉じ記法" },
+      { text: "通常", id: "通常" },
+    ]);
+  });
+
+  it("インデント4スペース以上の行は h2 として扱わない", () => {
+    const headings = extractMarkdownH2Headings(`    ## コードブロック相当
+
+## 対象
+`);
+
+    expect(headings).toEqual([{ text: "対象", id: "対象" }]);
+  });
 });

--- a/lib/extractMarkdownH2Headings.ts
+++ b/lib/extractMarkdownH2Headings.ts
@@ -1,0 +1,46 @@
+import { markdownHeadingToId } from "@/lib/markdownHeadingId";
+
+export type MarkdownHeading = {
+  id: string;
+  text: string;
+};
+
+/**
+ * Markdown 本文から ATX 形式の h2（`##`）を抽出する。
+ *
+ * コードフェンス内の行は無視する。`MarkdownContent` が付与する id と揃えるため
+ * `markdownHeadingToId` を使う。
+ */
+export function extractMarkdownH2Headings(content: string): MarkdownHeading[] {
+  const headings: MarkdownHeading[] = [];
+  const lines = content.split("\n");
+  let inCodeFence = false;
+
+  for (const line of lines) {
+    const trimmedStart = line.trimStart();
+    if (trimmedStart.startsWith("```")) {
+      inCodeFence = !inCodeFence;
+      continue;
+    }
+    if (inCodeFence) {
+      continue;
+    }
+
+    const match = /^##\s+(.+)$/.exec(line);
+    if (!match) {
+      continue;
+    }
+
+    const text = match[1]!.trim();
+    if (text.length === 0) {
+      continue;
+    }
+
+    headings.push({
+      text,
+      id: markdownHeadingToId(text),
+    });
+  }
+
+  return headings;
+}

--- a/lib/extractMarkdownH2Headings.ts
+++ b/lib/extractMarkdownH2Headings.ts
@@ -5,6 +5,22 @@ export type MarkdownHeading = {
   text: string;
 };
 
+/** ATX 形式 h2（先頭インデント最大3スペース・末尾の閉じ `##` に対応） */
+const ATX_H2_PATTERN = /^( {0,3})##(?!#)\s+(.+?)(?:\s+#+\s*)?$/;
+
+/**
+ * ATX 見出し行から h2 の表示テキストを取り出す。
+ */
+function parseAtxH2Line(line: string): string | null {
+  const match = ATX_H2_PATTERN.exec(line);
+  if (!match) {
+    return null;
+  }
+
+  const text = match[2]!.trim();
+  return text.length > 0 ? text : null;
+}
+
 /**
  * Markdown 本文から ATX 形式の h2（`##`）を抽出する。
  *
@@ -26,13 +42,8 @@ export function extractMarkdownH2Headings(content: string): MarkdownHeading[] {
       continue;
     }
 
-    const match = /^##\s+(.+)$/.exec(line);
-    if (!match) {
-      continue;
-    }
-
-    const text = match[1]!.trim();
-    if (text.length === 0) {
+    const text = parseAtxH2Line(line);
+    if (text === null) {
       continue;
     }
 

--- a/lib/extractMarkdownH2Headings.ts
+++ b/lib/extractMarkdownH2Headings.ts
@@ -1,4 +1,4 @@
-import { markdownHeadingToId } from "@/lib/markdownHeadingId";
+import { assignUniqueMarkdownHeadingId } from "@/lib/markdownHeadingId";
 
 export type MarkdownHeading = {
   id: string;
@@ -29,6 +29,7 @@ function parseAtxH2Line(line: string): string | null {
  */
 export function extractMarkdownH2Headings(content: string): MarkdownHeading[] {
   const headings: MarkdownHeading[] = [];
+  const usedIds = new Set<string>();
   const lines = content.split("\n");
   let inCodeFence = false;
 
@@ -49,7 +50,7 @@ export function extractMarkdownH2Headings(content: string): MarkdownHeading[] {
 
     headings.push({
       text,
-      id: markdownHeadingToId(text),
+      id: assignUniqueMarkdownHeadingId(text, usedIds),
     });
   }
 

--- a/lib/extractMarkdownH2Headings.ts
+++ b/lib/extractMarkdownH2Headings.ts
@@ -25,7 +25,7 @@ function parseAtxH2Line(line: string): string | null {
  * Markdown 本文から ATX 形式の h2（`##`）を抽出する。
  *
  * コードフェンス内の行は無視する。`MarkdownContent` が付与する id と揃えるため
- * `markdownHeadingToId` を使う。
+ * `assignUniqueMarkdownHeadingId` を使う（重複見出しは `-2` サフィックス）。
  */
 export function extractMarkdownH2Headings(content: string): MarkdownHeading[] {
   const headings: MarkdownHeading[] = [];

--- a/lib/markdownHeadingId.test.ts
+++ b/lib/markdownHeadingId.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { assignUniqueMarkdownHeadingId, markdownHeadingToId } from "./markdownHeadingId";
+
+describe("assignUniqueMarkdownHeadingId", () => {
+  it("初回は base id を返す", () => {
+    const usedIds = new Set<string>();
+
+    expect(assignUniqueMarkdownHeadingId("まとめ", usedIds)).toBe("まとめ");
+    expect(usedIds).toEqual(new Set(["まとめ"]));
+  });
+
+  it("重複時は -2, -3 とサフィックスを付与する", () => {
+    const usedIds = new Set<string>([markdownHeadingToId("まとめ")]);
+
+    expect(assignUniqueMarkdownHeadingId("まとめ", usedIds)).toBe("まとめ-2");
+    expect(assignUniqueMarkdownHeadingId("まとめ", usedIds)).toBe("まとめ-3");
+  });
+});

--- a/lib/markdownHeadingId.ts
+++ b/lib/markdownHeadingId.ts
@@ -8,3 +8,25 @@ export function markdownHeadingToId(text: string): string {
     .replace(/[（）()]/g, "")
     .replace(/[^a-zA-Z0-9\u3040-\u309f\u30a0-\u30ff\u4e00-\u9faf-]/g, "");
 }
+
+/**
+ * 同一ページ内で重複しない見出し id を割り当てる。
+ */
+export function assignUniqueMarkdownHeadingId(text: string, usedIds: Set<string>): string {
+  const base = markdownHeadingToId(text);
+
+  if (!usedIds.has(base)) {
+    usedIds.add(base);
+    return base;
+  }
+
+  let suffix = 2;
+  let candidate = `${base}-${suffix}`;
+  while (usedIds.has(candidate)) {
+    suffix += 1;
+    candidate = `${base}-${suffix}`;
+  }
+
+  usedIds.add(candidate);
+  return candidate;
+}

--- a/lib/normalizeMarkdownContent.test.ts
+++ b/lib/normalizeMarkdownContent.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { extractMarkdownH2Headings } from "./extractMarkdownH2Headings";
+import { normalizeMarkdownContent } from "./normalizeMarkdownContent";
+
+describe("normalizeMarkdownContent", () => {
+  it("HTML コメントを除去する", () => {
+    const normalized = normalizeMarkdownContent(
+      ["公開する本文", "<!--", "## コメント内見出し", "-->", "続きの本文"].join("\n")
+    );
+
+    expect(normalized).not.toContain("コメント内見出し");
+    expect(normalized).toContain("公開する本文");
+    expect(normalized).toContain("続きの本文");
+  });
+
+  it("details ディレクティブを remark-directive 向けに正規化する", () => {
+    const normalized = normalizeMarkdownContent("::::details スマホの場合");
+
+    expect(normalized).toBe("::::details[スマホの場合]");
+  });
+});
+
+describe("extractMarkdownH2Headings with normalizeMarkdownContent", () => {
+  it("HTML コメント内の h2 は見出しとして数えない", () => {
+    const content = ["<!--", "## コメント内見出し", "-->", "## 実際の見出し"].join("\n");
+    const headings = extractMarkdownH2Headings(normalizeMarkdownContent(content));
+
+    expect(headings).toEqual([{ text: "実際の見出し", id: "実際の見出し" }]);
+  });
+});

--- a/lib/normalizeMarkdownContent.ts
+++ b/lib/normalizeMarkdownContent.ts
@@ -1,0 +1,26 @@
+const DETAILS_DIRECTIVE_PATTERN = /^(:{3,})details[ \t]+(.+)$/gm;
+const HTML_COMMENT_PATTERN = /<!--[\s\S]*?-->/g;
+
+/**
+ * Qiita 風の `:::details タイトル` を remark-directive のラベル構文へ正規化する。
+ */
+export function normalizeDetailsDirective(content: string): string {
+  return content.replace(DETAILS_DIRECTIVE_PATTERN, (_, fence: string, rawTitle: string) => {
+    const title = rawTitle.trim();
+    return title.length > 0 ? `${fence}details[${title}]` : `${fence}details`;
+  });
+}
+
+/**
+ * 執筆メモ用の HTML コメントを公開本文から取り除く。
+ */
+export function stripMarkdownComments(content: string): string {
+  return content.replace(HTML_COMMENT_PATTERN, "");
+}
+
+/**
+ * Markdown 本文を `MarkdownContent` の描画前処理と同じ形に正規化する。
+ */
+export function normalizeMarkdownContent(content: string): string {
+  return normalizeDetailsDirective(stripMarkdownComments(content));
+}

--- a/lib/scrollToHeadingId.test.ts
+++ b/lib/scrollToHeadingId.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { scrollToHeadingId } from "./scrollToHeadingId";
+import { navigateToHeadingId, scrollToHeadingId, setHeadingHash } from "./scrollToHeadingId";
 
 describe("scrollToHeadingId", () => {
   beforeEach(() => {
@@ -24,10 +24,66 @@ describe("scrollToHeadingId", () => {
       behavior: "smooth",
       block: "start",
     });
-    expect(history.replaceState).toHaveBeenCalledWith(null, "", "#投稿前チェックリスト");
   });
 
   it("要素が無いとき false を返す", () => {
     expect(scrollToHeadingId("missing")).toBe(false);
+  });
+});
+
+describe("setHeadingHash", () => {
+  beforeEach(() => {
+    vi.stubGlobal("history", {
+      replaceState: vi.fn(),
+    });
+    vi.stubGlobal("location", {
+      hash: "",
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("ハッシュを更新する", () => {
+    setHeadingHash("まとめ");
+    expect(history.replaceState).toHaveBeenCalledWith(null, "", "#まとめ");
+  });
+});
+
+describe("navigateToHeadingId", () => {
+  beforeEach(() => {
+    vi.stubGlobal("history", {
+      replaceState: vi.fn(),
+    });
+    vi.stubGlobal("location", {
+      hash: "",
+    });
+    vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
+      callback(0);
+      return 1;
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    document.body.innerHTML = "";
+  });
+
+  it("要素が無くてもハッシュを先に更新する", () => {
+    navigateToHeadingId("missing");
+    expect(history.replaceState).toHaveBeenCalledWith(null, "", "#missing");
+  });
+
+  it("要素があるときスクロールする", () => {
+    const heading = document.createElement("h2");
+    heading.id = "まとめ";
+    heading.scrollIntoView = vi.fn();
+    document.body.append(heading);
+
+    navigateToHeadingId("まとめ");
+
+    expect(heading.scrollIntoView).toHaveBeenCalled();
+    expect(history.replaceState).toHaveBeenCalledWith(null, "", "#まとめ");
   });
 });

--- a/lib/scrollToHeadingId.test.ts
+++ b/lib/scrollToHeadingId.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { scrollToHeadingId } from "./scrollToHeadingId";
+
+describe("scrollToHeadingId", () => {
+  beforeEach(() => {
+    vi.stubGlobal("history", {
+      replaceState: vi.fn(),
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    document.body.innerHTML = "";
+  });
+
+  it("見出し要素へ scrollIntoView する", () => {
+    const heading = document.createElement("h2");
+    heading.id = "投稿前チェックリスト";
+    heading.scrollIntoView = vi.fn();
+    document.body.append(heading);
+
+    expect(scrollToHeadingId("投稿前チェックリスト")).toBe(true);
+    expect(heading.scrollIntoView).toHaveBeenCalledWith({
+      behavior: "smooth",
+      block: "start",
+    });
+    expect(history.replaceState).toHaveBeenCalledWith(null, "", "#投稿前チェックリスト");
+  });
+
+  it("要素が無いとき false を返す", () => {
+    expect(scrollToHeadingId("missing")).toBe(false);
+  });
+});

--- a/lib/scrollToHeadingId.ts
+++ b/lib/scrollToHeadingId.ts
@@ -1,0 +1,18 @@
+/**
+ * 見出し id へスクロールする。sticky Header を考慮するため h2 の scroll-margin に任せる。
+ */
+export function scrollToHeadingId(id: string): boolean {
+  const element = document.getElementById(id);
+  if (!element) {
+    return false;
+  }
+
+  element.scrollIntoView({ behavior: "smooth", block: "start" });
+
+  const nextHash = `#${id}`;
+  if (window.location.hash !== nextHash) {
+    window.history.replaceState(null, "", nextHash);
+  }
+
+  return true;
+}

--- a/lib/scrollToHeadingId.ts
+++ b/lib/scrollToHeadingId.ts
@@ -1,3 +1,5 @@
+"use client";
+
 /**
  * 見出し id へスクロールする。sticky Header を考慮するため h2 の scroll-margin に任せる。
  */

--- a/lib/scrollToHeadingId.ts
+++ b/lib/scrollToHeadingId.ts
@@ -8,11 +8,39 @@ export function scrollToHeadingId(id: string): boolean {
   }
 
   element.scrollIntoView({ behavior: "smooth", block: "start" });
+  return true;
+}
 
+/**
+ * 現在 URL のハッシュを見出し id に更新する。
+ */
+export function setHeadingHash(id: string): void {
   const nextHash = `#${id}`;
   if (window.location.hash !== nextHash) {
     window.history.replaceState(null, "", nextHash);
   }
+}
 
-  return true;
+const MAX_SCROLL_ATTEMPTS = 60;
+
+/**
+ * ハッシュを先に更新し、見出し DOM の出現を待ってスクロールする。
+ */
+export function navigateToHeadingId(id: string): void {
+  setHeadingHash(id);
+
+  let attempts = 0;
+
+  const tryScroll = (): void => {
+    if (scrollToHeadingId(id)) {
+      return;
+    }
+
+    attempts += 1;
+    if (attempts < MAX_SCROLL_ATTEMPTS) {
+      requestAnimationFrame(tryScroll);
+    }
+  };
+
+  tryScroll();
 }

--- a/lib/useActiveHeadingId.test.ts
+++ b/lib/useActiveHeadingId.test.ts
@@ -1,0 +1,81 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useActiveHeadingId } from "./useActiveHeadingId";
+
+describe("useActiveHeadingId", () => {
+  let observerCallback: IntersectionObserverCallback | undefined;
+  let observe: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    observerCallback = undefined;
+    observe = vi.fn();
+
+    vi.stubGlobal(
+      "IntersectionObserver",
+      class {
+        observe = observe;
+        disconnect = vi.fn();
+
+        constructor(callback: IntersectionObserverCallback) {
+          observerCallback = callback;
+        }
+      }
+    );
+
+    vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
+      callback(0);
+      return 1;
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    document.body.innerHTML = "";
+  });
+
+  it("見出し DOM が遅れて出現しても監視を開始する", async () => {
+    let rafCount = 0;
+    vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
+      rafCount += 1;
+      if (rafCount === 2) {
+        const heading = document.createElement("h2");
+        heading.id = "delayed";
+        document.body.append(heading);
+      }
+      callback(0);
+      return rafCount;
+    });
+
+    renderHook(() => useActiveHeadingId(["delayed"]));
+
+    await waitFor(() => {
+      expect(observe).toHaveBeenCalled();
+    });
+  });
+
+  it("交差状態に応じて activeId を更新する", async () => {
+    const first = document.createElement("h2");
+    first.id = "first";
+    const second = document.createElement("h2");
+    second.id = "second";
+    document.body.append(first, second);
+
+    const { result } = renderHook(() => useActiveHeadingId(["first", "second"]));
+
+    expect(result.current).toBe("first");
+
+    observerCallback?.(
+      [
+        {
+          target: second,
+          isIntersecting: true,
+        } as unknown as IntersectionObserverEntry,
+      ],
+      {} as IntersectionObserver
+    );
+
+    await waitFor(() => {
+      expect(result.current).toBe("second");
+    });
+  });
+});

--- a/lib/useActiveHeadingId.ts
+++ b/lib/useActiveHeadingId.ts
@@ -2,11 +2,12 @@
 
 import { useEffect, useState } from "react";
 
+const MAX_OBSERVER_SETUP_ATTEMPTS = 60;
+
 /**
  * 画面内で最も上にある見出し id を IntersectionObserver で追跡する。
  *
- * sticky Header 分のオフセットを rootMargin で考慮する。
- * 見出し一覧が変わった直後は先頭を仮の現在位置とし、Observer のコールバックで更新する。
+ * Markdown 本文は Client Component のため、見出し DOM の出現を待ってから監視を始める。
  */
 export function useActiveHeadingId(headingIds: string[]): string | null {
   const headingIdsKey = headingIds.join("\0");
@@ -25,46 +26,63 @@ export function useActiveHeadingId(headingIds: string[]): string | null {
       return;
     }
 
-    const elements = ids
-      .map((id) => document.getElementById(id))
-      .filter((element): element is HTMLElement => element !== null);
+    let cancelled = false;
+    let observer: IntersectionObserver | null = null;
+    let attempts = 0;
 
-    if (elements.length === 0) {
-      return;
-    }
-
-    const visibleIds = new Set<string>();
-
-    const observer = new IntersectionObserver(
-      (entries) => {
-        for (const entry of entries) {
-          if (!(entry.target instanceof HTMLElement) || !entry.target.id) {
-            continue;
-          }
-          if (entry.isIntersecting) {
-            visibleIds.add(entry.target.id);
-          } else {
-            visibleIds.delete(entry.target.id);
-          }
-        }
-
-        const nextActive = ids.find((id) => visibleIds.has(id));
-        if (nextActive) {
-          setObserved({ key: headingIdsKey, id: nextActive });
-        }
-      },
-      {
-        rootMargin: "-80px 0px -55% 0px",
-        threshold: [0, 1],
+    const setupObserver = (): void => {
+      if (cancelled) {
+        return;
       }
-    );
 
-    for (const element of elements) {
-      observer.observe(element);
-    }
+      const elements = ids
+        .map((id) => document.getElementById(id))
+        .filter((element): element is HTMLElement => element !== null);
+
+      if (elements.length === 0) {
+        attempts += 1;
+        if (attempts < MAX_OBSERVER_SETUP_ATTEMPTS) {
+          requestAnimationFrame(setupObserver);
+        }
+        return;
+      }
+
+      const visibleIds = new Set<string>();
+
+      observer = new IntersectionObserver(
+        (entries) => {
+          for (const entry of entries) {
+            if (!(entry.target instanceof HTMLElement) || !entry.target.id) {
+              continue;
+            }
+            if (entry.isIntersecting) {
+              visibleIds.add(entry.target.id);
+            } else {
+              visibleIds.delete(entry.target.id);
+            }
+          }
+
+          const nextActive = ids.find((id) => visibleIds.has(id));
+          if (nextActive) {
+            setObserved({ key: headingIdsKey, id: nextActive });
+          }
+        },
+        {
+          rootMargin: "-80px 0px -55% 0px",
+          threshold: [0, 1],
+        }
+      );
+
+      for (const element of elements) {
+        observer.observe(element);
+      }
+    };
+
+    setupObserver();
 
     return () => {
-      observer.disconnect();
+      cancelled = true;
+      observer?.disconnect();
     };
   }, [headingIdsKey]);
 

--- a/lib/useActiveHeadingId.ts
+++ b/lib/useActiveHeadingId.ts
@@ -1,0 +1,72 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/**
+ * 画面内で最も上にある見出し id を IntersectionObserver で追跡する。
+ *
+ * sticky Header 分のオフセットを rootMargin で考慮する。
+ * 見出し一覧が変わった直後は先頭を仮の現在位置とし、Observer のコールバックで更新する。
+ */
+export function useActiveHeadingId(headingIds: string[]): string | null {
+  const headingIdsKey = headingIds.join("\0");
+  const fallbackId = headingIds[0] ?? null;
+  const [observed, setObserved] = useState<{ key: string; id: string } | null>(null);
+
+  const activeId =
+    observed !== null && observed.key === headingIdsKey && headingIds.includes(observed.id)
+      ? observed.id
+      : fallbackId;
+
+  useEffect(() => {
+    const ids = headingIdsKey.length > 0 ? headingIdsKey.split("\0") : [];
+
+    if (ids.length === 0 || typeof IntersectionObserver === "undefined") {
+      return;
+    }
+
+    const elements = ids
+      .map((id) => document.getElementById(id))
+      .filter((element): element is HTMLElement => element !== null);
+
+    if (elements.length === 0) {
+      return;
+    }
+
+    const visibleIds = new Set<string>();
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (!(entry.target instanceof HTMLElement) || !entry.target.id) {
+            continue;
+          }
+          if (entry.isIntersecting) {
+            visibleIds.add(entry.target.id);
+          } else {
+            visibleIds.delete(entry.target.id);
+          }
+        }
+
+        const nextActive = ids.find((id) => visibleIds.has(id));
+        if (nextActive) {
+          setObserved({ key: headingIdsKey, id: nextActive });
+        }
+      },
+      {
+        rootMargin: "-80px 0px -55% 0px",
+        threshold: [0, 1],
+      }
+    );
+
+    for (const element of elements) {
+      observer.observe(element);
+    }
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [headingIdsKey]);
+
+  return activeId;
+}


### PR DESCRIPTION
## 概要

ブログ記事・使い方ガイドなどの Markdown ページ向けに、追従 TOC（目次）を追加します。PC では右側 sticky、SP では折りたたみ、現在位置ハイライトに対応します。

目次クリック時のスクロール不具合や、TOC なしページの幅広がりも本 PR で修正済みです。

## 関連Issue

Closes #114

## 変更内容

- [x] 機能追加
- [x] バグ修正
- [ ] リファクタリング
- [x] テスト追加・修正
- [ ] ドキュメント修正
- [ ] 設定・環境変更
- [ ] その他

## 主な変更箇所

### UI・コンポーネント

- `TableOfContents`（アンカーリンク + 現在位置ハイライト、SP は `details` 折りたたみ）
- `MarkdownWithToc`（PC: 右 sticky / SP: 本文上の折りたたみ）
- ブログ詳細・使い方ガイド詳細に TOC を組み込み
- `MarkdownContent` の h2 に `scroll-mt-24` を付与（sticky Header 対策）

### ロジック・処理

- `extractMarkdownH2Headings` で Markdown から h2 を抽出（コードフェンス内は無視）
- `scrollToHeadingId` で目次クリック時に `scrollIntoView` を明示実行（日本語 id のアンカー対策）
- `useActiveHeadingId` で IntersectionObserver による現在位置追跡
  - `MarkdownContent` のクライアント描画後に見出し DOM を待ってから監視開始

### レイアウト方針

- sticky 位置は **右側** を採用
- **h2 が 1 件以上** あれば TOC を表示（0 件のみ非表示）
- 幅
  - TOC なし: `max-w-3xl`（従来のガイド幅と同じ）
  - TOC あり: 全体 `max-w-5xl`、本文カラム `48rem` 固定 + 右に目次
- `LegalPageLayout` は規約ページ向けのまま維持し、ブログ・ガイド詳細は `MarkdownWithToc` に移行

## 動作確認

- [x] ローカル環境での動作確認
- [x] テストの実行・通過確認
- [x] UI動作確認（目次クリックのスクロール・ハイライト・幅）
- [x] 既存機能への影響確認
- [ ] ブラウザ動作確認（Chrome / Firefox / Safari）

## スクリーンショット・動画

レビュー時の確認 URL:

- `/blog/2026-07-08-event-photo-face-masking`（長文・TOC 複数項目）
- `/guides/manual-edit`（ガイド・TOC 複数項目）
- `/guides/image-import`（h2 1 件・TOC 1 項目）

## テスト

### 追加したテスト

- `extractMarkdownH2Headings`
- `scrollToHeadingId`
- `TableOfContents` / `MarkdownWithToc`
- ブログ・ガイド詳細ページの TOC 表示・クリック時スクロール
- h2 の `scroll-mt-24` 確認

### テスト結果

- [x] 全てのテストが通過
- [x] 新規テストを追加
- [x] 既存テストの修正

## 破壊的変更

- [ ] 破壊的変更あり
- [x] 破壊的変更なし

### 破壊的変更の詳細

なし

## レビューポイント

- PC sticky を右にした判断（Issue では左右どちらでも可だった）
- h2 が 1 件の短いページ（例: ガイド1）でも TOC を出す方針でよいか
- TOC ありページの幅（`max-w-5xl` + 本文 `48rem`）の見え方
- `scrollToHeadingId` + Observer の DOM 待ちリトライが過不足ないか
- SP の折りたたみが `details` / `summary` で十分か
- ガイド詳細への同時適用が意図どおりか

## 補足

- マスキングツール本体の操作体験変更ではないため、`content/updates/` の更新記事は未追加
- タグ絞り込み（#115）は本 PR の対象外

## チェックリスト

- [x] コードレビューの準備ができている
- [x] 適切なラベルを付けている
- [x] セルフレビューを実施している
- [x] `pnpm lint` と `pnpm type-check` が通ることを確認した（pre-commit で実施）
- [x] 必要に応じてドキュメントを更新している
- [x] ユーザー操作・体験に影響する変更がある場合、`content/updates/` に更新情報記事を追加した（追加不要の場合は理由を補足に記載）
