### PR TITLE
顔スタンプ選択時にプルダウンをキャンバス表示と同期する

### DIFF
--- a/features/editor/hooks/useEditorState.test.ts
+++ b/features/editor/hooks/useEditorState.test.ts
@@ -46,6 +46,7 @@ describe("useEditorState", () => {
       isEnabled: true,
       source: "face-detection",
     });
+    expect(result.current.stampRegions[0]?.stampFileName).toBeTruthy();
     expect(result.current.stampRegions[1]).toMatchObject({
       id: "f-1",
       x: 100,
@@ -57,6 +58,61 @@ describe("useEditorState", () => {
       source: "ocr",
       text: "test@example.com",
     });
+  });
+
+  it("顔スタンプ領域を選択するとプルダウン用ファイル名が同期する", () => {
+    vi.stubGlobal("crypto", {
+      randomUUID: vi.fn().mockReturnValueOnce("face-sync-1").mockReturnValueOnce("ocr-sync-1"),
+    });
+    const { result } = renderHook(() => useEditorState("beaming_face_with_smiling_eyes-64.png"));
+    act(() => {
+      result.current.initFromDetections(
+        [{ x: 10, y: 20, width: 50, height: 60 }],
+        [{ x: 0, y: 0, width: 10, height: 10, text: "x" }]
+      );
+    });
+    const faceRegion = result.current.stampRegions[0];
+    expect(faceRegion?.stampType).toBe("stamp-face");
+    expect(faceRegion?.stampFileName).toBeTruthy();
+
+    act(() => {
+      result.current.selectItem(faceRegion!.id);
+    });
+    expect(result.current.selectedStampFileName).toBe(faceRegion!.stampFileName);
+  });
+
+  it("stampFileName 未設定の stamp-face を選択すると解決してバックフィルする", () => {
+    const { result } = renderHook(() => useEditorState("beaming_face_with_smiling_eyes-64.png"));
+    act(() => {
+      result.current.restoreSnapshot({
+        mode: "select",
+        stampRegions: [
+          {
+            id: "legacy-face",
+            x: 0,
+            y: 0,
+            width: 40,
+            height: 40,
+            stampType: "stamp-face",
+            isEnabled: true,
+            source: "face-detection",
+          },
+        ],
+        paintStrokes: [],
+        selectedId: null,
+        selectedStampType: "stamp-face",
+        selectedStampFileName: "beaming_face_with_smiling_eyes-64.png",
+        brushSize: 20,
+      });
+    });
+    act(() => {
+      result.current.selectItem("legacy-face");
+    });
+    expect(result.current.selectedStampFileName).toBeTruthy();
+    expect(result.current.selectedStampFileName).not.toBe("");
+    expect(result.current.stampRegions[0]?.stampFileName).toBe(
+      result.current.selectedStampFileName
+    );
   });
 
   it("addStampRegion でマスキング領域を追加できる", () => {

--- a/features/editor/hooks/useEditorState.ts
+++ b/features/editor/hooks/useEditorState.ts
@@ -1,8 +1,10 @@
 "use client";
 
 import { useState, useCallback } from "react";
+import { STAMP_FILE_NAMES } from "../constants";
 import { createEditorSnapshotFromDetections } from "../lib/editorSnapshot";
 import { generateUUID } from "../lib/generateUUID";
+import { resolveStampFileName } from "../lib/pickStampImage";
 import type {
   EditorMode,
   EditorStateSnapshot,
@@ -69,8 +71,16 @@ export function useEditorState(initialStampFileName = ""): UseEditorStateReturn 
       const stampRegion = stampRegions.find((region) => region.id === id);
       if (!stampRegion) return;
       _setSelectedStampType(stampRegion.stampType);
-      if (stampRegion.stampFileName) {
-        _setSelectedStampFileName(stampRegion.stampFileName);
+      if (stampRegion.stampType !== "stamp-face") return;
+
+      const fileName = resolveStampFileName(stampRegion, STAMP_FILE_NAMES);
+      if (!fileName) return;
+      _setSelectedStampFileName(fileName);
+      /** 旧スナップショット等で stampFileName 未設定の領域は、表示と揃えてバックフィルする */
+      if (!stampRegion.stampFileName) {
+        setStampRegions((prev) =>
+          prev.map((region) => (region.id === id ? { ...region, stampFileName: fileName } : region))
+        );
       }
     },
     [stampRegions]

--- a/features/editor/lib/editorSnapshot.test.ts
+++ b/features/editor/lib/editorSnapshot.test.ts
@@ -1,7 +1,19 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { STAMP_FILE_NAMES } from "../constants";
 import { createEditorSnapshotFromDetections } from "./editorSnapshot";
+import { resolveStampFileName } from "./pickStampImage";
 
 describe("createEditorSnapshotFromDetections", () => {
+  beforeEach(() => {
+    vi.stubGlobal("crypto", {
+      randomUUID: vi.fn().mockReturnValueOnce("face-id").mockReturnValueOnce("ocr-id"),
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   it("顔検出と OCR からスタンプ領域を生成する", () => {
     const snapshot = createEditorSnapshotFromDetections(
       [{ x: 10, y: 20, width: 30, height: 40 }],
@@ -11,6 +23,9 @@ describe("createEditorSnapshotFromDetections", () => {
 
     expect(snapshot.stampRegions).toHaveLength(2);
     expect(snapshot.stampRegions[0]?.stampType).toBe("stamp-face");
+    expect(snapshot.stampRegions[0]?.stampFileName).toBe(
+      resolveStampFileName({ id: "face-id" }, STAMP_FILE_NAMES)
+    );
     expect(snapshot.stampRegions[1]?.stampType).toBe("fill-black");
     expect(snapshot.paintStrokes).toHaveLength(0);
     expect(snapshot.selectedId).toBeNull();

--- a/features/editor/lib/editorSnapshot.ts
+++ b/features/editor/lib/editorSnapshot.ts
@@ -1,5 +1,7 @@
+import { STAMP_FILE_NAMES } from "../constants";
 import type { EditorStateSnapshot, StampRegion, StampType } from "../types";
 import { generateUUID } from "./generateUUID";
+import { resolveStampFileName } from "./pickStampImage";
 
 /**
  * 検出結果からエディタの初期スナップショットを生成する
@@ -13,16 +15,20 @@ export function createEditorSnapshotFromDetections(
   ocrRegions: Array<{ x: number; y: number; width: number; height: number; text: string }>,
   initialStampFileName: string
 ): EditorStateSnapshot {
-  const faceRegions: StampRegion[] = detections.map((det) => ({
-    id: generateUUID(),
-    x: det.x,
-    y: det.y,
-    width: det.width,
-    height: det.height,
-    stampType: "stamp-face" as StampType,
-    isEnabled: true,
-    source: "face-detection" as const,
-  }));
+  const faceRegions: StampRegion[] = detections.map((det) => {
+    const id = generateUUID();
+    return {
+      id,
+      x: det.x,
+      y: det.y,
+      width: det.width,
+      height: det.height,
+      stampType: "stamp-face" as StampType,
+      stampFileName: resolveStampFileName({ id }, STAMP_FILE_NAMES),
+      isEnabled: true,
+      source: "face-detection" as const,
+    };
+  });
   const ocrMaskRegions: StampRegion[] = ocrRegions.map((region) => ({
     id: generateUUID(),
     x: region.x,

--- a/features/editor/lib/pickStampImage.test.ts
+++ b/features/editor/lib/pickStampImage.test.ts
@@ -40,9 +40,7 @@ describe("pickStampImage", () => {
     expect(pickStampImage(region, map)).toBe(img);
   });
 
-  it("stampFileName が無ければマップのキー順で id ハッシュ選択する", () => {
-    const img0 = new Image();
-    const img1 = new Image();
+  it("stampFileName が無ければカタログ順の id ハッシュで選択する", () => {
     const region: StampRegion = {
       id: "stable-id",
       x: 0,
@@ -53,14 +51,16 @@ describe("pickStampImage", () => {
       isEnabled: true,
       source: "manual",
     };
-    const map = new Map<string, HTMLImageElement>([
-      ["a", img0],
-      ["b", img1],
-    ]);
-    const expectedName = resolveStampFileName(region, ["a", "b"]);
-    const first = pickStampImage(region, map);
-    expect(first).toBe(expectedName === "a" ? img0 : img1);
-    expect(pickStampImage(region, map)).toBe(first);
+    const expectedName = resolveStampFileName(region, STAMP_FILE_NAMES) ?? "";
+    expect(expectedName).not.toBe("");
+    const expectedImg = new Image();
+    /** 意図的にカタログと異なる挿入順の Map でも、ハッシュ結果はカタログ順に従う */
+    const map = new Map<string, HTMLImageElement>();
+    for (const name of [...STAMP_FILE_NAMES].reverse()) {
+      map.set(name, name === expectedName ? expectedImg : new Image());
+    }
+    expect(pickStampImage(region, map)).toBe(expectedImg);
+    expect(pickStampImage(region, map)).toBe(expectedImg);
   });
 
   it("マップが空なら null", () => {

--- a/features/editor/lib/pickStampImage.test.ts
+++ b/features/editor/lib/pickStampImage.test.ts
@@ -1,6 +1,26 @@
 import { describe, expect, it } from "vitest";
+import { STAMP_FILE_NAMES } from "../constants";
 import type { StampRegion } from "../types";
-import { pickStampImage } from "./pickStampImage";
+import { pickStampImage, resolveStampFileName } from "./pickStampImage";
+
+describe("resolveStampFileName", () => {
+  it("stampFileName があればそれを返す", () => {
+    expect(
+      resolveStampFileName({ id: "any", stampFileName: "custom.png" }, ["a.png", "b.png"])
+    ).toBe("custom.png");
+  });
+
+  it("stampFileName が無ければ id ハッシュで決定的に選ぶ", () => {
+    const fileNames = ["a.png", "b.png", "c.png"] as const;
+    const first = resolveStampFileName({ id: "stable-id" }, fileNames);
+    expect(fileNames).toContain(first);
+    expect(resolveStampFileName({ id: "stable-id" }, fileNames)).toBe(first);
+  });
+
+  it("候補が空なら undefined", () => {
+    expect(resolveStampFileName({ id: "x" }, [])).toBeUndefined();
+  });
+});
 
 describe("pickStampImage", () => {
   it("stampFileName があればそのキーの画像を返す", () => {
@@ -20,7 +40,7 @@ describe("pickStampImage", () => {
     expect(pickStampImage(region, map)).toBe(img);
   });
 
-  it("stampFileName が無ければ id ハッシュで決定的に選択する", () => {
+  it("stampFileName が無ければマップのキー順で id ハッシュ選択する", () => {
     const img0 = new Image();
     const img1 = new Image();
     const region: StampRegion = {
@@ -37,8 +57,9 @@ describe("pickStampImage", () => {
       ["a", img0],
       ["b", img1],
     ]);
+    const expectedName = resolveStampFileName(region, ["a", "b"]);
     const first = pickStampImage(region, map);
-    expect([img0, img1]).toContain(first);
+    expect(first).toBe(expectedName === "a" ? img0 : img1);
     expect(pickStampImage(region, map)).toBe(first);
   });
 
@@ -54,5 +75,24 @@ describe("pickStampImage", () => {
       source: "manual",
     };
     expect(pickStampImage(region, new Map())).toBeNull();
+  });
+
+  it("カタログ既定では STAMP_FILE_NAMES と整合する", () => {
+    const id = "face-region-1";
+    const expected = resolveStampFileName({ id }, STAMP_FILE_NAMES) ?? "";
+    expect(expected).not.toBe("");
+    const img = new Image();
+    const map = new Map([[expected, img]]);
+    const region: StampRegion = {
+      id,
+      x: 0,
+      y: 0,
+      width: 10,
+      height: 10,
+      stampType: "stamp-face",
+      isEnabled: true,
+      source: "face-detection",
+    };
+    expect(pickStampImage(region, map)).toBe(img);
   });
 });

--- a/features/editor/lib/pickStampImage.ts
+++ b/features/editor/lib/pickStampImage.ts
@@ -27,7 +27,8 @@ export function resolveStampFileName(
  * スタンプ画像マップから画像を選択する
  *
  * region.stampFileName が設定されている場合はそれを優先し、
- * 未設定の場合は region.id ハッシュで決定的に選択する。
+ * 未設定の場合は STAMP_FILE_NAMES（カタログ順）に対する id ハッシュで決定的に選ぶ。
+ * Map の挿入順（画像 onload 完了順）には依存しない。
  *
  * @param region - StampRegion
  * @param stampImages - ファイル名をキーにした HTMLImageElement の Map
@@ -38,7 +39,7 @@ export function pickStampImage(
   stampImages: Map<string, HTMLImageElement>
 ): HTMLImageElement | null {
   if (stampImages.size === 0) return null;
-  const fileName = resolveStampFileName(region, Array.from(stampImages.keys()));
+  const fileName = resolveStampFileName(region, STAMP_FILE_NAMES);
   if (!fileName) return null;
   return stampImages.get(fileName) ?? null;
 }

--- a/features/editor/lib/pickStampImage.ts
+++ b/features/editor/lib/pickStampImage.ts
@@ -1,4 +1,27 @@
+import { STAMP_FILE_NAMES } from "../constants";
 import type { StampRegion } from "../types";
+
+/**
+ * 領域に対応するスタンプ画像ファイル名を解決する
+ *
+ * stampFileName が設定済みならそれを返し、未設定なら region.id のハッシュで
+ * fileNames から決定的に選ぶ（キャンバス表示・プルダウン・初期化で共通利用）。
+ *
+ * @param region - id と任意の stampFileName
+ * @param fileNames - 候補ファイル名一覧（挿入順がハッシュ選択に使われる）
+ * @returns 解決したファイル名。候補が空なら undefined
+ */
+export function resolveStampFileName(
+  region: Pick<StampRegion, "id" | "stampFileName">,
+  fileNames: readonly string[] = STAMP_FILE_NAMES
+): string | undefined {
+  if (region.stampFileName) {
+    return region.stampFileName;
+  }
+  if (fileNames.length === 0) return undefined;
+  const idHash = region.id.split("").reduce((acc, char) => (acc * 31 + char.charCodeAt(0)) | 0, 0);
+  return fileNames[Math.abs(idHash) % fileNames.length];
+}
 
 /**
  * スタンプ画像マップから画像を選択する
@@ -14,11 +37,8 @@ export function pickStampImage(
   region: StampRegion,
   stampImages: Map<string, HTMLImageElement>
 ): HTMLImageElement | null {
-  if (region.stampFileName) {
-    return stampImages.get(region.stampFileName) ?? null;
-  }
-  const values = Array.from(stampImages.values());
-  if (values.length === 0) return null;
-  const idHash = region.id.split("").reduce((acc, char) => (acc * 31 + char.charCodeAt(0)) | 0, 0);
-  return values[Math.abs(idHash) % values.length] ?? null;
+  if (stampImages.size === 0) return null;
+  const fileName = resolveStampFileName(region, Array.from(stampImages.keys()));
+  if (!fileName) return null;
+  return stampImages.get(fileName) ?? null;
 }

--- a/features/editor/utils/exportCanvas.ts
+++ b/features/editor/utils/exportCanvas.ts
@@ -1,4 +1,5 @@
 import { MAX_CANVAS_DIMENSION } from "@/lib/canvas";
+import { pickStampImage } from "../lib/pickStampImage";
 import type { PaintStroke, StampRegion } from "../types";
 
 /** モザイクブロックの最小サイズ（px） */
@@ -23,14 +24,7 @@ function pickExportStampImage(
   region: StampRegion,
   stampImages: Map<string, HTMLImageElement>
 ): HTMLImageElement | null {
-  if (region.stampFileName) {
-    return stampImages.get(region.stampFileName) ?? null;
-  }
-  const stampImagesArray = Array.from(stampImages.values());
-  if (stampImagesArray.length === 0) return null;
-  const idHash = region.id.split("").reduce((acc, char) => (acc * 31 + char.charCodeAt(0)) | 0, 0);
-  const stampIndex = Math.abs(idHash) % stampImagesArray.length;
-  return stampImagesArray[stampIndex] ?? null;
+  return pickStampImage(region, stampImages);
 }
 
 /**


### PR DESCRIPTION
## 概要

顔検出由来の顔スタンプを選択しても、ツールバーのスタンプ画像プルダウンがキャンバス上の表示と一致しない不具合を修正する。

## 関連Issue

Closes #123

## 変更内容

- [ ] 機能追加
- [x] バグ修正
- [ ] リファクタリング
- [x] テスト追加・修正
- [ ] ドキュメント修正
- [ ] 設定・環境変更
- [ ] その他

## 主な変更箇所

### UI・コンポーネント

- 変更なし（StampFacePicker は既存の `value` 表示のまま）

### ロジック・処理

- `resolveStampFileName` を追加し、表示・初期化・選択同期で共通のファイル名解決を行う
- 顔検出スナップショット生成時に各領域へ `stampFileName` を明示設定
- `selectItem` で stamp-face 選択時にプルダウンを同期。未設定領域はバックフィル
- export のスタンプ選択を `pickStampImage` に統一

### その他

なし

## 動作確認

- [ ] ローカル環境での動作確認
- [x] テストの実行・通過確認
- [ ] UI動作確認
- [x] 既存機能への影響確認
- [ ] ブラウザ動作確認（Chrome / Firefox / Safari）

## スクリーンショット・動画

なし（ロジック修正）

## テスト

### 追加したテスト

- `resolveStampFileName` の決定的選択・優先順位
- 顔検出初期化で `stampFileName` が付与されること
- 顔スタンプ選択時のプルダウン同期
- `stampFileName` 未設定領域の選択時バックフィル

### テスト結果

- [x] 全てのテストが通過
- [x] 新規テストを追加
- [x] 既存テストの修正

## 破壊的変更

- [ ] 破壊的変更あり
- [x] 破壊的変更なし

### 破壊的変更の詳細

なし

## レビューポイント

- 顔検出初期化時の `stampFileName` 付与が、従来の id ハッシュ選択と同じ見た目多様性を維持しているか
- 旧スナップショット（`stampFileName` なし）選択時のバックフィルが妥当か

## 補足

- ユーザー向け更新記事は、内部の選択同期バグ修正のため追加していない
- 回転・AABB の不具合（#124）は本 PR の対象外

## チェックリスト

- [x] コードレビューの準備ができている
- [x] 適切なラベルを付けている
- [x] セルフレビューを実施している
- [x] `pnpm lint` と `pnpm type-check` が通ることを確認した
- [ ] 必要に応じてドキュメントを更新している
- [x] ユーザー操作・体験に影響する変更がある場合、`content/updates/` に更新情報記事を追加した（追加不要の場合は理由を補足に記載）

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Editor-only stamp selection and display sync; no auth, data, or API changes. Legacy regions without `stampFileName` may get a catalog-based stamp instead of Map-order fallback, which is intentional alignment with the canvas.
> 
> **Overview**
> Fixes the bug where selecting a face-detected **stamp-face** region left the toolbar stamp image dropdown out of sync with what the canvas showed.
> 
> Introduces **`resolveStampFileName`** so canvas rendering, face-detection initialization, selection handling, and export all pick the same file name: use `stampFileName` when set, otherwise a deterministic choice from **`STAMP_FILE_NAMES`** via `region.id` (not the stamp image `Map` insertion/onload order). Face regions created from detections now get **`stampFileName`** at snapshot creation. **`selectItem`** updates **`selectedStampFileName`** for stamp-face regions and **backfills** missing `stampFileName` on legacy snapshots. Export reuses **`pickStampImage`** instead of duplicate hash logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a81bf31aa8f5a2154c02c0488f49f22cc749ce9e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->