### PR TITLE
スタンプ領域の回転を保持し保存時の向き・サイズずれを修正する

### DIFF
--- a/features/editor/components/EditorCanvas.tsx
+++ b/features/editor/components/EditorCanvas.tsx
@@ -17,6 +17,7 @@ import {
 import type { EditorMode, PaintStroke, StampRegion, StampType } from "../types";
 import { shouldShowEditorTransformer } from "../lib/editorCanvasInteraction";
 import { isEditableKeyboardTarget } from "../lib/isEditableKeyboardTarget";
+import { stampRegionUpdatesFromTransformEnd } from "../lib/stampRegionTransform";
 import { stagePointerToContentSpace } from "../lib/viewZoom";
 import { useEditorViewport } from "../hooks/useEditorViewport";
 import { useEditorViewportGestures } from "../hooks/useEditorViewportGestures";
@@ -474,29 +475,33 @@ export function EditorCanvas({
   }
 
   /**
-   * 形状のトランスフォーム終了時にサイズ・位置を元画像空間に変換して更新する
+   * 形状のトランスフォーム終了時にサイズ・位置・回転を元画像空間へ保存する
+   *
+   * AABB（外接矩形）は焼かず、scale は width/height に、rotation は角度として保持する。
    *
    * @param id - 領域のID
-   * @param kind - 領域の種別
    * @param node - Konva ノード
    */
   function handleTransformEnd(id: string, node: Konva.Node) {
-    // Group は width()/height() が常に 0 を返すため、スケールリセット前に
-    // getClientRect() でビジュアル上の実サイズ・位置を取得する
-    const parent = node.getParent();
-    const clientRect = parent
-      ? node.getClientRect({ relativeTo: parent, skipStroke: true })
-      : node.getClientRect({ skipStroke: true });
+    const region = stampRegions.find((r) => r.id === id);
+    if (!region) return;
+
+    const updates = stampRegionUpdatesFromTransformEnd(
+      region,
+      {
+        x: node.x(),
+        y: node.y(),
+        scaleX: node.scaleX(),
+        scaleY: node.scaleY(),
+        rotation: node.rotation(),
+      },
+      scaleX,
+      scaleY
+    );
 
     node.scaleX(1);
     node.scaleY(1);
-
-    const newX = clientRect.x / scaleX;
-    const newY = clientRect.y / scaleY;
-    const newW = clientRect.width / scaleX;
-    const newH = clientRect.height / scaleY;
-
-    onUpdateStampRegion(id, { x: newX, y: newY, width: newW, height: newH });
+    onUpdateStampRegion(id, updates);
   }
 
   const isStampRegionInteractive = mode === "select" || mode === "rect";

--- a/features/editor/components/EditorStampEffectPreview.tsx
+++ b/features/editor/components/EditorStampEffectPreview.tsx
@@ -48,6 +48,11 @@ export interface EditorStampEffectPreviewProps {
   offsetX: number;
   /** グループ内での画像 Y オフセット（= -(領域Y * scaleY)） */
   offsetY: number;
+  /**
+   * 親 Group の回転を打ち消し、背景画像がステージ座標と一致するようにする角度（度）
+   * 親が rotation=R のとき -R を渡す
+   */
+  counterRotation?: number;
   stageWidth: number;
   stageHeight: number;
   w: number;
@@ -64,6 +69,7 @@ export function EditorStampEffectPreview({
   bgImage,
   offsetX,
   offsetY,
+  counterRotation = 0,
   stageWidth,
   stageHeight,
   w,
@@ -86,20 +92,22 @@ export function EditorStampEffectPreview({
       pixelRatio: 1,
     });
     group.getLayer()?.batchDraw();
-  }, [kind, bgImage, offsetX, offsetY, stageWidth, stageHeight, w, h]);
+  }, [kind, bgImage, offsetX, offsetY, counterRotation, stageWidth, stageHeight, w, h]);
 
   const filters = kind === "blur" ? [Konva.Filters.Blur] : [pixelateFilter];
 
   return (
     <Group ref={groupRef} clipX={0} clipY={0} clipWidth={w} clipHeight={h} filters={filters}>
-      <KonvaImage
-        image={bgImage}
-        x={offsetX}
-        y={offsetY}
-        width={stageWidth}
-        height={stageHeight}
-        listening={false}
-      />
+      <Group rotation={counterRotation} listening={false}>
+        <KonvaImage
+          image={bgImage}
+          x={offsetX}
+          y={offsetY}
+          width={stageWidth}
+          height={stageHeight}
+          listening={false}
+        />
+      </Group>
     </Group>
   );
 }

--- a/features/editor/components/EditorStampRegionNode.tsx
+++ b/features/editor/components/EditorStampRegionNode.tsx
@@ -4,6 +4,7 @@ import Konva from "konva";
 import { Fragment } from "react";
 import { Group, Image as KonvaImage, Rect } from "react-konva";
 import { pickStampImage } from "../lib/pickStampImage";
+import { getStampRegionRotationDeg } from "../lib/stampRegionTransform";
 import type { StampRegion, StampType } from "../types";
 import { EditorStampEffectPreview } from "./EditorStampEffectPreview";
 
@@ -51,6 +52,7 @@ export function EditorStampRegionNode({
   const ry = region.y * scaleY;
   const w = region.width * scaleX;
   const h = region.height * scaleY;
+  const rotation = getStampRegionRotationDeg(region);
   const squareStampSize = Math.max(w, h);
   const squareStampX = (w - squareStampSize) / 2;
   const squareStampY = (h - squareStampSize) / 2;
@@ -63,12 +65,13 @@ export function EditorStampRegionNode({
     <Fragment>
       {isEffectStamp && (
         /* blur / mosaic の見た目は操作ノードと分離し、Transformer の計算へ影響させない */
-        <Group x={rx} y={ry} listening={false}>
+        <Group x={rx} y={ry} rotation={rotation} listening={false}>
           <EditorStampEffectPreview
             kind={region.stampType as "blur" | "mosaic"}
             bgImage={bgImage}
             offsetX={-rx}
             offsetY={-ry}
+            counterRotation={-rotation}
             stageWidth={stageWidth}
             stageHeight={stageHeight}
             w={w}
@@ -81,6 +84,7 @@ export function EditorStampRegionNode({
         id={region.id}
         x={rx}
         y={ry}
+        rotation={rotation}
         draggable={isInteractive}
         onClick={() => isInteractive && onSelect()}
         onTap={() => isInteractive && onSelect()}

--- a/features/editor/lib/stampRegionTransform.test.ts
+++ b/features/editor/lib/stampRegionTransform.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import {
+  getStampRegionRotationDeg,
+  MIN_STAMP_REGION_SIZE,
+  stampRegionUpdatesFromTransformEnd,
+} from "./stampRegionTransform";
+
+describe("stampRegionUpdatesFromTransformEnd", () => {
+  it("scale を width/height に焼き込み rotation を保持する（AABB は使わない）", () => {
+    const updates = stampRegionUpdatesFromTransformEnd(
+      { width: 100, height: 50 },
+      { x: 20, y: 40, scaleX: 2, scaleY: 1.5, rotation: 45 },
+      2,
+      2
+    );
+    expect(updates).toEqual({
+      x: 10,
+      y: 20,
+      width: 200,
+      height: 75,
+      rotation: 45,
+    });
+  });
+
+  it("負の scale は絶対値でサイズ化する", () => {
+    const updates = stampRegionUpdatesFromTransformEnd(
+      { width: 40, height: 40 },
+      { x: 0, y: 0, scaleX: -0.5, scaleY: -2, rotation: -30 },
+      1,
+      1
+    );
+    expect(updates.width).toBe(20);
+    expect(updates.height).toBe(80);
+    expect(updates.rotation).toBe(-30);
+  });
+
+  it("極小サイズは下限でクランプする", () => {
+    const updates = stampRegionUpdatesFromTransformEnd(
+      { width: 10, height: 10 },
+      { x: 0, y: 0, scaleX: 0.01, scaleY: 0.01, rotation: 0 },
+      1,
+      1
+    );
+    expect(updates.width).toBe(MIN_STAMP_REGION_SIZE);
+    expect(updates.height).toBe(MIN_STAMP_REGION_SIZE);
+  });
+});
+
+describe("getStampRegionRotationDeg", () => {
+  it("未設定は 0", () => {
+    expect(getStampRegionRotationDeg({})).toBe(0);
+  });
+
+  it("設定値を返す", () => {
+    expect(getStampRegionRotationDeg({ rotation: 90 })).toBe(90);
+  });
+});

--- a/features/editor/lib/stampRegionTransform.ts
+++ b/features/editor/lib/stampRegionTransform.ts
@@ -1,0 +1,41 @@
+import type { StampRegion } from "../types";
+
+/** Transformer 後に許容する最小サイズ（元画像ピクセル空間） */
+export const MIN_STAMP_REGION_SIZE = 1;
+
+/**
+ * Transformer 終了時の Konva ノード状態から、AABB を焼かずに領域更新値を求める
+ *
+ * 回転は角度として保持し、width/height はノードの scale を既存サイズへ乗算した実サイズとする。
+ * 位置は Group の top-left（Konva デフォルトの回転原点）を画像空間へ変換する。
+ *
+ * @param region - 変形前の領域（width/height 参照用）
+ * @param node - scale / rotation / x / y を持つ Konva ノード状態
+ * @param stageScaleX - ステージの X スケール（画像→表示）
+ * @param stageScaleY - ステージの Y スケール（画像→表示）
+ */
+export function stampRegionUpdatesFromTransformEnd(
+  region: Pick<StampRegion, "width" | "height">,
+  node: { x: number; y: number; scaleX: number; scaleY: number; rotation: number },
+  stageScaleX: number,
+  stageScaleY: number
+): Pick<StampRegion, "x" | "y" | "width" | "height" | "rotation"> {
+  const width = Math.max(MIN_STAMP_REGION_SIZE, region.width * Math.abs(node.scaleX));
+  const height = Math.max(MIN_STAMP_REGION_SIZE, region.height * Math.abs(node.scaleY));
+  return {
+    x: node.x / stageScaleX,
+    y: node.y / stageScaleY,
+    width,
+    height,
+    rotation: node.rotation,
+  };
+}
+
+/**
+ * 領域の回転角（度）。未設定は 0。
+ *
+ * @param region - スタンプ領域
+ */
+export function getStampRegionRotationDeg(region: Pick<StampRegion, "rotation">): number {
+  return region.rotation ?? 0;
+}

--- a/features/editor/types.ts
+++ b/features/editor/types.ts
@@ -19,6 +19,11 @@ export interface StampRegion {
   width: number;
   /** 高さ（元画像ピクセル空間） */
   height: number;
+  /**
+   * 回転角（度、時計回り）。Konva Group と同じく領域の左上を原点とする。
+   * 未設定・0 は無回転。
+   */
+  rotation?: number;
   /** マスキング種別 */
   stampType: StampType;
   /** stamp-face 種別で使用するスタンプ画像のファイル名 */

--- a/features/editor/utils/exportCanvas.test.ts
+++ b/features/editor/utils/exportCanvas.test.ts
@@ -18,8 +18,11 @@ function makeCtxMock() {
   const strokeCalls: number[] = [];
   const getImageDataCalls: FillRectCall[] = [];
   const saveRestoreCalls: string[] = [];
+  const translateCalls: [number, number][] = [];
+  const rotateCalls: number[] = [];
 
   const ctx = {
+    canvas: { width: 200, height: 200 } as HTMLCanvasElement,
     drawImage: vi.fn(),
     fillRect: vi.fn((...args: number[]) => fillRectCalls.push(args as FillRectCall)),
     beginPath: vi.fn(() => beginPathCalls.push(1)),
@@ -28,6 +31,8 @@ function makeCtxMock() {
     stroke: vi.fn(() => strokeCalls.push(1)),
     rect: vi.fn(),
     clip: vi.fn(),
+    translate: vi.fn((...args: number[]) => translateCalls.push(args as [number, number])),
+    rotate: vi.fn((angle: number) => rotateCalls.push(angle)),
     save: vi.fn(() => saveRestoreCalls.push("save")),
     restore: vi.fn(() => saveRestoreCalls.push("restore")),
     getImageData: vi.fn((x: number, y: number, w: number, h: number) => {
@@ -49,6 +54,8 @@ function makeCtxMock() {
     strokeCalls,
     getImageDataCalls,
     saveRestoreCalls,
+    translateCalls,
+    rotateCalls,
   };
 }
 
@@ -97,7 +104,10 @@ describe("exportEditorCanvas", () => {
     ];
     await exportEditorCanvas(img, stampRegions, [], new Map());
     expect(ctxMock.ctx.fillStyle).toBe("#000000");
-    expect(ctxMock.fillRectCalls.some(([x]) => x === 10)).toBe(true);
+    expect(ctxMock.translateCalls.some(([x, y]) => x === 10 && y === 10)).toBe(true);
+    expect(
+      ctxMock.fillRectCalls.some(([x, y, w, h]) => x === 0 && y === 0 && w === 50 && h === 50)
+    ).toBe(true);
   });
 
   it("mosaic スタンプ領域でモザイク処理（getImageData）を呼び出す", async () => {
@@ -200,7 +210,33 @@ describe("exportEditorCanvas", () => {
       },
     ];
     await exportEditorCanvas(img, stampRegions, [], new Map());
-    expect(ctxMock.fillRectCalls.some(([x]) => x === 5)).toBe(true);
+    expect(ctxMock.translateCalls.some(([x, y]) => x === 5 && y === 5)).toBe(true);
+    expect(
+      ctxMock.fillRectCalls.some(([x, y, w, h]) => x === 0 && y === 0 && w === 40 && h === 40)
+    ).toBe(true);
+  });
+
+  it("rotation 付き fill-black は rotate を適用する", async () => {
+    const img = makeImageElement(200, 200);
+    const stampRegions: StampRegion[] = [
+      {
+        id: "s-rot",
+        x: 10,
+        y: 20,
+        width: 30,
+        height: 40,
+        rotation: 45,
+        stampType: "fill-black",
+        isEnabled: true,
+        source: "manual",
+      },
+    ];
+    await exportEditorCanvas(img, stampRegions, [], new Map());
+    expect(ctxMock.translateCalls.some(([x, y]) => x === 10 && y === 20)).toBe(true);
+    expect(ctxMock.rotateCalls.some((rad) => Math.abs(rad - Math.PI / 4) < 1e-9)).toBe(true);
+    expect(
+      ctxMock.fillRectCalls.some(([x, y, w, h]) => x === 0 && y === 0 && w === 30 && h === 40)
+    ).toBe(true);
   });
 
   it("ペイントストロークを描画する", async () => {

--- a/features/editor/utils/exportCanvas.ts
+++ b/features/editor/utils/exportCanvas.ts
@@ -1,5 +1,6 @@
 import { MAX_CANVAS_DIMENSION } from "@/lib/canvas";
 import { pickStampImage } from "../lib/pickStampImage";
+import { getStampRegionRotationDeg } from "../lib/stampRegionTransform";
 import type { PaintStroke, StampRegion } from "../types";
 
 /** モザイクブロックの最小サイズ（px） */
@@ -28,7 +29,7 @@ function pickExportStampImage(
 }
 
 /**
- * モザイク処理を Canvas に適用する
+ * モザイク処理を Canvas に適用する（軸平行のローカル矩形向け）
  *
  * @param ctx - 2D コンテキスト
  * @param x - 矩形の X 座標
@@ -68,16 +69,54 @@ function applyMosaic(
 }
 
 /**
+ * 回転を考慮してモザイクを適用する
+ *
+ * ローカル矩形へ逆変換サンプリング → モザイク → 回転して描画する。
+ */
+function applyMosaicRotated(
+  ctx: CanvasRenderingContext2D,
+  sx: number,
+  sy: number,
+  sw: number,
+  sh: number,
+  rotationDeg: number
+): void {
+  const width = Math.max(1, Math.round(sw));
+  const height = Math.max(1, Math.round(sh));
+  const rad = (rotationDeg * Math.PI) / 180;
+  const offscreen = document.createElement("canvas");
+  offscreen.width = width;
+  offscreen.height = height;
+  const offCtx = offscreen.getContext("2d");
+  if (!offCtx) return;
+
+  offCtx.save();
+  offCtx.rotate(-rad);
+  offCtx.translate(-sx, -sy);
+  offCtx.drawImage(ctx.canvas, 0, 0);
+  offCtx.restore();
+
+  applyMosaic(offCtx, 0, 0, width, height);
+
+  ctx.save();
+  ctx.translate(sx, sy);
+  ctx.rotate(rad);
+  ctx.drawImage(offscreen, 0, 0);
+  ctx.restore();
+}
+
+/**
  * ぼかし処理を Canvas に適用する
  *
  * @param ctx - 2D コンテキスト
  * @param imageSource - 元画像要素
- * @param x - 矩形の X 座標
+ * @param x - 矩形の X 座標（キャンバス空間、回転前の左上）
  * @param y - 矩形の Y 座標
  * @param width - 矩形の幅
  * @param height - 矩形の高さ
  * @param scaleX - X 方向スケール
  * @param scaleY - Y 方向スケール
+ * @param rotationDeg - 回転角（度）。左上原点
  */
 function applyBlur(
   ctx: CanvasRenderingContext2D,
@@ -87,12 +126,18 @@ function applyBlur(
   width: number,
   height: number,
   scaleX: number,
-  scaleY: number
+  scaleY: number,
+  rotationDeg = 0
 ): void {
+  const rad = (rotationDeg * Math.PI) / 180;
   ctx.save();
+  ctx.translate(x, y);
+  ctx.rotate(rad);
   ctx.beginPath();
-  ctx.rect(x, y, width, height);
+  ctx.rect(0, 0, width, height);
   ctx.clip();
+  ctx.rotate(-rad);
+  ctx.translate(-x, -y);
   const blurRadius = Math.max(
     MIN_BLUR_RADIUS,
     Math.round(Math.min(width, height) / BLUR_RADIUS_DIVISOR)
@@ -106,6 +151,24 @@ function applyBlur(
     Math.round(imageSource.height * scaleY)
   );
   ctx.filter = "none";
+  ctx.restore();
+}
+
+/**
+ * 領域ローカル座標（左上原点・回転込み）で描画コールバックを実行する
+ */
+function withStampRegionTransform(
+  ctx: CanvasRenderingContext2D,
+  sx: number,
+  sy: number,
+  rotationDeg: number,
+  draw: () => void
+): void {
+  const rad = (rotationDeg * Math.PI) / 180;
+  ctx.save();
+  ctx.translate(sx, sy);
+  ctx.rotate(rad);
+  draw();
   ctx.restore();
 }
 
@@ -148,41 +211,52 @@ export async function exportEditorCanvas(
   /** 有効なマスキング領域を種別に応じて描画 */
   for (const region of stampRegions) {
     if (!region.isEnabled) continue;
-    const sx = Math.round(region.x * scaleX);
-    const sy = Math.round(region.y * scaleY);
-    const sw = Math.round(region.width * scaleX);
-    const sh = Math.round(region.height * scaleY);
+    const sx = region.x * scaleX;
+    const sy = region.y * scaleY;
+    const sw = region.width * scaleX;
+    const sh = region.height * scaleY;
+    const rotationDeg = getStampRegionRotationDeg(region);
 
     switch (region.stampType) {
       case "fill-black":
-        ctx.fillStyle = "#000000";
-        ctx.fillRect(sx, sy, sw, sh);
+        withStampRegionTransform(ctx, sx, sy, rotationDeg, () => {
+          ctx.fillStyle = "#000000";
+          ctx.fillRect(0, 0, sw, sh);
+        });
         break;
 
       case "mosaic":
-        applyMosaic(ctx, sx, sy, sw, sh);
+        if (rotationDeg === 0) {
+          applyMosaic(ctx, Math.round(sx), Math.round(sy), Math.round(sw), Math.round(sh));
+        } else {
+          applyMosaicRotated(ctx, sx, sy, sw, sh, rotationDeg);
+        }
         break;
 
       case "blur":
-        applyBlur(ctx, imageElement, sx, sy, sw, sh, scaleX, scaleY);
+        applyBlur(ctx, imageElement, sx, sy, sw, sh, scaleX, scaleY, rotationDeg);
         break;
 
       case "stamp-face": {
         const stamp = pickExportStampImage(region, stampImages);
         if (stamp) {
-          const centerX = sx + sw / 2;
-          const centerY = sy + sh / 2;
-          const stampSize = Math.max(sw, sh);
-          ctx.drawImage(
-            stamp,
-            centerX - stampSize / 2,
-            centerY - stampSize / 2,
-            stampSize,
-            stampSize
-          );
+          withStampRegionTransform(ctx, sx, sy, rotationDeg, () => {
+            const centerX = sw / 2;
+            const centerY = sh / 2;
+            const stampSize = Math.max(sw, sh);
+            ctx.drawImage(
+              stamp,
+              centerX - stampSize / 2,
+              centerY - stampSize / 2,
+              stampSize,
+              stampSize
+            );
+          });
         } else {
-          ctx.fillStyle = "rgba(0,0,0,0.5)";
-          ctx.fillRect(sx, sy, sw, sh);
+          withStampRegionTransform(ctx, sx, sy, rotationDeg, () => {
+            ctx.fillStyle = "rgba(0,0,0,0.5)";
+            ctx.fillRect(0, 0, sw, sh);
+          });
         }
         break;
       }


### PR DESCRIPTION
## 概要

スタンプ領域を斜めに回転すると AABB（外接矩形）がサイズとして焼き込まれ肥大化・ズレる問題を修正する。回転角をデータとして保持し、キャンバス表示と保存結果の向き・位置・サイズを一致させる。

## 関連Issue

Closes #124

## 変更内容

- [ ] 機能追加
- [x] バグ修正
- [ ] リファクタリング
- [x] テスト追加・修正
- [ ] ドキュメント修正
- [ ] 設定・環境変更
- [ ] その他

## 主な変更箇所

### UI・コンポーネント

- `EditorStampRegionNode` / `EditorStampEffectPreview` で `rotation` を描画に反映（ぼかし・モザイクは背景の逆回転でクリップを維持）

### ロジック・処理

- `StampRegion.rotation?`（度・左上原点）を追加。未設定は 0 で後方互換
- `handleTransformEnd` が AABB を焼かず、scale→width/height・rotation を保存（`stampRegionUpdatesFromTransformEnd`）
- `exportEditorCanvas` で fill-black / stamp-face / blur / mosaic に同じ回転を適用

### その他

なし

## 動作確認

- [ ] ローカル環境での動作確認
- [x] テストの実行・通過確認
- [ ] UI動作確認
- [x] 既存機能への影響確認
- [ ] ブラウザ動作確認（Chrome / Firefox / Safari）

## スクリーンショット・動画

なし（ロジック修正。レビュー時にエディタで回転→保存の確認を推奨）

## テスト

### 追加したテスト

- `stampRegionUpdatesFromTransformEnd`（AABB非使用・scale/rotation 反映・下限クランプ）
- export の rotation 付き fill-black で translate/rotate が掛かること

### テスト結果

- [x] 全てのテストが通過
- [x] 新規テストを追加
- [x] 既存テストの修正

## 破壊的変更

- [ ] 破壊的変更あり
- [x] 破壊的変更なし

### 破壊的変更の詳細

なし（`rotation` は optional。既存スナップショットは無回転として動作）

## レビューポイント

- transform 終了時のサイズ計算が「既存 width/height × |scale|」で正しいか
- export と Konva の回転原点（領域左上）が揃っているか
- mosaic 回転時のオフスクリーン逆変換サンプリング

## 補足

- 既に AABB で膨らんでしまった領域は自動修復しない
- ユーザー向け更新記事は、バグ修正による期待動作の復元のため追加していない
- 顔スタンププルダウン同期（#123 / #125）とは独立

## チェックリスト

- [x] コードレビューの準備ができている
- [x] 適切なラベルを付けている
- [x] セルフレビューを実施している
- [x] `pnpm lint` と `pnpm type-check` が通ることを確認した
- [ ] 必要に応じてドキュメントを更新している
- [x] ユーザー操作・体験に影響する変更がある場合、`content/updates/` に更新情報記事を追加した（追加不要の場合は理由を補足に記載）

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core editor geometry persistence and PNG export for all stamp types; optional `rotation` is backward compatible, but rotated mosaic/blur paths are new and worth manual rotate-then-export checks.
> 
> **Overview**
> Fixes rotated stamp regions growing or shifting after transform because the editor previously saved the axis-aligned bounding box (AABB) as `width`/`height` instead of true size and angle.
> 
> **Data & transform end:** Adds optional `StampRegion.rotation` (degrees, top-left origin) and `stampRegionUpdatesFromTransformEnd`, which maps Konva scale into `width`/`height`, keeps `rotation`, and clamps minimum size—no AABB baking.
> 
> **Canvas UI:** Region nodes and blur/mosaic previews apply `rotation`; effect previews use `counterRotation` so clipped background stays aligned with the stage.
> 
> **Export:** `exportEditorCanvas` draws fill-black, stamp-face, blur, and mosaic through a shared translate/rotate wrapper; rotated mosaic uses offscreen inverse sampling. Tests cover transform math and rotated export.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f3b3d64968d5d7135344e8fa90de1f3db079d70. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->